### PR TITLE
[errors] don't panic when asserting error type

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -87,7 +87,7 @@ func (e *Error) Error() string { return strings.Join(e.LongDescription[:], ".") 
 
 func GetCode(err error) string {
 
-	if obj := err.(*Error); obj != nil && obj.Code != " " {
+	if obj, ok := err.(*Error); ok && obj != nil && obj.Code != " " {
 		return obj.Code
 	}
 	return strings.Join(NoneString[:], "")
@@ -95,7 +95,7 @@ func GetCode(err error) string {
 
 func GetSeverity(err error) Severity {
 
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); ok && obj != nil {
 		return obj.Severity
 	}
 	return None
@@ -103,7 +103,7 @@ func GetSeverity(err error) Severity {
 
 func GetSDescription(err error) string {
 
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); ok && obj != nil {
 		return strings.Join(err.(*Error).ShortDescription[:], ".")
 	}
 	return strings.Join(NoneString[:], "")
@@ -111,7 +111,7 @@ func GetSDescription(err error) string {
 
 func GetCause(err error) string {
 
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); ok && obj != nil {
 		return strings.Join(err.(*Error).ProbableCause[:], ".")
 	}
 	return strings.Join(NoneString[:], "")
@@ -119,7 +119,7 @@ func GetCause(err error) string {
 
 func GetRemedy(err error) string {
 
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); ok && obj != nil {
 		return strings.Join(err.(*Error).SuggestedRemediation[:], ".")
 	}
 	return strings.Join(NoneString[:], "")


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes frequent panics due to logging non-meshkit errors.

**Notes for Reviewers**
* It would be nice to get this in quick to prevent hideous panic cases which we're facing across all repos.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
