### PR TITLE
Add DockerCompose file verification utility function

### DIFF
--- a/utils/kubernetes/kompose/models/composefile.go
+++ b/utils/kubernetes/kompose/models/composefile.go
@@ -1,0 +1,8 @@
+package models
+
+import "encoding/json"
+
+type DockerComposeFile struct {
+	Version  json.Number `yaml:"version" json:"version"`
+	Services interface{} `yaml:"services" json:"services"` // more constraints should be added to this type
+}

--- a/utils/kubernetes/kompose/utils.go
+++ b/utils/kubernetes/kompose/utils.go
@@ -1,0 +1,18 @@
+package kompose
+
+import (
+	"github.com/layer5io/meshkit/utils/kubernetes/kompose/models"
+	"gopkg.in/yaml.v2"
+)
+
+// IsManifestADockerCompose takes in a manifest and returns true only when the given manifest is a 'valid' docker compose file
+func IsManifestADockerCompose(yamlManifest []byte) bool {
+	data := models.DockerComposeFile{}
+	if err := yaml.Unmarshal(yamlManifest, &data); err != nil {
+		return false
+	}
+	if data.Version == "" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
**Description**

This PR adds a utility function to verify whether or not a given yaml manifest is a valid DockerCompose file. 

**Notes for Reviewers**
The constraints for the DockerCompose struct are intentionally loose right now and can be made strict. Ideally, we should not be the ones defining what is a valid `DockerCompose` file but docker. We will see how we can make this more dynamic in the future. This PR is to make this functional. 


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
