### PR TITLE
fixed logger types

### DIFF
--- a/logger/controller.go
+++ b/logger/controller.go
@@ -19,11 +19,12 @@ type Controller struct {
 	base    *Logger
 }
 
-func (l *Logger) ControllerLogger() logr.LogSink {
-	return &Controller{
+func (l *Logger) ControllerLogger() logr.Logger {
+	c := &Controller{
 		enabled: true,
 		base:    l,
 	}
+	return logr.New(c)
 }
 
 func (c *Controller) Init(info logr.RuntimeInfo) {}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,7 +17,7 @@ type Handler interface {
 	Error(err error)
 
 	// Kubernetes Controller compliant logger
-	ControllerLogger() logr.LogSink
+	ControllerLogger() logr.Logger
 	DatabaseLogger() gormlogger.Interface
 }
 


### PR DESCRIPTION
Signed-off-by: Jared Byers <j.byers@f5.com>

**Description**
Fixed issue where `logger.ControllerLogger()` returned the wrong type expected by `sigs.k8s.io/controller-runtime/pkg/log.SetLogger()`

This PR fixes issue encountered in https://github.com/meshery/meshery-operator/pull/299.

**Notes for Reviewers**
Ensured `golangci-lint` and unit tests passed locally.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 