### PR TITLE
refactor: use CUE go api to load and validate schema

### DIFF
--- a/utils/kubernetes/kompose/composefile.go
+++ b/utils/kubernetes/kompose/composefile.go
@@ -1,68 +1,36 @@
 package kompose
 
 import (
-	"context"
-	"io"
-	"os"
-	"path/filepath"
-
-	"cuelang.org/go/cmd/cue/cmd"
 	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/encoding/json"
+	"cuelang.org/go/encoding/jsonschema"
 	"cuelang.org/go/encoding/yaml"
-	"github.com/layer5io/meshkit/utils"
 )
 
 type DockerComposeFile []byte
 
-// TODO: This should be dynamic
-// once we move to using encoding/jsonschema, this will be removed
-var (
-	DefaultSpecDirectory = filepath.Join(utils.GetHome(), ".meshery", "cue")
-	DefaultSpecPath      = filepath.Join(DefaultSpecDirectory, "compose-spec.cue")
-)
-
-func generateCueSchema(jsonSchema []byte, dir string) error {
-	err := os.MkdirAll(dir, os.ModePerm)
-	if err != nil {
-		return ErrValidateDockerComposeFile(err)
-	}
-	err = utils.CreateFile(jsonSchema, "compose-spec.json", dir)
-	if err != nil {
-		return ErrValidateDockerComposeFile(err)
-	}
-	defer os.Remove(filepath.Join(DefaultSpecDirectory, "compose-spec.json"))
-	//load and parse the schema
-	// NOTE: this approach makes the process slow and is not recommended
-	// TODO: use encoding/jsonschema.
-	importCmd, err := cmd.New([]string{"import", "-f", "--files", filepath.Join(DefaultSpecDirectory, "compose-spec.json")})
-	if err != nil {
-		return ErrValidateDockerComposeFile(err)
-	}
-	// no need for logs
-	importCmd.SetOut(io.Discard)
-	err = importCmd.Run(context.TODO())
-	if err != nil {
-		return ErrValidateDockerComposeFile(err)
-	}
-	return nil
-}
-
 func (dc *DockerComposeFile) Validate(schema []byte) error {
-	cueCtx := cuecontext.New()
-	// check if the spec is already present
-	if _, err := os.Stat(DefaultSpecPath); err != nil {
-		// if not, create the spec
-		err = generateCueSchema(schema, DefaultSpecDirectory)
-		if err != nil {
-			return ErrValidateDockerComposeFile(err)
-		}
-	}
-
-	cueSchema, err := utils.ReadLocalFile(DefaultSpecPath)
+	jsonSchema, err := json.Extract("", schema)
 	if err != nil {
 		return ErrValidateDockerComposeFile(err)
 	}
-	sv := cueCtx.CompileString(cueSchema)
+	cueCtx := cuecontext.New()
+	cueJsonSchemaExpr := cueCtx.BuildExpr(jsonSchema)
+	if err := cueJsonSchemaExpr.Err(); err != nil {
+		return ErrValidateDockerComposeFile(err)
+	}
+	extractedSchema, err := jsonschema.Extract(cueJsonSchemaExpr, &jsonschema.Config{
+		PkgName: "composespec",
+	})
+	if err != nil {
+		return ErrValidateDockerComposeFile(err)
+	}
+	src, err := format.Node(extractedSchema)
+	if err != nil {
+		return ErrValidateDockerComposeFile(err)
+	}
+	sv := cueCtx.CompileString(string(src))
 	if sv.Err() != nil {
 		return ErrValidateDockerComposeFile(sv.Err())
 	}


### PR DESCRIPTION
**Description**

This PR uses go API to load and validate docker-compose file instead of using CUE's command line utility which was slow. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
