### PR TITLE
Fix gitwalker bug

### DIFF
--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -180,15 +180,15 @@ func clonewalk(g *Git) error {
 		path := filepath.Join(path, g.root, f.Name())
 		if f.IsDir() && g.dirInterceptor != nil {
 			name := f.Name()
-			go func(name string, path string) {
+			go func(name string, path string, filename string) {
 				err := g.dirInterceptor(Directory{
-					Name: f.Name(),
+					Name: filename,
 					Path: path,
 				})
 				if err != nil {
 					fmt.Println(err.Error())
 				}
-			}(name, path)
+			}(name, path, f.Name())
 			continue
 		}
 		if f.IsDir() {


### PR DESCRIPTION
Signed-off-by: Ashish Tiwari <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes a race condition where a go routine is given a variable without copying. This results in false directory names being present in gitwalker function.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
