### PR TITLE
Skip and continue generating components when encountered error

### DIFF
--- a/utils/manifests/generateComponent.go
+++ b/utils/manifests/generateComponent.go
@@ -22,13 +22,17 @@ func GenerateComponents(ctx context.Context, manifest string, resource int, cfg 
 		if cfg.CrdFilter.IsJson != true {
 			file, err := yaml.Extract("crds", crd) // first argument is dummy
 			if err != nil {
-				return nil, err
+				// inability to generate component for a single crd should not affect the rest
+				// TODO: Maintain a list of errors and keep pushing the errors to the list so that it can be displayed at last
+				continue
 			}
 			parsedCrd = cueCtx.BuildFile(file)
 		} else {
 			expr, err := json.Extract("", []byte(crd))
 			if err != nil {
-				return nil, err
+				// inability to generate component for a single crd should not affect the rest
+				// TODO: Maintain a list of errors and keep pushing the errors to the list so that it can be displayed at last
+				continue
 			}
 			parsedCrd = cueCtx.BuildExpr(expr)
 		}
@@ -37,14 +41,12 @@ func GenerateComponents(ctx context.Context, manifest string, resource int, cfg 
 			// inability to generate component for a single crd should not affect the rest
 			// TODO: Maintain a list of errors and keep pushing the errors to the list so that it can be displayed at last
 			continue
-			// return nil, err
 		}
 		outSchema, err := getSchema(parsedCrd, cfg, ctx)
 		if err != nil {
 			// inability to generate component for a single crd should not affect the rest
 			// TODO: Maintain a list of errors and keep pushing the errors to the list so that it can be displayed at last
 			continue
-			// return nil, ErrGetSchemas(err)
 		}
 		if cfg.ModifyDefSchema != nil {
 			cfg.ModifyDefSchema(&outDef, &outSchema) //definition and schema can be modified using some call back function


### PR DESCRIPTION
Signed-off-by: Ashish Tiwari <ashishjaitiwari15112000@gmail.com>

**Description**
Currently when encountered an error while generating error with a CRD, the function exits.
We should continue.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
