### PR TITLE
Add Event struct

### DIFF
--- a/utils/events/event.go
+++ b/utils/events/event.go
@@ -1,0 +1,54 @@
+package events
+
+import (
+	"sync"
+)
+
+type EventBuffer struct {
+	circularqueue  []interface{}
+	clientChannels []chan interface{}
+	last           int //last=-1 means queue is empty
+	mx             sync.Mutex
+	clmx           sync.Mutex
+}
+
+func NewEventBuffer(size int) *EventBuffer {
+	return &EventBuffer{
+		circularqueue: make([]interface{}, size),
+		last:          0,
+	}
+}
+
+// Each event will be first stored in a circular queue to return the last n operations whenever a new client connects.
+// After that, further events will be pushed to the client.
+func (e *EventBuffer) Enqueue(i interface{}) {
+	e.mx.Lock()
+	defer e.mx.Unlock()
+	pos := e.last % len(e.circularqueue)
+	e.circularqueue[pos] = i
+	e.last++
+	go func() {
+		for _, ch := range e.clientChannels {
+			ch <- i
+		}
+	}()
+}
+func (e *EventBuffer) Copy(client chan interface{}) {
+	e.mx.Lock()
+	defer e.mx.Unlock()
+	var events []interface{}
+	for i := 0; i < e.last%len(e.circularqueue); i++ {
+		ev := e.circularqueue[i]
+		events = append(events, ev)
+		go func(ev interface{}) {
+			client <- ev
+		}(ev)
+	}
+	return
+}
+
+func (e *EventBuffer) Subscribe(ch chan interface{}) {
+	e.clmx.Lock()
+	defer e.clmx.Unlock()
+	e.clientChannels = append(e.clientChannels, ch)
+}

--- a/utils/events/event.go
+++ b/utils/events/event.go
@@ -4,50 +4,29 @@ import (
 	"sync"
 )
 
-type EventBuffer struct {
-	circularqueue  []interface{}
+type EventStreamer struct {
 	clientChannels []chan interface{}
-	last           int //last=-1 means queue is empty
-	mx             sync.Mutex
 	clmx           sync.Mutex
 }
 
-func NewEventBuffer(size int) *EventBuffer {
-	return &EventBuffer{
-		circularqueue: make([]interface{}, size),
-		last:          0,
+func NewEventStreamer() *EventStreamer {
+	return &EventStreamer{
+		clientChannels: make([]chan interface{}, 0),
 	}
 }
 
-// Each event will be first stored in a circular queue to return the last n operations whenever a new client connects.
-// After that, further events will be pushed to the client.
-func (e *EventBuffer) Enqueue(i interface{}) {
-	e.mx.Lock()
-	defer e.mx.Unlock()
-	pos := e.last % len(e.circularqueue)
-	e.circularqueue[pos] = i
-	e.last++
-	go func() {
-		for _, ch := range e.clientChannels {
+func (e *EventStreamer) Publish(i interface{}) {
+	e.clmx.Lock()
+	defer e.clmx.Unlock()
+	for _, ch := range e.clientChannels {
+		go func(ch chan interface{}) {
 			ch <- i
-		}
-	}()
-}
-func (e *EventBuffer) Copy(client chan interface{}) {
-	e.mx.Lock()
-	defer e.mx.Unlock()
-	var events []interface{}
-	for i := 0; i < e.last%len(e.circularqueue); i++ {
-		ev := e.circularqueue[i]
-		events = append(events, ev)
-		go func(ev interface{}) {
-			client <- ev
-		}(ev)
+		}(ch)
 	}
-	return
+
 }
 
-func (e *EventBuffer) Subscribe(ch chan interface{}) {
+func (e *EventStreamer) Subscribe(ch chan interface{}) {
 	e.clmx.Lock()
 	defer e.clmx.Unlock()
 	e.clientChannels = append(e.clientChannels, ch)


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

This PR adds an EventBuffer struct which will be used by Event producers for eg: adapters, Meshery server,etc

**Notes for Reviewers**
The buffer is essentially a circular queue storing last n Events. 
This struct allows:
1. Subscribing to new events.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
