### PR TITLE
Fix/Hack for helm cli bug[In progress][Do not merge]

### DIFF
--- a/models/controllers/helpers.go
+++ b/models/controllers/helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/layer5io/meshery-operator/api/v1alpha1"
 	"github.com/layer5io/meshkit/utils"
 	mesherykube "github.com/layer5io/meshkit/utils/kubernetes"
-	"github.com/spf13/viper"
 )
 
 const BrokerPingEndpoint = "8222/connz"
@@ -66,10 +65,7 @@ func applyOperatorHelmChart(chartRepo string, client mesherykube.Client, meshery
 		act   = mesherykube.INSTALL
 		chart = "meshery-operator"
 	)
-	if viper.GetString("KUBERNETES_SERVICE_HOST") != "" {
-		act = mesherykube.UPGRADE
-		chart = "meshery"
-	} else if delete {
+	if delete {
 		act = mesherykube.UNINSTALL
 	}
 	err := client.ApplyHelmChart(mesherykube.ApplyHelmChartConfig{

--- a/utils/kubernetes/client.go
+++ b/utils/kubernetes/client.go
@@ -32,6 +32,7 @@ func DetectKubeConfig(configfile []byte) (config *rest.Config, err error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig != "" {
 		if config, err = clientcmd.BuildConfigFromFlags("", kubeconfig); err == nil {
+
 			return config, err
 		}
 	}
@@ -39,6 +40,7 @@ func DetectKubeConfig(configfile []byte) (config *rest.Config, err error) {
 	// Look for kubeconfig at the default path
 	path := filepath.Join(utils.GetHome(), ".kube", "config")
 	if config, err = clientcmd.BuildConfigFromFlags("", path); err == nil {
+
 		return config, err
 	}
 


### PR DESCRIPTION
Signed-off-by: revolyssup <ashishjaitiwari15112000@gmail.com>

**Description**
1. Helm cli doesn't respect the passed kubeconfig and always defaults to the one in ~/.kube/config and in the case of in-cluster deployments it breaks as there is nothing inside ~/.kube/config
This PR sets the appropriate env variable through which helm cli can consume our input rather than setting it to empty in all cases. 
2. Also the applyOperatorHelmChart function wasn't undeploying operator for in-cluster deployments but rather tried to upgrade the operator. This weird logic might have crept in some time ago so this PR also fixed that.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
