### PR TITLE
[Refactor] Update ArtifactHub component generation logic 

### DIFF
--- a/cmd/syncmodutil/internal/modsync/sync.go
+++ b/cmd/syncmodutil/internal/modsync/sync.go
@@ -37,14 +37,14 @@ type GoMod struct {
 	RequiredVersions []Package
 }
 
-//For debugging
+// For debugging
 func (g *GoMod) PrintRequiredVersions() {
 	for _, v := range g.RequiredVersions {
 		fmt.Printf("package=%s ;version=%s\n", v.Name, v.Version)
 	}
 }
 
-//For debugging
+// For debugging
 func (g *GoMod) PrintReplacedVersions() {
 	for _, v := range g.ReplacedVersions {
 		fmt.Printf("%s replaced by %s\n", v[0].Name+v[0].Version, v[1].Name+v[1].Version)
@@ -96,7 +96,7 @@ func (g *GoMod) SyncRequire(f io.Reader) (gomod string, err error) {
 	return
 }
 
-//NewGoMod takes an io.Reader to a go.mod and returns GoMod struct
+// NewGoMod takes an io.Reader to a go.mod and returns GoMod struct
 func New(f io.Reader) (*GoMod, error) {
 	var b = make([]byte, 1000)
 	b, err := io.ReadAll(f)

--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshkit",
   "type": "library",
-  "next_error_code": 11095
+  "next_error_code": 11096
 }

--- a/utils/artifacthub/error.go
+++ b/utils/artifacthub/error.go
@@ -5,10 +5,15 @@ import (
 )
 
 var (
-	ErrGetChartUrlCode       = "11092"
-	ErrGetAhPackageCode      = "1093"
-	ErrComponentGenerateCode = "11094"
+	ErrGetChartUrlCode        = "11092"
+	ErrGetAhPackageCode       = "1093"
+	ErrComponentGenerateCode  = "11094"
+	ErrGetAllHelmPackagesCode = "11095"
 )
+
+func ErrGetAllHelmPackages(err error) error {
+	return errors.New(ErrGetAllHelmPackagesCode, errors.Alert, []string{"Could not get HELM packages from Artifacthub"}, []string{err.Error()}, []string{""}, []string{"make sure that the artifacthub API service is available"})
+}
 
 func ErrGetChartUrl(err error) error {
 	return errors.New(ErrGetChartUrlCode, errors.Alert, []string{"Could not get the chart url for this ArtifactHub package"}, []string{err.Error()}, []string{""}, []string{"make sure that the package exists"})

--- a/utils/artifacthub/package_test.go
+++ b/utils/artifacthub/package_test.go
@@ -19,8 +19,8 @@ func TestGetChartUrl(t *testing.T) {
 				t.Errorf("error while updating package data = %v", err)
 				return
 			}
-			if tt.ahpkg.Url != tt.want {
-				t.Errorf("got %v, want %v", tt.ahpkg.Url, tt.want)
+			if tt.ahpkg.ChartUrl != tt.want {
+				t.Errorf("got %v, want %v", tt.ahpkg.ChartUrl, tt.want)
 			}
 		})
 	}

--- a/utils/artifacthub/scanner.go
+++ b/utils/artifacthub/scanner.go
@@ -54,7 +54,7 @@ func GetAhPackagesWithName(name string) ([]AhPackage, error) {
 func FilterPackagesWithCrds(pkgs []AhPackage) []AhPackage {
 	out := make([]AhPackage, 0)
 	for _, ap := range pkgs {
-		crds, err := manifests.GetCrdsFromHelm(ap.Url)
+		crds, err := manifests.GetCrdsFromHelm(ap.ChartUrl)
 		if err == nil && len(crds) != 0 {
 			out = append(out, ap)
 		}

--- a/utils/artifacthub/scanner_test.go
+++ b/utils/artifacthub/scanner_test.go
@@ -39,8 +39,8 @@ func TestFilterPackagesWithCrds(t *testing.T) {
 		want  []string
 	}{
 		{[]AhPackage{
-			{Name: "crossplane-types", Repository: "crossplane", Organization: "", Url: "https://charts.crossplane.io/master/crossplane-types-0.13.0-rc.98.g1eb0776.tgz"},
-			{Name: "crossplane", Repository: "crossplane", Organization: "", Url: "https://charts.crossplane.io/master/crossplane-1.10.0-rc.0.99.g7f471c48.tgz"},
+			{Name: "crossplane-types", Repository: "crossplane", Organization: "", ChartUrl: "https://charts.crossplane.io/master/crossplane-types-0.13.0-rc.98.g1eb0776.tgz"},
+			{Name: "crossplane", Repository: "crossplane", Organization: "", ChartUrl: "https://charts.crossplane.io/master/crossplane-1.10.0-rc.0.99.g7f471c48.tgz"},
 		},
 			[]string{
 				"crossplane-types",

--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -25,15 +25,28 @@ var DefaultPathConfig = CuePathConfig{
 	SpecPath:       "spec.versions[0].schema.openAPIV3Schema.properties.spec",
 }
 
+var DefaultPathConfig2 = CuePathConfig{
+	NamePath:       "spec.names.kind",
+	IdentifierPath: "spec.names.kind",
+	VersionPath:    "spec.versions[0].name",
+	GroupPath:      "spec.group",
+	SpecPath:       "spec.validation.openAPIV3Schema.properties.spec",
+}
+
+var Configs = []CuePathConfig{DefaultPathConfig, DefaultPathConfig2}
+
 func Generate(crd string) (v1alpha1.Component, error) {
 	component := v1alpha1.NewComponent()
 	crdCue, err := utils.YamlToCue(crd)
 	if err != nil {
 		return component, err
 	}
-	schema, err := getSchema(crdCue, DefaultPathConfig)
-	if err != nil {
-		return component, err
+	var schema string
+	for _, cfg := range Configs {
+		schema, err = getSchema(crdCue, cfg)
+		if err == nil {
+			break
+		}
 	}
 	component.Spec = schema
 	name, err := extractCueValueFromPath(crdCue, DefaultPathConfig.NamePath)

--- a/utils/kubernetes/client.go
+++ b/utils/kubernetes/client.go
@@ -32,7 +32,6 @@ func DetectKubeConfig(configfile []byte) (config *rest.Config, err error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig != "" {
 		if config, err = clientcmd.BuildConfigFromFlags("", kubeconfig); err == nil {
-
 			return config, err
 		}
 	}
@@ -40,7 +39,6 @@ func DetectKubeConfig(configfile []byte) (config *rest.Config, err error) {
 	// Look for kubeconfig at the default path
 	path := filepath.Join(utils.GetHome(), ".kube", "config")
 	if config, err = clientcmd.BuildConfigFromFlags("", path); err == nil {
-
 		return config, err
 	}
 


### PR DESCRIPTION
**Description**

This PR 

- Updates the logic for generating components from ArtifactHub to make use of the [helmExporterDump](https://artifacthub.io/docs/api/#/Integrations/getHelmExporterDump) integration
- This makes the generation process much faster and helps us escape the rate-limiting issue since we now just have to send 1 request in place of 150
- It makes use of the fact that we can access the list of charts of a repository via appending `/index.yaml` on `repository_url` which is given as a package metadata
- Adds a function that generates AhPackages of all HELM charts available in ArtifactHub
- Adds support for use of multiple configs when extracting schema from CRDs. It is needed since the format in which the CRDs are structured slightly varies from system to system and we need the ability to accommodate that. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
