### PR TITLE
Add option for throwing error in gomodsync

### DIFF
--- a/cmd/syncmodutil/internal/modsync/sync.go
+++ b/cmd/syncmodutil/internal/modsync/sync.go
@@ -50,7 +50,7 @@ func (g *GoMod) PrintReplacedVersions() {
 		fmt.Printf("%s replaced by %s\n", v[0].Name+v[0].Version, v[1].Name+v[1].Version)
 	}
 }
-func (g *GoMod) SyncRequire(f io.Reader) (gomod string, err error) {
+func (g *GoMod) SyncRequire(f io.Reader, throwerr bool) (gomod string, err error) {
 	var b = make([]byte, 1000)
 	b, err = io.ReadAll(f)
 	if err != nil {
@@ -60,6 +60,9 @@ func (g *GoMod) SyncRequire(f io.Reader) (gomod string, err error) {
 	for _, required := range g.RequiredVersions {
 		for i, d := range data {
 			if !strings.Contains(d, "=>") && strings.Contains(d, required.Name+" ") && !strings.Contains(d, required.Version) {
+				if throwerr {
+					return "", fmt.Errorf("version mismatch for %s. Meshery has: %s but extension has %s", required.Name, required.Version, d)
+				}
 				indirect := strings.Contains(d, "//indirect")
 				updateVersion := "\t" + required.Name + " " + required.Version
 				if indirect {

--- a/cmd/syncmodutil/main.go
+++ b/cmd/syncmodutil/main.go
@@ -13,6 +13,11 @@ func main() {
 	}
 	src := os.Args[1]
 	dest := os.Args[2]
+	var throwerr bool
+	if len(os.Args) > 3 && os.Args[3] == "--err" {
+		throwerr = true
+	}
+
 	f, err := os.Open(src)
 	if err != nil {
 		log.Fatal(err)
@@ -25,7 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	newgomod, err := g.SyncRequire(f2)
+	newgomod, err := g.SyncRequire(f2, throwerr)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Ashish Tiwari <ashishjaitiwari15112000@gmail.com>

**Description**

Currently go mod sync utility automatically syncs the target go.mod with source go.mod but this PR adds a `--err` flag that can be passed to signal the utility to error out in case of mismatch instead of automatically syncing.
This flag will be used in the tests on pull requests to make sure that the contributor doesn't mistakenly introduce a versioning problem on edge.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
