### PR TITLE
[Refactor] Add `ErrorV2` struct 

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -83,6 +83,18 @@ func New(code string, severity Severity, sdescription []string, ldescription []s
 	}
 }
 
+func NewV2(code string, severity Severity, sdescription []string, ldescription []string, probablecause []string, remedy []string, additionalInfo interface{}) *ErrorV2 {
+	return &ErrorV2{
+		Code:                 code,
+		Severity:             severity,
+		ShortDescription:     sdescription,
+		LongDescription:      ldescription,
+		ProbableCause:        probablecause,
+		SuggestedRemediation: remedy,
+		AdditionalInfo:       additionalInfo,
+	}
+}
+
 func (e *Error) Error() string { return strings.Join(e.LongDescription[:], ".") }
 
 func (e *Error) ErrorV2(additionalInfo interface{}) ErrorV2 {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -85,6 +85,10 @@ func New(code string, severity Severity, sdescription []string, ldescription []s
 
 func (e *Error) Error() string { return strings.Join(e.LongDescription[:], ".") }
 
+func (e *Error) ErrorV2(additionalInfo interface{}) ErrorV2 {
+	return ErrorV2{Code: e.Code, Severity: e.Severity, ShortDescription: e.ShortDescription, LongDescription: e.LongDescription, ProbableCause: e.ProbableCause, SuggestedRemediation: e.SuggestedRemediation, AdditionalInfo: additionalInfo}
+}
+
 func GetCode(err error) string {
 	if obj := err.(*Error); obj != nil && obj.Code != " " {
 		return obj.Code

--- a/errors/types.go
+++ b/errors/types.go
@@ -9,9 +9,12 @@ type (
 		ProbableCause        []string
 		SuggestedRemediation []string
 	}
+	// Limitations of Error struct defined above:
 	// There are different types of Errors. Each type of error contains different information.
+	// Short and Long Descriptions accept only strings and so they cannot contain structured information.
+	// e.g. The Validation Error information (instancePath, badValue etc.) cannot be contained in Error struct (or not in a structured way that the clients can make use of it)
+	//
 	// ErrorV2 struct adds the ability to express all different types of errors.
-	// e.g. The information that a Validation Error (instancePath, badValue etc.) has cannot be contained in Error struct (or atleast in a me)
 	// ErrorV2 is backwards compatible with Error struct
 	ErrorV2 struct {
 		Code                 string

--- a/errors/types.go
+++ b/errors/types.go
@@ -9,6 +9,19 @@ type (
 		ProbableCause        []string
 		SuggestedRemediation []string
 	}
+	// There are different types of Errors. Each type of error contains different information.
+	// ErrorV2 struct adds the ability to express all different types of errors.
+	// e.g. The information that a Validation Error (instancePath, badValue etc.) has cannot be contained in Error struct (or atleast in a me)
+	// ErrorV2 is backwards compatible with Error struct
+	ErrorV2 struct {
+		Code                 string
+		Severity             Severity
+		ShortDescription     []string
+		LongDescription      []string
+		ProbableCause        []string
+		SuggestedRemediation []string
+		AdditionalInfo       interface{}
+	}
 )
 
 type Severity int
@@ -19,7 +32,6 @@ const (
 	Alert            // Immediate action needed
 	Critical         // Critical condition—default level
 	Fatal            // Fatal condition
-
 )
 
 var (


### PR DESCRIPTION
**Description**

 There are some limitations with the existing `Error` type:
1. There are different types of Errors. Each type of error contains different information which cannot be contained in the `Error` struct.
2. Short and Long Descriptions accept only strings and so they cannot contain structured information.
3. For example, the Validation Error information i.e. `instancePath`, `badValue`, etc. cannot be contained in the `Error` struct (or not in a structured way that the clients can make use of it).

`ErrorV2` Proposal: 
1. `ErrorV2` struct adds the ability to express all different types of errors.
2. It does so via adding a new field to the struct called `AdditionalInfo` which can contain structured error-specific information.
3. `ErrorV2` is backward compatible with the `Error` struct.


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
