### PR TITLE
[chore] Drop Relationships Table on Meshery Server Shut Down

### DIFF
--- a/models/meshmodel/registry.go
+++ b/models/meshmodel/registry.go
@@ -85,6 +85,7 @@ func (rm *RegistryManager) Cleanup() {
 		&Host{},
 		&v1alpha1.ComponentDefinitionDB{},
 		&v1alpha1.Model{},
+		&v1alpha1.RelationshipDefinitionDB{},
 	)
 }
 func (rm *RegistryManager) RegisterEntity(h Host, en Entity) error {


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**

This PR adds the relationship table in the cleanup function so that on shutting of Meshery Server, the relationship table is dropped along with other MeshModel tables. This would prevent duplicate registrations of relationships.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
