### PR TITLE
Use Joins in Meshmodel queries

### DIFF
--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -127,7 +127,7 @@ func GetMeshModelComponents(db *database.Handler, f ComponentFilter) (c []Compon
 	err := finder.
 		Scan(&componentDefinitionsWithModel).Error
 	if err != nil {
-		fmt.Println("bruh: ", err.Error())
+		fmt.Println(err.Error()) //for debugging
 	}
 	for _, cm := range componentDefinitionsWithModel {
 		c = append(c, cm.ComponentDefinitionDB.GetComponentDefinition(cm.Model))

--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -55,15 +55,9 @@ func (c ComponentDefinition) Type() types.CapabilityType {
 func (c ComponentDefinition) GetID() uuid.UUID {
 	return c.ID
 }
-func hash(val ...string) uuid.UUID {
-	p := make([]byte, 0)
-	for _, v := range val {
-		p = append(p, []byte(v)...)
-	}
-	return uuid.NewSHA1(uuid.UUID{}, p)
-}
+
 func CreateComponent(db *database.Handler, c ComponentDefinition) (uuid.UUID, error) {
-	c.ID = hash(c.Kind, c.APIVersion, c.Model.Name, c.Model.Version) //ComponentID is a composite hash of kind,apiversion and model.name. This enforces that two components cannot have same kind,apiVersion and model.Name
+	c.ID = uuid.New()
 	tempModelID := uuid.New()
 	byt, err := json.Marshal(c.Model)
 	if err != nil {

--- a/models/meshmodel/core/v1alpha1/models.go
+++ b/models/meshmodel/core/v1alpha1/models.go
@@ -1,5 +1,12 @@
 package v1alpha1
 
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+var modelCreationLock sync.Mutex //Each component/relationship will perform a check and if the model already doesn't exist, it will create a model. This lock will make sure that there are no race conditions.
 type ModelFilter struct {
 	Name     string
 	Greedy   bool //when set to true - instead of an exact match, name will be prefix matched
@@ -9,6 +16,16 @@ type ModelFilter struct {
 	Sort     string //asc or desc. Default behavior is asc
 	Limit    int    //If 0 or  unspecified then all records are returned and limit is not used
 	Offset   int
+}
+
+// swagger:response Model
+type Model struct {
+	ID          uuid.UUID `json:"-"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	DisplayName string    `json:"model-display-name" gorm:"display-name"`
+	Category    string    `json:"category"`
+	SubCategory string    `json:"sub-category"`
 }
 
 // Create the filter from map[string]interface{}

--- a/models/meshmodel/core/v1alpha1/relationship.go
+++ b/models/meshmodel/core/v1alpha1/relationship.go
@@ -98,7 +98,7 @@ func GetMeshModelRelationship(db *database.Handler, f RelationshipFilter) (r []R
 	err := finder.
 		Scan(&componentDefinitionsWithModel).Error
 	if err != nil {
-		fmt.Println("bruh: ", err.Error())
+		fmt.Println(err.Error()) //for debugging
 	}
 	for _, cm := range componentDefinitionsWithModel {
 		r = append(r, cm.RelationshipDefinitionDB.GetRelationshipDefinition(cm.Model))

--- a/models/meshmodel/core/v1alpha1/relationship.go
+++ b/models/meshmodel/core/v1alpha1/relationship.go
@@ -131,7 +131,7 @@ func (r RelationshipDefinition) GetID() uuid.UUID {
 }
 
 func CreateRelationship(db *database.Handler, r RelationshipDefinition) (uuid.UUID, error) {
-	r.ID = hash(r.Kind, r.APIVersion, r.Model.Name, r.Model.Version)
+	r.ID = uuid.New()
 	tempModelID := uuid.New()
 	byt, err := json.Marshal(r.Model)
 	if err != nil {

--- a/models/meshmodel/registry.go
+++ b/models/meshmodel/registry.go
@@ -136,14 +136,14 @@ func (rm *RegistryManager) GetEntities(f types.Filter) []Entity {
 	switch filter := f.(type) {
 	case *v1alpha1.ComponentFilter:
 		en := make([]Entity, 0)
-		comps := v1alpha1.GetComponents(rm.db, *filter)
+		comps := v1alpha1.GetMeshModelComponents(rm.db, *filter)
 		for _, comp := range comps {
 			en = append(en, comp)
 		}
 		return en
 	case *v1alpha1.RelationshipFilter:
 		en := make([]Entity, 0)
-		relationships := v1alpha1.GetRelationships(rm.db, *filter)
+		relationships := v1alpha1.GetMeshModelRelationship(rm.db, *filter)
 		for _, rel := range relationships {
 			en = append(en, rel)
 		}

--- a/utils/artifacthub/package.go
+++ b/utils/artifacthub/package.go
@@ -64,7 +64,6 @@ func (pkg *AhPackage) UpdatePackageData() error {
 	}
 	charts, err := utils.ReadRemoteFile(pkg.RepoUrl + urlSuffix)
 	if err != nil {
-		fmt.Println("bruh: ", err.Error())
 		return ErrGetChartUrl(err)
 	}
 	var out map[string]interface{}


### PR DESCRIPTION
**Description**

This PR fixes #251 
1. Uses joins to query Meshmodels.
2. Adds the constraint that each meshmodel(component and relationship) will have unique apiVersion,kind,model.name,model.version as a composite key
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
