### PR TITLE
Add trim filter and add empty schema check

### DIFF
--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -66,7 +66,6 @@ func emptySchemaCheck(schema string) (valid bool) {
 	}
 	valid = true
 	return
-
 }
 func CreateComponent(db *database.Handler, c ComponentDefinition) (uuid.UUID, error) {
 	c.ID = uuid.New()

--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -55,7 +55,7 @@ func (c ComponentDefinition) Type() types.CapabilityType {
 func (c ComponentDefinition) GetID() uuid.UUID {
 	return c.ID
 }
-func schemaValidationCheck(schema string) (valid bool) {
+func emptySchemaCheck(schema string) (valid bool) {
 	if schema == "" {
 		return
 	}
@@ -75,7 +75,7 @@ func CreateComponent(db *database.Handler, c ComponentDefinition) (uuid.UUID, er
 	if err != nil {
 		return uuid.UUID{}, err
 	}
-	if !schemaValidationCheck(c.Schema) {
+	if !emptySchemaCheck(c.Schema) {
 		c.Metadata["hasInvalidSchema"] = true
 	}
 	modelID := uuid.NewSHA1(uuid.UUID{}, byt)

--- a/models/meshmodel/core/v1alpha1/models.go
+++ b/models/meshmodel/core/v1alpha1/models.go
@@ -9,7 +9,7 @@ import (
 var modelCreationLock sync.Mutex //Each component/relationship will perform a check and if the model already doesn't exist, it will create a model. This lock will make sure that there are no race conditions.
 type ModelFilter struct {
 	Name        string
-	DisplayName string //If Name is already passed, avoid passing Display name unless greedy=true, else the filter will translate to an AND returning only the models where name and display name match exactly. Ignore, if this behaviour is expected.
+	DisplayName string //If Name is already passed, avoid passing Display name unless greedy=true, else the filter will translate to an AND returning only the models where name and display name match exactly. Ignore, if this behavior is expected.
 	Greedy      bool   //when set to true - instead of an exact match, name will be prefix matched. Also an OR will be performed of name and display_name
 	Version     string
 	Category    string


### PR DESCRIPTION
**Description**

This PR fixes #
1. Adds a trim filter so that on few endpoints components can be returned without the schema, where schema is not needed.
2. Since clients will not get schema when ?trim=true, an empty schema check is done at the time of registration so that component's metadata can tell if the component is usable by clients like RJSF or not.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
