### PR TITLE
Add support for "isNamespaced" in components generated from CRDs

### DIFF
--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -68,10 +68,8 @@ func Generate(crd string) (v1alpha1.ComponentDefinition, error) {
 	if err != nil {
 		return component, err
 	}
-	scope, err := extractCueValueFromPath(crdCue, DefaultPathConfig.ScopePath)
-	if err != nil {
-		// return component, err Ignore error if scope isn't found
-	}
+	// return component, err Ignore error if scope isn't found
+	scope, _ := extractCueValueFromPath(crdCue, DefaultPathConfig.ScopePath)
 	if scope == "Cluster" {
 		component.Metadata["isNamespaced"] = false
 	} else if scope == "Namespaced" {

--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/layer5io/meshkit/models/meshmodel/core/v1alpha1"
 	"github.com/layer5io/meshkit/utils"
 	"github.com/layer5io/meshkit/utils/manifests"
@@ -14,6 +16,7 @@ type CuePathConfig struct {
 	GroupPath   string
 	VersionPath string
 	SpecPath    string
+	ScopePath   string
 	// identifiers are the values that uniquely identify a CRD (in most of the cases, it is the 'Name' field)
 	IdentifierPath string
 }
@@ -23,6 +26,7 @@ var DefaultPathConfig = CuePathConfig{
 	IdentifierPath: "spec.names.kind",
 	VersionPath:    "spec.versions[0].name",
 	GroupPath:      "spec.group",
+	ScopePath:      "spec.scope",
 	SpecPath:       "spec.versions[0].schema.openAPIV3Schema.properties.spec",
 }
 
@@ -31,6 +35,7 @@ var DefaultPathConfig2 = CuePathConfig{
 	IdentifierPath: "spec.names.kind",
 	VersionPath:    "spec.versions[0].name",
 	GroupPath:      "spec.group",
+	ScopePath:      "spec.scope",
 	SpecPath:       "spec.validation.openAPIV3Schema.properties.spec",
 }
 
@@ -59,8 +64,26 @@ func Generate(crd string) (v1alpha1.ComponentDefinition, error) {
 	if err != nil {
 		return component, err
 	}
+	group, err := extractCueValueFromPath(crdCue, DefaultPathConfig.GroupPath)
+	if err != nil {
+		return component, err
+	}
+	scope, err := extractCueValueFromPath(crdCue, DefaultPathConfig.ScopePath)
+	if err != nil {
+		// return component, err Ignore error if scope isn't found
+	}
+	if scope == "Cluster" {
+		component.Metadata["isNamespaced"] = false
+	} else if scope == "Namespaced" {
+		component.Metadata["isNamespaced"] = true
+	}
 	component.Kind = name
-	component.APIVersion = version
+	if group != "" {
+		component.APIVersion = fmt.Sprintf("%s/%s", group, version)
+	} else {
+		component.APIVersion = version
+	}
+
 	component.Format = v1alpha1.JSON
 	component.DisplayName = manifests.FormatToReadableString(name)
 	return component, nil


### PR DESCRIPTION
**Description**

We have two types of sources from where we generate components.
1. The response returned by kubernetes on `/openapi/v2` 
2. CRDs extracted from Helm charts or manifests

For 1, we are already attaching the info about a component being namespaced inside metadata.
For 2, CRDs have `spec.scope` field which can be used for the same purpose. This PR does just that.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
4. Build and test your changes before submitting a PR. 
5. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
