### PR TITLE
New Docker client from config

### DIFF
--- a/helpers/compose.go
+++ b/helpers/compose.go
@@ -19,6 +19,11 @@ import (
 
 	dockerClient "github.com/docker/docker/client"
 
+	dockerCmd "github.com/docker/cli/cli/command"
+	cliconfig "github.com/docker/cli/cli/config"
+	cliflags "github.com/docker/cli/cli/flags"
+	dockerconfig "github.com/docker/docker/cli/config"
+
 	format "github.com/docker/compose/v2/cmd/formatter"
 	"github.com/docker/compose/v2/pkg/api"
 )
@@ -29,6 +34,25 @@ type ContainerView struct {
 	Status  string
 	Command string
 	Ports   []string
+}
+
+func NewDockerAPIClientFromConfig(configDir string) (*dockerClient.APIClient, error) {
+	if configDir == "" {
+		configDir = dockerconfig.Dir()
+	}
+
+	// Get the Docker configuration
+	dockerCfg, err := cliconfig.Load(configDir)
+	if err != nil {
+		return nil, err
+	}
+
+	//connection to docker-client
+	cli, err := dockerCmd.NewAPIClientFromFlags(cliflags.NewCommonOptions(), dockerCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &cli, nil
 }
 
 func NewComposeClientFromDocker(c *dockerClient.APIClient) *client.Client {

--- a/helpers/compose_test.go
+++ b/helpers/compose_test.go
@@ -6,37 +6,23 @@ import (
 	"path/filepath"
 	"testing"
 
-	dockerCmd "github.com/docker/cli/cli/command"
-	cliconfig "github.com/docker/cli/cli/config"
-	cliflags "github.com/docker/cli/cli/flags"
 	format "github.com/docker/compose/v2/cmd/formatter"
-	dockerconfig "github.com/docker/docker/cli/config"
-	dockerClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 )
 
 var testDockerComposeConfig string = "./docker-compose.test.yml"
 
-func mockDockerClient() (*dockerClient.APIClient, error) {
-	// Get the Docker configuration
-	dockerCfg, err := cliconfig.Load(dockerconfig.Dir())
-	if err != nil {
-		return nil, err
-	}
+func TestNewDockerAPIClientFromConfig(t *testing.T) {
+	dc, err := NewDockerAPIClientFromConfig("")
 
-	//connection to docker-client
-	cli, err := dockerCmd.NewAPIClientFromFlags(cliflags.NewCommonOptions(), dockerCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cli, nil
+	assert.NotNil(t, dc)
+	assert.NoError(t, err)
 }
 
 func TestNewComposeClient(t *testing.T) {
 	// Test that NewComposeClient returns a non-nil client and no error
 
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NotNil(t, dc)
 	assert.NoError(t, err)
 
@@ -57,10 +43,18 @@ func TestNewComposeClient(t *testing.T) {
 // 	assert.NoError(t, err)
 // }
 
+func TestOrchestration(t *testing.T) {
+	t.Run("Test Up command", TestUp)
+
+	t.Run("Test Stop command", TestStop)
+
+	t.Run("Test Compose command", TestStop)
+}
+
 func TestUp(t *testing.T) {
 	// Test that Up returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -76,7 +70,7 @@ func TestUp(t *testing.T) {
 func TestRm(t *testing.T) {
 	// Test that Rm returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -89,7 +83,7 @@ func TestRm(t *testing.T) {
 func TestStop(t *testing.T) {
 	// Test that Stop returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -102,7 +96,7 @@ func TestStop(t *testing.T) {
 func TestPs(t *testing.T) {
 	// Test that Ps returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -115,7 +109,7 @@ func TestPs(t *testing.T) {
 func TestListContainers(t *testing.T) {
 	// Test that ListContainers returns a non-nil slice of ContainerView and no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -129,7 +123,7 @@ func TestListContainers(t *testing.T) {
 func TestPull(t *testing.T) {
 	// Test that Pull returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)
@@ -142,7 +136,7 @@ func TestPull(t *testing.T) {
 func TestGetLogs(t *testing.T) {
 	// Test that GetLogs returns no error
 	ctx := context.Background()
-	dc, err := mockDockerClient()
+	dc, err := NewDockerAPIClientFromConfig("")
 	assert.NoError(t, err)
 
 	c := NewComposeClientFromDocker(dc)

--- a/helpers/compose_test.go
+++ b/helpers/compose_test.go
@@ -102,7 +102,7 @@ func TestPs(t *testing.T) {
 	c := NewComposeClientFromDocker(dc)
 	assert.NotNil(t, c)
 
-	err = Ps(ctx, c, false, false, "")
+	err = Ps(ctx, c, false, false, "", testDockerComposeConfig)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
**Description**

This PR
- adds helper function for creating a new Docker client from existing configuration and respective unit tests.
- adds another unit test to test whether `Up`, `Stop` & `Remove` commands work as expected since this chronology is not guaranteed when running respective unit tests individually.
- updates `Ps` function from mimicking `docker ps` to `docker compose ps`

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
