### PR TITLE
Register components based on ui compatibility

### DIFF
--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -119,6 +119,9 @@ func GetMeshModelComponents(db *database.Handler, f ComponentFilter) (c []Compon
 			finder = finder.Where("component_definition_dbs.display_name = ?", f.DisplayName)
 		}
 	}
+	if !f.ReturnIncompatibleComponent {
+		finder = finder.Where("json_extract(component_definition_dbs.metadata, '$.uiCompatible') = ? ", true)
+	}
 	if f.ModelName != "" && f.ModelName != "all" {
 		finder = finder.Where("model_dbs.name = ?", f.ModelName)
 	}
@@ -163,18 +166,19 @@ func GetMeshModelComponents(db *database.Handler, f ComponentFilter) (c []Compon
 }
 
 type ComponentFilter struct {
-	Name         string
-	APIVersion   string
-	Greedy       bool //when set to true - instead of an exact match, name will be prefix matched
-	Trim         bool //when set to true - the schema is not returned
-	DisplayName  string
-	ModelName    string
-	CategoryName string
-	Version      string
-	Sort         string //asc or desc. Default behavior is asc
-	OrderOn      string
-	Limit        int //If 0 or  unspecified then all records are returned and limit is not used
-	Offset       int
+	Name                        string
+	APIVersion                  string
+	Greedy                      bool //when set to true - instead of an exact match, name will be prefix matched
+	Trim                        bool //when set to true - the schema is not returned
+	DisplayName                 string
+	ModelName                   string
+	CategoryName                string
+	ReturnIncompatibleComponent bool
+	Version                     string
+	Sort                        string //asc or desc. Default behavior is asc
+	OrderOn                     string
+	Limit                       int //If 0 or  unspecified then all records are returned and limit is not used
+	Offset                      int
 }
 
 // Create the filter from map[string]interface{}


### PR DESCRIPTION
**Description**
Every component has `uiCompatible` property in their `metadata`. If `uiCompatible` property is unset then the component is still registered (if schema is valid) so that  `Applications` upload doesn't fail, but is not returned to UI.
`uiCompatible ` can be un-set in 2 cases:
1. Schema is not present,
2. UI cannot handle the schema correctly (eg: CRD).
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
