### PR TITLE
Update spec path

### DIFF
--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -31,7 +31,7 @@ var DefaultPathConfig = CuePathConfig{
 	VersionPath:    "spec.versions[0].name",
 	GroupPath:      "spec.group",
 	ScopePath:      "spec.scope",
-	SpecPath:       "spec.versions[0].schema.openAPIV3Schema.properties.spec",
+	SpecPath:       "spec.versions[0].schema.openAPIV3Schema",
 	PropertiesPath: "properties",
 }
 
@@ -41,7 +41,7 @@ var DefaultPathConfig2 = CuePathConfig{
 	VersionPath:    "spec.versions[0].name",
 	GroupPath:      "spec.group",
 	ScopePath:      "spec.scope",
-	SpecPath:       "spec.validation.openAPIV3Schema.properties.spec",
+	SpecPath:       "spec.validation.openAPIV3Schema",
 }
 
 var Configs = []CuePathConfig{DefaultPathConfig, DefaultPathConfig2}

--- a/utils/component/utils.go
+++ b/utils/component/utils.go
@@ -30,13 +30,13 @@ func getSchema(parsedCrd cue.Value, pathConf CuePathConfig) (string, error) {
 	if err != nil {
 		return "", ErrGetSchema(err)
 	}
-	
+
 	updatedProps, err := UpdateProperties(specCueVal, cue.ParsePath(pathConf.PropertiesPath), resourceId)
 
 	if err != nil {
 		return "", err
 	}
-	
+
 	schema = updatedProps
 	DeleteFields(schema)
 
@@ -74,4 +74,3 @@ func DeleteFields(m map[string]interface{}) {
 		m[key] = prop
 	}
 }
-

--- a/utils/component/utils.go
+++ b/utils/component/utils.go
@@ -8,6 +8,9 @@ import (
 	"github.com/layer5io/meshkit/utils/manifests"
 )
 
+// Remove the fields which is either not required by end user (like status) or is prefilled by system (like apiVersion, kind and metadata)
+var fieldsToDelete = [4]string{"apiVersion", "kind", "status", "metadata"}
+
 // extracts the JSONSCHEMA of the CRD and outputs the json encoded string of the schema
 func getSchema(parsedCrd cue.Value, pathConf CuePathConfig) (string, error) {
 	schema := map[string]interface{}{}
@@ -27,14 +30,15 @@ func getSchema(parsedCrd cue.Value, pathConf CuePathConfig) (string, error) {
 	if err != nil {
 		return "", ErrGetSchema(err)
 	}
-
+	
 	updatedProps, err := UpdateProperties(specCueVal, cue.ParsePath(pathConf.PropertiesPath), resourceId)
 
 	if err != nil {
 		return "", err
 	}
-
+	
 	schema = updatedProps
+	DeleteFields(schema)
 
 	(schema)["title"] = manifests.FormatToReadableString(resourceId)
 	var output []byte
@@ -56,3 +60,18 @@ func extractCueValueFromPath(crd cue.Value, pathConf string) (string, error) {
 	}
 	return res, nil
 }
+
+// function to remove fields that are not required or prefilled
+func DeleteFields(m map[string]interface{}) {
+	key := "properties"
+	if m[key] == nil {
+		return
+	}
+	if prop, ok := m[key].(map[string]interface{}); ok && prop != nil {
+		for _, f := range fieldsToDelete {
+			delete(prop, f)
+		}
+		m[key] = prop
+	}
+}
+


### PR DESCRIPTION
**Description**
This PR ensures components registered dynamically and statically have the same schema, currently, there are discrepancies, resulting in deployment issues.
Some components are deployed like Istio, because the schema doesn't mark spec as a required field hence, it passes pattern-engine validation as well as k8s, but there's a warning and deployed resource is of no use.
<details>
<summary>Deployments</summary>
<img width="640" alt="Screenshot 2023-07-19 at 2 37 50 PM" src="https://github.com/meshery/meshkit/assets/79860504/4ac1a812-4b08-43fb-8947-0a44ddbe76a6">
<img width="952" alt="Screenshot 2023-07-19 at 2 47 55 PM" src="https://github.com/meshery/meshkit/assets/79860504/9005fa14-dc1e-4224-8d5c-ecaa13328331">
Deployed with spec attribute in the design file
<img width="952" alt="Screenshot 2023-07-19 at 2 47 55 PM" src="https://github.com/meshery/meshkit/assets/79860504/ac1b0f94-4b13-4b3e-a2fb-497e45e4d8bb">
</details>

AlertManger has "spec" as a required field in their schema, therefore even if the static AlertManger comp omits the spec attribute, deployment fails with the error: ``` Alertmanager.monitoring.coreos.com "alertmanager" is invalid: spec: Required value``` (returned from k8s).
<details>
<summary>Sample design</summary>

```
name: Untitled Design
services:
  alertmanager:
    name: alertmanager
    type: Alertmanager
    apiVersion: monitoring.coreos.com/v1
    namespace: default
    model: kube-prometheus-stack
    settings:
        alertmanager Config Matcher Strategy:
          type: None
        image: quay.io/prometheus/alertmanager:v0.25.0
        port Name: web
        retention: 120h
    traits:
      meshmap:
        edges: []
        id: f5340528-3a36-46da-a336-325f779b759f
        label: alertmanager
        meshmodel-data:
          category:
            metadata: null
            name: Observability and Analysis
          displayName: Kube Prometheus Stack
          metadata:
            svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/alertmanager-color.svg
            svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/alertmanager-white.svg
          name: kube-prometheus-stack
          version: 45.7.1
        meshmodel-metadata:
          genealogy: ""
          isNamespaced: true
          logoURL: https://github.com/cncf/artwork/blob/master/examples/graduated.md#prometheus-logos
          model: kube-prometheus-stack
          modelDisplayName: Kube Prometheus Stack
          primaryColor: '#e75225'
          published: true
          secondaryColor: '#ec7551'
          shape: circle
          styleOverrides: ""
          subCategory: Monitoring
          svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/alertmanager-color.svg
          svgComplete: ""
          svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/alertmanager-white.svg
        position:
          posX: 2.434789490733465
          posY: 88.81485589759697
```
</details>
Check out both branches and regenerate comp and try creating a new design, it will be deployed correctly.

**Notes for Reviewers**
**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
