### PR TITLE
Added formatted fields

### DIFF
--- a/logger/formatter.go
+++ b/logger/formatter.go
@@ -1,0 +1,20 @@
+package logger
+
+import "github.com/sirupsen/logrus"
+
+const (
+	JsonLogFormat = iota
+	SyslogLogFormat
+	TerminalLogFormat
+)
+
+type Format int
+
+// TerminalFormatter is exported
+type TerminalFormatter struct{}
+
+// Format defined the format of output for Logrus logs
+// Format is exported
+func (f *TerminalFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return append([]byte(entry.Message), '\n'), nil
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,6 +11,15 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
+type LogLevel int
+
+const (
+	DebugLevel LogLevel = iota
+	InfoLevel
+	WarnLevel
+	ErrorLevel
+)
+
 type Handler interface {
 	SetLogFormatter(formatter TerminalFormatter)
 
@@ -31,6 +40,7 @@ type Handler interface {
 
 type Logger struct {
 	handler      *logrus.Entry
+	logLevel     LogLevel
 	logFormatter TerminalFormatter
 }
 
@@ -82,6 +92,10 @@ func (l *Logger) Error(err error) {
 
 func (l *Logger) SetLogFormatter(formatter TerminalFormatter) {
 	l.logFormatter = formatter
+}
+
+func (l *Logger) SetLogLevel(level LogLevel) {
+	l.logLevel = level
 }
 
 func (l *Logger) Errorf(format string, args ...interface{}) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -21,6 +21,8 @@ const (
 )
 
 type Handler interface {
+	SetLogLevel(level LogLevel)
+	GetLogLevel() LogLevel
 	SetLogFormatter(formatter TerminalFormatter)
 
 	Info(description ...interface{})
@@ -92,6 +94,10 @@ func (l *Logger) Error(err error) {
 
 func (l *Logger) SetLogFormatter(formatter TerminalFormatter) {
 	l.logFormatter = formatter
+}
+
+func (l *Logger) GetLogLevel() LogLevel {
+	return l.logLevel
 }
 
 func (l *Logger) SetLogLevel(level LogLevel) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,6 +12,8 @@ import (
 )
 
 type Handler interface {
+	SetLogFormatter(formatter TerminalFormatter)
+
 	Info(description ...interface{})
 	Debug(description ...interface{})
 	Warn(err error)
@@ -28,7 +30,8 @@ type Handler interface {
 }
 
 type Logger struct {
-	handler *logrus.Entry
+	handler      *logrus.Entry
+	logFormatter TerminalFormatter
 }
 
 func New(appname string, opts Options) (Handler, error) {
@@ -45,7 +48,7 @@ func New(appname string, opts Options) (Handler, error) {
 			FullTimestamp:   true,
 		})
 	case TerminalLogFormat:
-		log.SetFormatter(new(TerminalFormatter))
+		log.SetFormatter(&TerminalFormatter{})
 	}
 
 	// log.SetReportCaller(true)
@@ -75,6 +78,10 @@ func (l *Logger) Error(err error) {
 		"probable-cause":        errors.GetCause(err),
 		"suggested-remediation": errors.GetRemedy(err),
 	}).Log(logrus.ErrorLevel, err.Error())
+}
+
+func (l *Logger) SetLogFormatter(formatter TerminalFormatter) {
+	l.logFormatter = formatter
 }
 
 func (l *Logger) Errorf(format string, args ...interface{}) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -16,6 +17,11 @@ type Handler interface {
 	Warn(err error)
 	Error(err error)
 
+	Infof(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+
 	// Kubernetes Controller compliant logger
 	ControllerLogger() logr.Logger
 	DatabaseLogger() gormlogger.Interface
@@ -23,15 +29,6 @@ type Handler interface {
 
 type Logger struct {
 	handler *logrus.Entry
-}
-
-// TerminalFormatter is exported
-type TerminalFormatter struct{}
-
-// Format defined the format of output for Logrus logs
-// Format is exported
-func (f *TerminalFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	return append([]byte(entry.Message), '\n'), nil
 }
 
 func New(appname string, opts Options) (Handler, error) {
@@ -80,16 +77,31 @@ func (l *Logger) Error(err error) {
 	}).Log(logrus.ErrorLevel, err.Error())
 }
 
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	l.handler.Logger.Error(message)
+}
+
 func (l *Logger) Info(description ...interface{}) {
 	l.handler.Log(logrus.InfoLevel,
 		description...,
 	)
 }
 
+func (l *Logger) Infof(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	l.handler.Log(logrus.InfoLevel, message)
+}
+
 func (l *Logger) Debug(description ...interface{}) {
 	l.handler.Log(logrus.DebugLevel,
 		description...,
 	)
+}
+
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	l.handler.Log(logrus.DebugLevel, message)
 }
 
 func (l *Logger) Warn(err error) {
@@ -104,4 +116,9 @@ func (l *Logger) Warn(err error) {
 		"probable-cause":        errors.GetCause(err),
 		"suggested-remediation": errors.GetRemedy(err),
 	}).Log(logrus.WarnLevel, err.Error())
+}
+
+func (l *Logger) Warnf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	l.handler.Log(logrus.WarnLevel, message)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,42 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/layer5io/meshkit/errors"
+	"github.com/layer5io/meshkit/logger"
+)
+
+var ErrCode = "10000"
+
+func Err(err error, msg string) error {
+	return errors.New(ErrCode, errors.Alert, []string{msg}, []string{err.Error()}, []string{}, []string{})
+}
+
+func TestLogger(t *testing.T) {
+
+	t.Run("New", func(t *testing.T) {
+		_, err := logger.New("app", logger.Options{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("LoggingLevels", func(t *testing.T) {
+		logger, err := logger.New("app", logger.Options{})
+
+		logger.Debug("debug")
+		logger.Info("info")
+		logger.Warn(err)
+		logger.Error(err)
+
+		logger.Debugf("debugf %d", 1)
+		logger.Infof("infof %d", 2)
+		logger.Warnf("warnf %d", 3)
+		logger.Errorf("errorf %d", 4)
+	})
+
+	// Could add more test cases for different options,
+	// log formats, error cases, etc.
+
+}

--- a/logger/types.go
+++ b/logger/types.go
@@ -2,14 +2,6 @@ package logger
 
 import "io"
 
-const (
-	JsonLogFormat = iota
-	SyslogLogFormat
-	TerminalLogFormat
-)
-
-type Format int
-
 type Options struct {
 	Format     Format
 	DebugLevel bool


### PR DESCRIPTION
**Description**

This PR added formatted fields to our custom logger.

We now support `infof`, `warnf`, `errorf`, and `debugf`.

Pass `TerminalFormatter` through the logger, instead of declaring them again in `mesheryctl`

This PR is not ready for review at the moment, but anyone can use this commit to test against their relevant repos and provide feedback.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
