### PR TITLE
Updated the slack action to not use ::set-env

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - name: Get current star count
       run: |
-        echo ::set-env name=STARS::$(curl --silent 'https://api.github.com/repos/layer5io/meshkit' -H 'Accept: application/vnd.github.preview' | jq '.watchers_count')
+        echo "STARS=$(curl --silent 'https://api.github.com/repos/layer5io/meshkit' -H 'Accept: application/vnd.github.preview' | jq '.watchers_count')" >> $GITHUB_ENV
     - name: Notify slack
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
* ::set-env has been deprecated. The recommended method is to use the environment files (GITHUB_ENV).

This PR fixes: https://github.com/meshery/meshkit/issues/336

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
