### PR TITLE
Fix import modal errors coming because of multiple wild card

### DIFF
--- a/schemas/configuration/publishCatalogItem.json
+++ b/schemas/configuration/publishCatalogItem.json
@@ -34,16 +34,16 @@
             "type": "string",
             "title": "Type",
             "enum": [
-                "deployment",
-                "observability",
-                "resiliency",
-                "scaling",
-                "security",
-                "traffic-management",
-                "troubleshooting",
-                "workloads"
+                "Deployment",
+                "Observability",
+                "Resiliency",
+                "Scaling",
+                "Security",
+                "Traffic-management",
+                "Troubleshooting",
+                "Workloads"
             ],
-            "default": "deployment",
+            "default": "Deployment",
             "description": "Categorization of the type of design or operational flow depicted in this design.",
             "x-rjsf-grid-area": 6
         }

--- a/schemas/configuration/uiSchemaApplication.json
+++ b/schemas/configuration/uiSchemaApplication.json
@@ -2,5 +2,5 @@
   "applicationType": {
     "ui:widget": "radio"
   },
-  "ui:order" : ["name", "applicationType", "*"]
+  "ui:order" : ["name", "applicationType"]
 }

--- a/schemas/configuration/uiSchemaDesignImport.json
+++ b/schemas/configuration/uiSchemaDesignImport.json
@@ -2,5 +2,5 @@
   "uploadType": {
     "ui:widget": "radio"
   },
-  "ui:order" : ["name", "uploadType", "*"]
+  "ui:order" : ["name", "uploadType"]
 }

--- a/schemas/configuration/uiSchemaFilter.json
+++ b/schemas/configuration/uiSchemaFilter.json
@@ -1,3 +1,3 @@
 {
-    "ui:order" : ["name", "uploadType", "config", "*"]
+    "ui:order" : ["name", "uploadType", "config"]
 }


### PR DESCRIPTION
**Description**

This PR fixes #

**Issue**

Import modal is crashing with error
```diff
Invalid "root" object field configuration: uiSchema order list contains more than one wildcard item.
```

**Notes for Reviewers**

"*" is what we call it wild card, as per [documentation](https://rjsf-team.github.io/react-jsonschema-form/docs/json-schema/objects/#specifying-property-order) this is right approach to use, so for now I'm fixing it with removing wild card and will investigate if that issue still comes in after updating RJSF


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
