### PR TITLE
[Schemas] Define all fields in ui:order to prevent crash

### DIFF
--- a/schemas/configuration/uiSchemaApplication.json
+++ b/schemas/configuration/uiSchemaApplication.json
@@ -2,5 +2,5 @@
   "applicationType": {
     "ui:widget": "radio"
   },
-  "ui:order" : ["name", "applicationType"]
+  "ui:order" : ["name", "applicationType", "file", "url"]
 }

--- a/schemas/configuration/uiSchemaDesignImport.json
+++ b/schemas/configuration/uiSchemaDesignImport.json
@@ -2,5 +2,5 @@
   "uploadType": {
     "ui:widget": "radio"
   },
-  "ui:order" : ["name", "uploadType"]
+  "ui:order" : ["name", "uploadType", "file", "url"]
 }

--- a/schemas/configuration/uiSchemaFilter.json
+++ b/schemas/configuration/uiSchemaFilter.json
@@ -1,3 +1,3 @@
 {
-    "ui:order" : ["name", "uploadType", "config"]
+    "ui:order" : ["name", "uploadType", "config", "file", "url"]
 }


### PR DESCRIPTION
**Description**

This PR fixes #

Recently we get `*` wild card issues in Meshery from RJSF form and error was `You can't use multiple wild cards in ui:order` even if we were using the single wild card and removing it fixes the issue in Meshery and works fine

As a result, it crashes in Meshery cloud RJSF forms and the form and error is `include all field in ui:order` I think this was because of different RJSF versions in both applications, though to prevent that in the future we will make sure to not use `*` wild card and explicitly define all fields in ui:order

FYI wild card helps us not to explicitly define ui order for all fields in form all the time, with the help of wild card we can define the order of some fields and the rest can render after that

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
