### PR TITLE
Add tidy in order to check go mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: Lint and unit tests
 on:
   push:
     branches:
-      - '**'
-    tags:
-      - 'v*'
+      - master
   pull_request:
     branches:
       - master
@@ -21,9 +19,22 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=5m
+      - name: Run golangci-lint
+        run: make check
+  tidy:
+    name: tidy
+    needs: [golangci]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@master
+        with:
+          go-version: '1.21'
+      - name: go mod tidy
+        run: make tidy
   tests:
      name: Tests
+     needs: [golangci, tidy]
      runs-on: ubuntu-latest
      env:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -36,5 +47,4 @@ jobs:
        uses: actions/setup-go@master
        with:
         go-version: 1.21
-     - run: |
-         GOPROXY=direct,https://proxy.golang.org GOSUMDB=off GO111MODULE=on go test -v ./...
+     - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  go-mod-tidy:
+    enabled: true
   gci:
     enabled: true
     max-len: 120
@@ -58,7 +60,5 @@ run:
   skip-dirs:
     - vendor
     - bundle
-    - config
     - hack
-    - helpers
     - img

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ include build/Makefile.core.mk
 include build/Makefile.show-help.mk
 
 check:
-	golangci-lint run
+	golangci-lint run -c .golangci.yml -v ./...
 
-check-clean-cache:
-	golangci-lint cache clean
+tidy:
+	go mod tidy
+	git diff --exit-code go.mod go.sum
 
 test:
-	go test ./...
+	go test -v ./...
 
 errorutil:
 	go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # MeshKit for Meshery and it's ecosystem
 A toolkit for Meshery's microservices and various individual architectural components to reuse and share common functionality. Learn more: [Introducing MeshKit and the Meshery Adapter Library](https://layer5.io/blog/meshery/introducing-meshkit-and-the-meshery-adapter-library)
 
+
+![](https://github.com/meshery/meshkit/actions/workflows/ci.yml/badge.svg)
+![](https://github.com/meshery/meshkit/actions/workflows/release-drafter.yml/badge.svg)
+![](https://github.com/meshery/meshkit/actions/workflows/error-codes-updater.yaml/badge.svg)
+
+
+
 ### Instructions for making custom dictionary entries
 
 Enter new key:value pairs into the `useDictionary()` map in https://github.com/meshery/meshkit/blob/master/utils/utils.go


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

`golangci-lint` is not enough, you can see go mod tidy is failed. This repo is a lib, so we can't build it, but we can still checking the `go.mod` here to make sure the dependencies are ok.

Also remove the abuse of CI.  One PR can trigger one CI check runs two times.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
