### PR TITLE
[meshmodel] Add new `Registrant` filter for Models Construct 

### DIFF
--- a/models/meshmodel/core/v1alpha1/models.go
+++ b/models/meshmodel/core/v1alpha1/models.go
@@ -14,7 +14,7 @@ import (
 var modelCreationLock sync.Mutex //Each component/relationship will perform a check and if the model already doesn't exist, it will create a model. This lock will make sure that there are no race conditions.
 type ModelFilter struct {
 	Name        string
-	Registrant string //name of the registrant of the model
+	Registrant string //name of the registrant for a given model
 	DisplayName string //If Name is already passed, avoid passing Display name unless greedy=true, else the filter will translate to an AND returning only the models where name and display name match exactly. Ignore, if this behavior is expected.
 	Greedy      bool   //when set to true - instead of an exact match, name will be prefix matched. Also an OR will be performed of name and display_name
 	Version     string

--- a/models/meshmodel/core/v1alpha1/models.go
+++ b/models/meshmodel/core/v1alpha1/models.go
@@ -14,6 +14,7 @@ import (
 var modelCreationLock sync.Mutex //Each component/relationship will perform a check and if the model already doesn't exist, it will create a model. This lock will make sure that there are no race conditions.
 type ModelFilter struct {
 	Name        string
+	Registrant string //name of the registrant of the model
 	DisplayName string //If Name is already passed, avoid passing Display name unless greedy=true, else the filter will translate to an AND returning only the models where name and display name match exactly. Ignore, if this behavior is expected.
 	Greedy      bool   //when set to true - instead of an exact match, name will be prefix matched. Also an OR will be performed of name and display_name
 	Version     string


### PR DESCRIPTION
**Description**

This filter would allow GET /models request in Meshery Server to leverage filtering based on registrant.
Would be used in Registry Browser. 

Relates: https://github.com/meshery/meshery/pull/9184

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
