### PR TITLE
[events] Add support for actedUpon as filter

### DIFF
--- a/models/events/events.go
+++ b/models/events/events.go
@@ -92,6 +92,9 @@ type EventsFilter struct {
 	Severity []string    `json:"severity"`
 	// SortOn Field on which records are sorted
 	SortOn string `json:"sort_on"`
+
+	// ActedUpon UUID of the entity on which the event was performed.
+	ActedUpon []uuid.UUID `json:"acted_upon"`
 }
 
 // ID defines model for id.

--- a/models/events/events.go
+++ b/models/events/events.go
@@ -94,7 +94,7 @@ type EventsFilter struct {
 	SortOn string `json:"sort_on"`
 
 	// ActedUpon UUID of the entity on which the event was performed.
-	ActedUpon []uuid.UUID `json:"acted_upon"`
+	ActedUpon []string `json:"acted_upon"`
 }
 
 // ID defines model for id.


### PR DESCRIPTION
**Description**

Currently, events filter doesn't support filtering based on actedUpon ids (entities on which the event was performed).

This would be helpful in adding support of filtering events for specific Workspace. That is, supporting recent activities for workspaces.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
