### PR TITLE
[chore] Revert removal of application_configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
-	oras.land/oras-go v1.2.4 // indirect
+	oras.land/oras-go v1.2.3 // indirect
 	sigs.k8s.io/controller-runtime v0.13.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1408,8 +1408,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-oras.land/oras-go v1.2.4 h1:djpBY2/2Cs1PV87GSJlxv4voajVOMZxqqtq9AB8YNvY=
-oras.land/oras-go v1.2.4/go.mod h1:DYcGfb3YF1nKjcezfX2SNlDAeQFKSXmf+qrFmrh4324=
+oras.land/oras-go v1.2.3 h1:v8PJl+gEAntI1pJ/LCrDgsuk+1PKVavVEPsYIHFE5uY=
+oras.land/oras-go v1.2.3/go.mod h1:M/uaPdYklze0Vf3AakfarnpoEckvw0ESbRdN8Z1vdJg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/models/oam/core/v1alpha1/application_configuration.go
+++ b/models/oam/core/v1alpha1/application_configuration.go
@@ -1,0 +1,47 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Configuration is the structure for OAM Application Configuration
+type Configuration struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ConfigurationSpec `json:"spec,omitempty"`
+}
+
+// ConfigurationSpec is the structure for the OAM Application
+// Configuration Spec
+type ConfigurationSpec struct {
+	Components []ConfigurationSpecComponent
+}
+
+// ConfigurationSpecComponent is the struct for OAM Application
+// Configuration's spec's components
+type ConfigurationSpecComponent struct {
+	ComponentName string
+	Traits        []ConfigurationSpecComponentTrait
+	Scopes        []ConfigurationSpecComponentScope
+}
+
+// ConfigurationSpecComponentTrait is the struct
+type ConfigurationSpecComponentTrait struct {
+	Name       string
+	Properties map[string]interface{}
+}
+
+// ConfigurationSpecComponentScope struct defines the structure
+// for scope of OAM application configuration's spec's component's scope
+type ConfigurationSpecComponentScope struct {
+	ScopeRef ConfigurationSpecComponentScopeRef
+}
+
+// ConfigurationSpecComponentScopeRef struct defines the structure for
+// scope of OAM application configuration's spec's component's scope's
+// scopeRef
+type ConfigurationSpecComponentScopeRef struct {
+	metav1.TypeMeta `json:",inline"`
+	Name            string
+}


### PR DESCRIPTION
**Description**

This [PR](https://github.com/meshery/meshkit/pull/401) removed the Application Configuration which is still currently being used by Provision Stage of Pattern Engine of Meshery. 

Reference: https://github.com/meshery/meshery/blob/master/server/models/pattern/stages/provision.go#L45

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
