### PR TITLE
[bug] Fix default selection for Helm chart

### DIFF
--- a/schemas/configuration/designImport.json
+++ b/schemas/configuration/designImport.json
@@ -41,7 +41,7 @@
               "File Upload",
               "URL Import"
             ],
-            "default": "File Upload",
+            "default": "URL Import",
             "x-rjsf-grid-area": "12",
             "description": "Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online."
           }


### PR DESCRIPTION
**Description**
Currently, If a user directly selects the Helm Chat selection for importing an app, then they face a bug and UI crash.

Issue is the by default the RJSF Schema selects uploadType to "File Upload" which is not updated even when switch the content type. So keeping uploadType to "URL Import" fits precisely into all the cases and doesn't lead to any err


Relates: https://github.com/meshery/meshkit/pull/409

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
