### PR TITLE
chore: add annotations for `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,27 @@
 include build/Makefile.core.mk
 include build/Makefile.show-help.mk
 
+## Run suite of Golang lint checks
 check:
 	golangci-lint run -c .golangci.yml -v ./...
 
+## Run Golang tests
 test:
 	go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
 
+## Clean up Golang packages. Print diff.
 tidy:
 	go mod tidy
 	git diff --exit-code go.mod go.sum
 
+## Run Meshery Error Code Utility. Generate error codes.
 errorutil:
 	go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
 
+## Run Meshery Error Code Utility. Analyze only.
 errorutil-analyze:
 	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze --skip-dirs meshery -i ./helpers -o ./helpers
 
+## Build the Meshery Error Code Utility. 
 build-errorutil:
 	go build -o errorutil cmd/errorutil/main.go


### PR DESCRIPTION
**Description**

This PR fixes missing `make` target annotations.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
