### PR TITLE
Update meshmodel structs to send id in JSON response

### DIFF
--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -41,7 +41,7 @@ type ComponentDefinition struct {
 }
 type ComponentDefinitionDB struct {
 	ID      uuid.UUID `json:"id"`
-	ModelID uuid.UUID `json:"model_id" gorm:"index:idx_component_definition_dbs_model_id,column:modelID"`
+	ModelID uuid.UUID `json:"-" gorm:"index:idx_component_definition_dbs_model_id,column:modelID"`
 	TypeMeta
 	DisplayName string          `json:"displayName" gorm:"displayName"`
 	Format      ComponentFormat `json:"format" yaml:"format"`

--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -26,7 +26,7 @@ const (
 // swagger:response ComponentDefinition
 // use NewComponent function for instantiating
 type ComponentDefinition struct {
-	ID uuid.UUID `json:"-"`
+	ID uuid.UUID `json:"id"`
 	TypeMeta
 	DisplayName     string                 `json:"displayName" gorm:"displayName"`
 	Format          ComponentFormat        `json:"format" yaml:"format"`
@@ -40,8 +40,8 @@ type ComponentDefinition struct {
 	UpdatedAt       time.Time              `json:"-"`
 }
 type ComponentDefinitionDB struct {
-	ID      uuid.UUID `json:"-"`
-	ModelID uuid.UUID `json:"-" gorm:"index:idx_component_definition_dbs_model_id,column:modelID"`
+	ID      uuid.UUID `json:"id"`
+	ModelID uuid.UUID `json:"model_id" gorm:"index:idx_component_definition_dbs_model_id,column:modelID"`
 	TypeMeta
 	DisplayName string          `json:"displayName" gorm:"displayName"`
 	Format      ComponentFormat `json:"format" yaml:"format"`

--- a/models/meshmodel/core/v1alpha1/models.go
+++ b/models/meshmodel/core/v1alpha1/models.go
@@ -40,7 +40,7 @@ func (cf *ModelFilter) Create(m map[string]interface{}) {
 
 // swagger:response Model
 type Model struct {
-	ID              uuid.UUID                  `json:"-" yaml:"-"`
+	ID              uuid.UUID                  `json:"id" yaml:"-"`
 	Name            string                     `json:"name"`
 	Version         string                     `json:"version"`
 	DisplayName     string                     `json:"displayName" gorm:"modelDisplayName"`
@@ -54,7 +54,7 @@ type Model struct {
 }
 
 type ModelDB struct {
-	ID          uuid.UUID `json:"-"`
+	ID          uuid.UUID `json:"id"`
 	CategoryID  uuid.UUID `json:"-" gorm:"categoryID"`
 	Name        string    `json:"modelName" gorm:"modelName"`
 	Version     string    `json:"version"`

--- a/models/meshmodel/core/v1alpha1/relationship.go
+++ b/models/meshmodel/core/v1alpha1/relationship.go
@@ -16,7 +16,7 @@ import (
 // swagger:response RelationshipDefinition
 // TODO: Add support for Model
 type RelationshipDefinition struct {
-	ID uuid.UUID `json:"-"`
+	ID uuid.UUID `json:"id"`
 	TypeMeta
 	Model           Model                  `json:"model"`
 	HostName        string                 `json:"hostname"`
@@ -31,7 +31,7 @@ type RelationshipDefinition struct {
 }
 
 type RelationshipDefinitionDB struct {
-	ID      uuid.UUID `json:"-"`
+	ID      uuid.UUID `json:"id"`
 	ModelID uuid.UUID `json:"-" gorm:"index:idx_relationship_definition_dbs_model_id,column:modelID"`
 	TypeMeta
 	Metadata        []byte    `json:"metadata" yaml:"metadata"`

--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -392,8 +392,8 @@ func (rm *RegistryManager) GetModels(db *database.Handler, f types.Filter) ([]v1
 		if includeComponents {
 			var components []v1alpha1.ComponentDefinitionDB
 			finder := db.Model(&v1alpha1.ComponentDefinitionDB{}).
-				Select("component_definition_dbs.kind, component_definition_dbs.display_name, component_definition_dbs.api_version, component_definition_dbs.metadata").
-				Where("component_definition_dbs.model_id = ?", model.ID)
+				Select("component_definition_dbs.id, component_definition_dbs.kind,component_definition_dbs.display_name, component_definition_dbs.api_version, component_definition_dbs.metadata").
+				Where("component_definition_dbs.model_id = ?", model.ID)				
 			if err := finder.Scan(&components).Error; err != nil {
 				fmt.Println(err)
 			}


### PR DESCRIPTION
**Description**

This PR fixes #

This PR updates struct to support sending 'id' for meshmodel structs by default instead of ignoring `id` in JSON response

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
