### PR TITLE
Make extract URL func public

### DIFF
--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -90,6 +90,10 @@ func (gr GitRepo) extractRepoDetailsFromSourceURL() (owner, repo, branch, root s
 	return
 }
 
+func (gr GitRepo) ExtractRepoDetailsFromSourceURL() (owner, repo, branch, root string, err error) {
+	return gr.extractRepoDetailsFromSourceURL()
+}
+
 func fileInterceptor(br *bufio.Writer) walker.FileInterceptor {
 	return func(file walker.File) error {
 		tempPath := filepath.Join(os.TempDir(), utils.GetRandomAlphabetsOfDigit(5))


### PR DESCRIPTION
**Description**

This PR fixes #

The ExtractRepoDetailsFromSourceURL function is a public method that calls the private method internally. This function can be accessed outside of the package, while the private method cannot.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
