### PR TITLE
Default sorting of component based on their display name

### DIFF
--- a/models/meshmodel/core/v1alpha1/component.go
+++ b/models/meshmodel/core/v1alpha1/component.go
@@ -152,6 +152,8 @@ func GetMeshModelComponents(db *database.Handler, f ComponentFilter) (c []Compon
 		} else {
 			finder = finder.Order(f.OrderOn)
 		}
+	} else {
+		finder = finder.Order("display_name")
 	}
 
 	finder.Count(&count)


### PR DESCRIPTION
**Description**

Implements default alphabetical sorting of components based on their display names.

This PR fixes #490

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<img width="389" alt="Screenshot 2024-04-12 at 13 06 20" src="https://github.com/meshery/meshkit/assets/53005190/f22ced41-92b2-47a7-bcf9-926041233066">

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
