### PR TITLE
Shallow cloning through git clone walker

### DIFF
--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -145,6 +145,7 @@ func clonewalk(g *Git) error {
 	cloneOptions := &git.CloneOptions{
 		URL:          fmt.Sprintf("%s/%s/%s", g.baseURL, g.owner, g.repo),
 		SingleBranch: true,
+		Depth:        1,
 	}
 
 	if g.referenceName != "" {


### PR DESCRIPTION
**Description**

This PR fixes #

Presently git clone walker doesn't do shallow cloning or depth of 1 cloning which clones the unnecessary repo history too, adding `Depth: 1` in cloneOptions will make sure walker does shallow clone which will save much more memory during cloning.

However, [go-git](https://github.com/go-git/go-git) by default doesn't provide a function to identify the size of the repo or a function to add a limit on the specific size, we might need to add our logic in Walker to do that.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
