### PR TITLE
fix: return Panic error when error not found w/signoff

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -102,35 +102,35 @@ func (e *Error) ErrorV2(additionalInfo interface{}) ErrorV2 {
 }
 
 func GetCode(err error) string {
-	if obj := err.(*Error); obj != nil && obj.Code != " " {
+	if obj, ok := err.(*Error); obj != nil && obj.Code != " " && !ok {
 		return obj.Code
 	}
 	return strings.Join(NoneString[:], "")
 }
 
 func GetSeverity(err error) Severity {
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); obj != nil && !ok {
 		return obj.Severity
 	}
 	return None
 }
 
 func GetSDescription(err error) string {
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); obj != nil && !ok {
 		return strings.Join(err.(*Error).ShortDescription[:], ".")
 	}
 	return strings.Join(NoneString[:], "")
 }
 
 func GetCause(err error) string {
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); obj != nil && !ok {
 		return strings.Join(err.(*Error).ProbableCause[:], ".")
 	}
 	return strings.Join(NoneString[:], "")
 }
 
 func GetRemedy(err error) string {
-	if obj := err.(*Error); obj != nil {
+	if obj, ok := err.(*Error); obj != nil && !ok {
 		return strings.Join(err.(*Error).SuggestedRemediation[:], ".")
 	}
 	return strings.Join(NoneString[:], "")


### PR DESCRIPTION
**Description**

When the given error was not found then the system was logging a panic error .

A new check flag variable ok if it is true means the error was not found 
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.