### PR TITLE
Fixing wrongly hardcoded Registrant Artfact-Hub

### DIFF
--- a/models/meshmodel/core/v1beta1/host.go
+++ b/models/meshmodel/core/v1beta1/host.go
@@ -140,7 +140,7 @@ func (ah ArtifactHub) HandleDependents(comp Component, kc *kubernetes.Client, is
 }
 
 func (ah ArtifactHub) String() string {
-	return "artifacthub"
+	return "Artifact Hub"
 }
 
 type Kubernetes struct{}


### PR DESCRIPTION
**Description**
Identified an issue in the Host struct where the String method within the ArtifactHub type was returning a hardcoded string “artifacthub” in all lowercase. This caused inconsistencies and formatting problems in the output where the string representation of ArtifactHub was used.
This PR fixes #[10437](https://github.com/meshery/meshery/issues/10437)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
