### PR TITLE
[Helm] Update DryRun to include Kubernetes version.

### DIFF
--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -3,14 +3,15 @@ package github
 import (
 	"bufio"
 	"fmt"
-	"github.com/layer5io/meshkit/generators/models"
-	"github.com/layer5io/meshkit/utils"
-	"github.com/layer5io/meshkit/utils/helm"
-	"github.com/layer5io/meshkit/utils/walker"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/layer5io/meshkit/generators/models"
+	"github.com/layer5io/meshkit/utils"
+	"github.com/layer5io/meshkit/utils/helm"
+	"github.com/layer5io/meshkit/utils/walker"
 )
 
 type GitRepo struct {

--- a/utils/helm/helm.go
+++ b/utils/helm/helm.go
@@ -16,12 +16,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
-var KubeVersion = &chartutil.KubeVersion{
-	Version: "v1.25.2",
-	Major:   "1",
-	Minor:   "25",
-}
-
 func extractSemVer(versionConstraint string) string {
 	reg := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$`)
 	match := reg.Find([]byte(versionConstraint))

--- a/utils/helm/helm.go
+++ b/utils/helm/helm.go
@@ -12,7 +12,14 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 )
+
+var KubeVersion = &chartutil.KubeVersion{
+	Version: "v1.25.2",
+	Major:   "1",
+	Minor:   "25",
+}
 
 // DryRun a given helm chart to convert into k8s manifest
 func DryRunHelmChart(chart *chart.Chart) ([]byte, error) {
@@ -23,6 +30,7 @@ func DryRunHelmChart(chart *chart.Chart) ([]byte, error) {
 	act.DryRun = true
 	act.IncludeCRDs = true
 	act.ClientOnly = true
+	act.KubeVersion = KubeVersion
 	rel, err := act.Run(chart, nil)
 	if err != nil {
 		return nil, ErrDryRunHelmChart(err, chart.Name())
@@ -46,7 +54,7 @@ func ConvertToK8sManifest(path string, w io.Writer) error {
 		helmChartPath, _ = strings.CutSuffix(path, filepath.Base(path))
 	}
 	if IsHelmChart(helmChartPath) {
-		err := LoadHelmChart(helmChartPath, w, true)
+		err := LoadHelmChart(helmChartPath, w, false)
 		if err != nil {
 			return err
 		}

--- a/utils/helm/helm.go
+++ b/utils/helm/helm.go
@@ -65,7 +65,7 @@ func ConvertToK8sManifest(path string, w io.Writer) error {
 		helmChartPath, _ = strings.CutSuffix(path, filepath.Base(path))
 	}
 	if IsHelmChart(helmChartPath) {
-		err := LoadHelmChart(helmChartPath, w, false)
+		err := LoadHelmChart(helmChartPath, w, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description**

This PR fixes #
1. When performing the dry run using the helm client, `kubernetes` version was not specified leading to `v1.20.0` being used for rendering the templates and converting them to manifests. (static analysis).
This caused an issue when trying to import charts that depend on some specific (or required) Kubernetes version. For eg: In the case of `KEDA` helm chart is `v1.23.0`.

2. The location of `crds` that are bundled inside the charts is usually at top level `crds` folder. (This is also the location expected by the helm client). In cases where the CRDs are included inside some other location or inside `templates` folder, at the time of model generation no CRDs were detected doesn't matter whether the registrant is ArtifactHub/GitHub as we use the helm client `CRDObjects` function.
The logic has been updated to dry run the chart and then extract CRDs.

**Notes for Reviewers**.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
