### PR TITLE
Error handling for EmptyChartUrl and PakcageNotFound w/signoff

### DIFF
--- a/generators/artifacthub/error.go
+++ b/generators/artifacthub/error.go
@@ -1,6 +1,8 @@
 package artifacthub
 
 import (
+	"fmt"
+
 	"github.com/layer5io/meshkit/errors"
 )
 
@@ -9,6 +11,8 @@ var (
 	ErrGetAhPackageCode       = "meshkit-11135"
 	ErrComponentGenerateCode  = "meshkit-11136"
 	ErrGetAllHelmPackagesCode = "meshkit-11137"
+	ErrChartUrlEmptyCode      = "replace_me"
+	ErrNoPackageFoundCode     = "replace_me"
 )
 
 func ErrGetAllHelmPackages(err error) error {
@@ -25,4 +29,24 @@ func ErrGetAhPackage(err error) error {
 
 func ErrComponentGenerate(err error) error {
 	return errors.New(ErrComponentGenerateCode, errors.Alert, []string{"failed to generate components for the package"}, []string{err.Error()}, []string{}, []string{"Make sure that the package is compatible"})
+}
+func ErrChartUrlEmpty(modelName string) error {
+	return errors.New(
+		ErrChartUrlEmptyCode,
+		errors.Alert,
+		[]string{fmt.Sprintf("The Chart URL for the %s model is empty.", modelName)},
+		[]string{fmt.Sprintf("provided Chart URL for the model %s is empty.", modelName)},
+		[]string{fmt.Sprintf("Artifacthub does not have Chart URL for %s", modelName)},
+		[]string{fmt.Sprintf("Please provide the Chart URL for the model %s.", modelName)},
+	)
+}
+func ErrNoPackageFound(modelName string) error {
+	return errors.New(
+		ErrNoPackageFoundCode,
+		errors.Alert,
+		[]string{fmt.Sprintf("No package found for the model %s.", modelName)},
+		[]string{fmt.Sprintf("their was no package for %s model.", modelName)},
+		[]string{fmt.Sprintf("Artifacthub does not have any package for model name %s", modelName)},
+		[]string{fmt.Sprintf("Please provide the correct package name for the model %s.", modelName)},
+	)
 }

--- a/generators/artifacthub/package.go
+++ b/generators/artifacthub/package.go
@@ -39,6 +39,10 @@ func (pkg AhPackage) GetVersion() string {
 func (pkg AhPackage) GenerateComponents() ([]v1beta1.ComponentDefinition, error) {
 	components := make([]v1beta1.ComponentDefinition, 0)
 	// TODO: Move this to the configuration
+
+	if pkg.ChartUrl == "" {
+		return components, ErrChartUrlEmpty(pkg.Name)
+	}
 	crds, err := manifests.GetCrdsFromHelm(pkg.ChartUrl)
 	if err != nil {
 		return components, ErrComponentGenerate(err)

--- a/generators/artifacthub/package_manager.go
+++ b/generators/artifacthub/package_manager.go
@@ -17,6 +17,9 @@ func (ahpm ArtifactHubPackageManager) GetPackage() (models.Package, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(pkgs) == 0 {
+		return nil, ErrNoPackageFound(ahpm.PackageName)
+	}
 	// update package information
 	for i, ap := range pkgs {
 		_ = ap.UpdatePackageData()


### PR DESCRIPTION
**Description**

This PR fixes issue with the error logs in `Errors.txt` file generated by `Model Component Generator`

``` cannot load irregular file /tmp/clr-debug-pipe-1684-29526-in as it has file mode type bits set```=>ErrChartUrlEmpty


``` could not find any appropriate artifacthub package```=>ErrNoPackageFound
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
