### PR TITLE
feat: Add Debugf function to logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,7 @@ type Handler interface {
 	Info(description ...interface{})
 	Infof(format string, args ...interface{})
 	Debug(description ...interface{})
+	Debugf(format string, args ...interface{})
 	Warn(err error)
 	Warnf(format string, args ...interface{})
 	Error(err error)
@@ -127,4 +128,8 @@ func (l *Logger) Infof(format string, args ...interface{}) {
 
 func (l *Logger) Warnf(format string, args ...interface{}) {
 	l.handler.Log(logrus.WarnLevel, fmt.Sprintf(format, args...))
+}
+
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.handler.Log(logrus.DebugLevel, fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
**Description**

This PR fixes #524 

**Notes for Reviewers**
Now, we can use it like this:

`logger.Debugf("This is a test: %s", "Debugf")`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
