### PR TITLE
[Feat] Add Support For Writing Out Models as Yaml Files

### DIFF
--- a/models/meshmodel/core/v1beta1/models.go
+++ b/models/meshmodel/core/v1beta1/models.go
@@ -120,14 +120,22 @@ func (m *Model) UpdateStatus(db *database.Handler, status entity.EntityStatus) e
 	return nil
 }
 
-func (c Model) WriteModelDefinition(modelDefPath string) error {
+// WriteModelDefinition writes out the model to the given `modelDefPath` in the `outputType` format.
+// `outputType` can be `yaml` or `json`.
+func (c Model) WriteModelDefinition(modelDefPath string, outputType string) error {
 	err := utils.CreateDirectory(modelDefPath)
 	if err != nil {
 		return err
 	}
-
-	modelFilePath := filepath.Join(modelDefPath, "model.json")
+    var modelFilePath string
+    if(outputType == "json"){
+    modelFilePath = filepath.Join(modelDefPath)
 	err = utils.WriteJSONToFile[Model](modelFilePath, c)
+    }
+    if(outputType == "yaml"){
+    modelFilePath = filepath.Join(modelDefPath)
+	err = utils.WriteYamlToFile[Model](modelFilePath, c)
+    }
 	if err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 // transforms the keys of a Map recursively with the given transform function
@@ -343,6 +344,25 @@ func MergeMaps(mergeInto, toMerge map[string]interface{}) map[string]interface{}
 		mergeInto[k] = v
 	}
 	return mergeInto
+}
+
+func WriteYamlToFile[K any](outputPath string, data K) error {
+	byt, err := yaml.Marshal(data)
+	if err != nil {
+        // Use a different error code
+		return ErrMarshal(err)
+	}
+
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return ErrCreateFile(err, outputPath)
+	}
+
+	_, err = file.Write(byt)
+	if err != nil {
+		return ErrWriteFile(err, outputPath)
+	}
+	return nil
 }
 
 func WriteJSONToFile[K any](outputPath string, data K) error {


### PR DESCRIPTION
**Description**

This PR fixes updates the `WriteModelDefinition` function to be able to write out as Yaml as well rather than just Json. 

**Notes for Reviewers**

This function is being used only in Meshery server and its usage will be updated in a follow up PR. 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
