### PR TITLE
Remove Redundant Function - `registerModels`

### DIFF
--- a/models/meshmodel/core/v1beta1/models.go
+++ b/models/meshmodel/core/v1beta1/models.go
@@ -102,11 +102,6 @@ func (m *Model) Create(db *database.Handler, hostID uuid.UUID) (uuid.UUID, error
 		if err != nil {
 			return uuid.UUID{}, err
 		}
-		// register model inside registries table
-		err = registerModel(db, hostID, modelID)
-		if err != nil {
-			return uuid.UUID{}, err
-		}
 		return m.ID, nil
 	}
 	return model.ID, nil
@@ -140,20 +135,3 @@ func (c Model) WriteModelDefinition(modelDefPath string, outputType string) erro
 	return nil
 }
 
-// Registers models into registries table.
-func registerModel(db *database.Handler, regID, modelID uuid.UUID) error {
-	var count int64
-	err := db.Table("registries").Where("registrant_id = ?", regID).Where("type = ?", "model").Where("entity = ?", modelID).Count(&count).Error
-
-	if err != nil && err != gorm.ErrRecordNotFound {
-		return err
-	}
-
-	if count == 0 {
-		err = db.Exec("INSERT INTO registries (registrant_id, entity, type) VALUES (?,?,?)", regID, modelID, "model").Error
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
**Description**

This PR removes the `registerModel` function. Entities are registered to the register here -https://github.com/meshery/meshkit/blob/master/models/meshmodel/registry/registry.go#L95. This causes redundancy. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
