### PR TITLE
[CI] Pull Changes Before auto-commit Action 

### DIFF
--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -27,6 +27,9 @@ jobs:
         run: |
           go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
 
+      - name: Pull changes from remote
+        run: git pull origin master
+
       # to update errorutil* files in meshkit repo
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes pulls the changes from the repository before running the [`auto-commit`](https://github.com/stefanzweifel/git-auto-commit-action) action. This is to make sure that there are no new changes introduced in the time between when the code was checked out and when the workflow is trying to commit the changes. 

This PR ensures that the code is being pulled before running the `auto-commit` action in all of Meshkit's workflows. 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
