### PR TITLE
Query Only the Models with `enabled` Status 

### DIFF
--- a/models/meshmodel/registry/v1alpha2/relationship_filter.go
+++ b/models/meshmodel/registry/v1alpha2/relationship_filter.go
@@ -48,6 +48,10 @@ func (relationshipFilter *RelationshipFilter) Get(db *database.Handler) ([]entit
 	finder := db.Model(&v1alpha2.RelationshipDefinition{}).Preload("Model").Preload("Model.Category").
 		Joins("JOIN model_dbs ON relationship_definition_dbs.model_id = model_dbs.id").
 		Joins("JOIN category_dbs ON model_dbs.category_id = category_dbs.id")
+
+    // TODO(@MUzairS15): Refactor this once Status is made a first class field in RelationshipFilter
+    finder = finder.Where("model_dbs.status = enabled")
+
 	if relationshipFilter.Kind != "" {
 		if relationshipFilter.Greedy {
 			finder = finder.Where("relationship_definition_dbs.kind LIKE ?", "%"+relationshipFilter.Kind+"%")

--- a/models/meshmodel/registry/v1beta1/component_filter.go
+++ b/models/meshmodel/registry/v1beta1/component_filter.go
@@ -69,6 +69,9 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 		Joins("JOIN hosts ON hosts.id = model_dbs.host_id")
 		//
 
+    // TODO(@MUzairS15): Refactor this once Status is made a first class field in ComponentFilter
+    finder = finder.Where("model_dbs.status = enabled")
+
 	if componentFilter.Greedy {
 		if componentFilter.Name != "" && componentFilter.DisplayName != "" {
 			finder = finder.Where("component_definition_dbs.component->>'kind' LIKE ? OR display_name LIKE ?", "%"+componentFilter.Name+"%", componentFilter.DisplayName+"%")

--- a/models/meshmodel/registry/v1beta1/component_filter.go
+++ b/models/meshmodel/registry/v1beta1/component_filter.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ComponentFilter struct {
-    Id           string
+	Id           string
 	Name         string
 	APIVersion   string
 	Greedy       bool //when set to true - instead of an exact match, name will be matched as a substring
@@ -23,6 +23,7 @@ type ComponentFilter struct {
 	Limit        int //If 0 or  unspecified then all records are returned and limit is not used
 	Offset       int
 	Annotations  string //When this query parameter is "true", only components with the "isAnnotation" property set to true are returned. When this query parameter is "false", all components except those considered to be annotation components are returned. Any other value of the query parameter results in both annotations as well as non-annotation models being returned.
+	Status       string
 }
 
 type componentDefinitionWithModel struct {
@@ -33,12 +34,12 @@ type componentDefinitionWithModel struct {
 }
 
 func (cf *ComponentFilter) GetById(db *database.Handler) (entity.Entity, error) {
-    c := &v1beta1.ComponentDefinition{}
-    err := db.First(c, "id = ?", cf.Id).Error
+	c := &v1beta1.ComponentDefinition{}
+	err := db.First(c, "id = ?", cf.Id).Error
 	if err != nil {
 		return nil, registry.ErrGetById(err, cf.Id)
 	}
-    return  c, err
+	return c, err
 }
 
 // Create the filter from map[string]interface{}
@@ -69,8 +70,14 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 		Joins("JOIN hosts ON hosts.id = model_dbs.host_id")
 		//
 
-    // TODO(@MUzairS15): Refactor this once Status is made a first class field in ComponentFilter
-    finder = finder.Where("model_dbs.status = enabled")
+	// TODO(@MUzairS15): Refactor this once Status is made a first class field in ComponentFilter
+	status := "enabled"
+	
+	if componentFilter.Status != ""  {
+		status = componentFilter.Status
+	}
+
+	finder = finder.Where("model_dbs.status = ?", status)
 
 	if componentFilter.Greedy {
 		if componentFilter.Name != "" && componentFilter.DisplayName != "" {

--- a/models/meshmodel/registry/v1beta1/model_filter.go
+++ b/models/meshmodel/registry/v1beta1/model_filter.go
@@ -127,6 +127,15 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 	if mf.Offset != 0 {
 		finder = finder.Offset(mf.Offset)
 	}
+
+	status := "enabled"
+	
+	if mf.Status != ""  {
+		status = mf.Status
+	}
+
+	finder = finder.Where("model_dbs.status = ?", status)
+
 	if mf.Status != "" {
 		finder = finder.Where("model_dbs.status = ?", mf.Status)
 	}


### PR DESCRIPTION
**Description**

This PR updates the Component and Relationship getter functions to query for the models with `enabled` status alone. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
