### PR TITLE
peform helm dry run based on the k8s model available in the registry

### DIFF
--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -105,7 +105,7 @@ func fileInterceptor(br *bufio.Writer) walker.FileInterceptor {
 // Add more calrifying commment and entry inside docs.
 func dirInterceptor(br *bufio.Writer) walker.DirInterceptor {
 	return func(d walker.Directory) error {
-		err := helm.ConvertToK8sManifest(d.Path, br)
+		err := helm.ConvertToK8sManifest(d.Path, "", br)
 		if err != nil {
 			return err
 		}

--- a/generators/github/url.go
+++ b/generators/github/url.go
@@ -77,7 +77,7 @@ func ProcessContent(w io.Writer, downloadDirPath, downloadfilePath string) error
 	}
 
 	err = utils.ProcessContent(downloadDirPath, func(path string) error {
-		err = helm.ConvertToK8sManifest(path, w)
+		err = helm.ConvertToK8sManifest(path, "", w)
 		if err != nil {
 			return err
 		}

--- a/utils/helm/helm.go
+++ b/utils/helm/helm.go
@@ -26,7 +26,7 @@ func extractSemVer(versionConstraint string) string {
 }
 
 // DryRun a given helm chart to convert into k8s manifest
-func DryRunHelmChart(chart *chart.Chart) ([]byte, error) {
+func DryRunHelmChart(chart *chart.Chart, kubernetesVersion string) ([]byte, error) {
 	actconfig := new(action.Configuration)
 	act := action.NewInstall(actconfig)
 	act.ReleaseName = chart.Metadata.Name
@@ -34,14 +34,22 @@ func DryRunHelmChart(chart *chart.Chart) ([]byte, error) {
 	act.DryRun = true
 	act.IncludeCRDs = true
 	act.ClientOnly = true
+
+	kubeVersion := kubernetesVersion
 	if chart.Metadata.KubeVersion != "" {
-		version := extractSemVer(chart.Metadata.KubeVersion)
-		if version != "" {
-			act.KubeVersion = &chartutil.KubeVersion{
-				Version: version,
-			}
+		extractedVersion := extractSemVer(chart.Metadata.KubeVersion)
+
+		if extractedVersion != "" {
+			kubeVersion = extractedVersion
 		}
 	}
+
+	if kubeVersion != "" {
+		act.KubeVersion = &chartutil.KubeVersion{
+			Version: kubeVersion,
+		}
+	}
+
 	rel, err := act.Run(chart, nil)
 	if err != nil {
 		return nil, ErrDryRunHelmChart(err, chart.Name())
@@ -55,7 +63,7 @@ func DryRunHelmChart(chart *chart.Chart) ([]byte, error) {
 }
 
 // Takes in the directory and converts HelmCharts/multiple manifests into a single K8s manifest
-func ConvertToK8sManifest(path string, w io.Writer) error {
+func ConvertToK8sManifest(path, kubeVersion string, w io.Writer) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return utils.ErrReadDir(err, path)
@@ -65,7 +73,7 @@ func ConvertToK8sManifest(path string, w io.Writer) error {
 		helmChartPath, _ = strings.CutSuffix(path, filepath.Base(path))
 	}
 	if IsHelmChart(helmChartPath) {
-		err := LoadHelmChart(helmChartPath, w, true)
+		err := LoadHelmChart(helmChartPath, w, true, kubeVersion)
 		if err != nil {
 			return err
 		}
@@ -124,7 +132,7 @@ func IsHelmChart(dirPath string) bool {
 	return true
 }
 
-func LoadHelmChart(path string, w io.Writer, extractOnlyCrds bool) error {
+func LoadHelmChart(path string, w io.Writer, extractOnlyCrds bool, kubeVersion string) error {
 	var errs []error
 	chart, err := loader.Load(path)
 	if err != nil {
@@ -145,7 +153,7 @@ func LoadHelmChart(path string, w io.Writer, extractOnlyCrds bool) error {
 			_, _ = w.Write([]byte("\n---\n"))
 		}
 	} else {
-		manifests, err := DryRunHelmChart(chart)
+		manifests, err := DryRunHelmChart(chart, kubeVersion)
 		if err != nil {
 			return ErrLoadHelmChart(err, path)
 		}

--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -122,6 +122,9 @@ type ApplyHelmChartConfig struct {
 	// SkipCRDs while installation
 	SkipCRDs bool
 
+	// Kubernetes version against which the DryRun is performed
+	KubernetesVersion string
+
 	// Upgrade the release if already installed
 	UpgradeIfInstalled bool
 
@@ -451,6 +454,7 @@ func generateAction(actionConfig *action.Configuration, cfg ApplyHelmChartConfig
 	case UNINSTALL:
 		return func(c *chart.Chart) error {
 			act := action.NewUninstall(actionConfig)
+			
 			act.DryRun = cfg.DryRun
 			if _, err := act.Run(cfg.ReleaseName); err != nil {
 				return ErrApplyHelmChart(err)

--- a/utils/kubernetes/helm.go
+++ b/utils/kubernetes/helm.go
@@ -23,5 +23,5 @@ func ConvertHelmChartToK8sManifest(cfg ApplyHelmChartConfig) (manifest []byte, e
 		return nil, ErrApplyHelmChart(err)
 	}
 
-	return helm.DryRunHelmChart(helmChart)
+	return helm.DryRunHelmChart(helmChart, cfg.KubernetesVersion)
 }


### PR DESCRIPTION
**Description**

This PR fixes #
During the import of helm charts, they are converted into k8s manifests by performing a dry run (w.o involving Kubernetes API server).  The charts might have certain constraints for the Kubernetes version; accordingly, templates are converted. 

For charts which do not specify the `kubeversion`, instead of hardcoding to `v1.29.2` (playground k8s cluster version), it will be better to perform the dry run based on the highest version of the Kubernetes model available in the registry. 

This ensures if the helm chart is imported successfully, the meshery server can also perform lifecycle operations. Hardcoding to a specific version may result in Helm Chart import being successful but because the meshery server doesn't have the required K8s components it might lead to failures when performing lifecycle operations.



 
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
