### PR TITLE
Fix #575: Replaced deprecated utils.Unmarshal and removed unused variables

### DIFF
--- a/config/provider/inmem.go
+++ b/config/provider/inmem.go
@@ -16,7 +16,7 @@ package provider
 
 import (
 	"sync"
-
+	"encoding/json"
 	"github.com/layer5io/meshkit/config"
 	"github.com/layer5io/meshkit/utils"
 )
@@ -54,7 +54,8 @@ func (l *InMem) GetKey(key string) string {
 func (l *InMem) GetObject(key string, result interface{}) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	return utils.Unmarshal(l.store[key], result)
+	//return utils.Unmarshal(l.store[key], result)
+	return json.Unmarshal([]byte(l.store[key]), result)
 }
 
 // SetObject sets an object value for the key

--- a/utils/kubernetes/crd.go
+++ b/utils/kubernetes/crd.go
@@ -2,8 +2,8 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 
-	"github.com/layer5io/meshkit/utils"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
@@ -35,7 +35,8 @@ func GetAllCustomResourcesInCluster(ctx context.Context, client rest.Interface) 
 	}
 	var xcrd CRD
 	gvks := []*schema.GroupVersionResource{}
-	err = utils.Unmarshal(string(crdresult), &xcrd)
+	//err = utils.Unmarshal(string(crdresult), &xcrd)
+	err = json.Unmarshal(crdresult, &xcrd)
 	if err != nil {
 		return nil, err
 	}

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -14,7 +14,6 @@ import (
 
 var (
 	ErrValidateCode = ""
-	schemaPath      = "components.schemas"
 	cueschema       cue.Value
 	mx              sync.Mutex
 	isSchemaLoaded  bool


### PR DESCRIPTION
**Description**

This PR fixes #575 by replacing deprecated `utils.Unmarshal` with `json.Unmarshal` and removing unused variables from the codebase.

**Notes for Reviewers**

- The changes involve updates to two specific files: `config/provider/inmem.go` and `utils/kubernetes/crd.go`.
- Please verify that the replacement of `utils.Unmarshal` does not impact any other parts of the code that may rely on its specific behavior.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.