### PR TITLE
Fix `unknown kind github` error during deployment

### DIFF
--- a/models/meshmodel/core/v1beta1/host.go
+++ b/models/meshmodel/core/v1beta1/host.go
@@ -50,6 +50,8 @@ func NewDependencyHandler(connectionKind string) (DependencyHandler, error) {
 		return Kubernetes{}, nil
 	case "artifacthub":
 		return ArtifactHub{}, nil
+	case "github":
+		return GitHub{}, nil
 	}
 	return nil, ErrUnknownKind(fmt.Errorf("unknown kind %s", connectionKind))
 }
@@ -114,4 +116,14 @@ func (k Kubernetes) HandleDependents(_ component.ComponentDefinition, _ *kuberne
 
 func (k Kubernetes) String() string {
 	return "kubernetes"
+}
+
+type GitHub struct{}
+
+func(gh GitHub) HandleDependents(_ component.ComponentDefinition, _ *kubernetes.Client, _, _ bool) (summary string, err error) {
+	return summary, err
+}
+
+func(gh GitHub) String() string {
+	return "github"
 }


### PR DESCRIPTION
**Description**
The error originated from the `NewDependencyHandler` function. This function is designed to automate the deployment of dependencies, specifically CRDs and controllers, for components so users don’t have to perform these steps manually. 

Before the function only supported components with `kind: artifacthub`, which led to failures when handling components with `kind: github`.

It appears that the kind for Kubernetes components,  was recently updated to github, causing the function to break.

**Notes for Reviewers**
The function logic for `kind:github` still needs to be implemented. This is just a quick fix.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! `

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
