### PR TITLE
Fix: Url field issue in Import Design Modal

### DIFF
--- a/schemas/configuration/designImport.json
+++ b/schemas/configuration/designImport.json
@@ -11,11 +11,12 @@
     "designType": {
       "title": "Design type",
       "enum": [
+        "Docker Compose",
         "Helm Chart",
         "Kubernetes Manifest",
-        "Docker Compose",
         "Meshery Design"
       ],
+      "default": "Docker Compose",
       "x-rjsf-grid-area": "6",
       "description": "Select the type of design you are uploading. The 'Design Type' determines the format, structure, and content of the file you are uploading. Choose the appropriate design type that matches the nature of your file. Checkout https://docs.meshery.io/guides/meshery-design to learn more about designs"
     }


### PR DESCRIPTION
**Description**

This PR addresses the issue where the "Url" field is displayed in the Import Design Modal when the file upload option is selected. The bug was causing unnecessary UI clutter and confusion for users who intended to upload a file rather than providing a URL.

### Changeous made:
- Making default design type Docker compose.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
