### PR TITLE
add: kubernetes status error parser with appropriate message

### DIFF
--- a/utils/kubernetes/error.go
+++ b/utils/kubernetes/error.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/layer5io/meshkit/errors"
+	"github.com/layer5io/meshkit/utils"
+	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -39,47 +41,175 @@ var (
 )
 
 func ErrApplyManifest(err error) error {
-	return errors.New(ErrApplyManifestCode, errors.Alert, []string{"Error Applying manifest"}, []string{err.Error()}, []string{"Manifest could be invalid"}, []string{"Make sure manifest yaml is valid"})
+	short := []string{"Error Applying manifest"}
+	long := []string{err.Error()}
+	probable := []string{"Manifest could be invalid"}
+	remedy := []string{"Make sure manifest yaml is valid"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrApplyManifestCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrServiceDiscovery returns an error of type "ErrServiceDiscovery" along with the passed error
+// ErrServiceDiscovery handles service discovery errors, including Kubernetes status errors
 func ErrServiceDiscovery(err error) error {
-	return errors.New(ErrServiceDiscoveryCode, errors.Alert, []string{"Error Discovering service"}, []string{err.Error()}, []string{"Network not reachable to the service"}, []string{"Make sure the endpoint is reachable"})
+	// Define default error messages
+	short := []string{"Error discovering service"}
+	long := []string{err.Error()}
+	probable := []string{"Network not reachable to the service"}
+	remedy := []string{"Make sure the endpoint is reachable"}
+
+	// If this is a Kubernetes status error, get more specific error details
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrServiceDiscoveryCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrApplyHelmChart is the error which occurs in the process of applying helm chart
+// ErrApplyHelmChart handles helm chart application errors, including Kubernetes status errors
 func ErrApplyHelmChart(err error) error {
-	return errors.New(ErrApplyHelmChartCode, errors.Alert, []string{"Error applying helm chart"}, []string{err.Error()}, []string{"Chart could be invalid"}, []string{"Make sure to apply valid chart"})
+	short := []string{"Error applying helm chart"}
+	long := []string{err.Error()}
+	probable := []string{"Chart could be invalid"}
+	remedy := []string{"Make sure to apply valid chart"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrApplyHelmChartCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrNewKubeClient is the error which occurs when creating a new Kubernetes clientset
+// ErrNewKubeClient handles Kubernetes client creation errors
 func ErrNewKubeClient(err error) error {
-	return errors.New(ErrNewKubeClientCode, errors.Alert, []string{"Error creating kubernetes clientset"}, []string{err.Error()}, []string{"Kubernetes config is not accessible to meshery or not valid"}, []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"})
+	short := []string{"Error creating kubernetes clientset"}
+	long := []string{err.Error()}
+	probable := []string{"Kubernetes config is not accessible to meshery or not valid"}
+	remedy := []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrNewKubeClientCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrNewDynClient is the error which occurs when creating a new dynamic client
+// ErrNewDynClient handles dynamic client creation errors
 func ErrNewDynClient(err error) error {
-	return errors.New(ErrNewDynClientCode, errors.Alert, []string{"Error creating dynamic client"}, []string{err.Error()}, []string{"Kubernetes config is not accessible to meshery or not valid"}, []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"})
+	short := []string{"Error creating dynamic client"}
+	long := []string{err.Error()}
+	probable := []string{"Kubernetes config is not accessible to meshery or not valid"}
+	remedy := []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrNewDynClientCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrNewDiscovery is the error which occurs when creating a new discovery client
+// ErrNewDiscovery handles discovery client creation errors
 func ErrNewDiscovery(err error) error {
-	return errors.New(ErrNewDiscoveryCode, errors.Alert, []string{"Error creating discovery client"}, []string{err.Error()}, []string{"Discovery resource is invalid or doesnt exist"}, []string{"Makes sure the you input valid resource for discovery"})
+	short := []string{"Error creating discovery client"}
+	long := []string{err.Error()}
+	probable := []string{"Discovery resource is invalid or doesnt exist"}
+	remedy := []string{"Makes sure the you input valid resource for discovery"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrNewDiscoveryCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrNewInformer is the error which occurs when creating a new informer
+// ErrNewInformer handles informer creation errors
 func ErrNewInformer(err error) error {
-	return errors.New(ErrNewInformerCode, errors.Alert, []string{"Error creating informer client"}, []string{err.Error()}, []string{"Informer is invalid or doesnt exist"}, []string{"Makes sure the you input valid resource for the informer"})
+	short := []string{"Error creating informer client"}
+	long := []string{err.Error()}
+	probable := []string{"Informer is invalid or doesnt exist"}
+	remedy := []string{"Makes sure the you input valid resource for the informer"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrNewInformerCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrLoadConfig is the error which occurs in the process of loading a kubernetes config
+// ErrLoadConfig handles config loading errors
 func ErrLoadConfig(err error) error {
-	return errors.New(ErrLoadConfigCode, errors.Alert, []string{"Error loading kubernetes config"}, []string{err.Error()}, []string{"Kubernetes config is not accessible to meshery or not valid"}, []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"})
+	short := []string{"Error loading kubernetes config"}
+	long := []string{err.Error()}
+	probable := []string{"Kubernetes config is not accessible to meshery or not valid"}
+	remedy := []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrLoadConfigCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
-// ErrValidateConfig is the error which occurs in the process of validating a kubernetes config
+// ErrValidateConfig handles config validation errors
 func ErrValidateConfig(err error) error {
-	return errors.New(ErrValidateConfigCode, errors.Alert, []string{"Validation failed in the kubernetes config"}, []string{err.Error()}, []string{"Kubernetes config is not accessible to meshery or not valid"}, []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"})
+	short := []string{"Validation failed in the kubernetes config"}
+	long := []string{err.Error()}
+	probable := []string{"Kubernetes config is not accessible to meshery or not valid"}
+	remedy := []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"}
+
+	if utils.IsErrKubeStatusErr(err) {
+		statusErr := err.(*kubeerror.StatusError)
+		short, long, probable, remedy = utils.ParseKubeStatusErr(statusErr)
+	}
+
+	return errors.New(ErrValidateConfigCode, errors.Alert,
+		short,
+		long,
+		probable,
+		remedy)
 }
 
 // ErrCreatingHelmIndex is the error for creating helm index

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -25,6 +25,9 @@ import (
 	"github.com/layer5io/meshkit/models/meshmodel/entity"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	kubeerror "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // transforms the keys of a Map recursively with the given transform function
@@ -715,4 +718,157 @@ func IsDirectoryNonEmpty(dirPath string) bool {
 	}
 
 	return len(entries) > 0
+}
+
+// checks if the error is of type kubeerror.StatusError
+func IsErrKubeStatusErr(err error) bool {
+	switch err.(type) {
+	case *kubeerror.StatusError:
+		return true
+	default:
+		return false
+	}
+}
+
+// handleStatusReason processes the high-level reason for the error and generates appropriate messaging
+func handleStatusReason(reason v1.StatusReason) (probableCause, remedy string) {
+	switch reason {
+	case v1.StatusReasonUnauthorized:
+		return "User authentication failed or authentication credentials were not provided",
+			"Ensure you have provided valid authentication credentials and they have not expired"
+
+	case v1.StatusReasonForbidden:
+		return "The server understood the request but refuses to authorize it",
+			"Verify you have the necessary permissions to perform this operation"
+
+	case v1.StatusReasonNotFound:
+		return "The requested resource does not exist on the server",
+			"Check if the resource name and namespace are correct, and the resource exists"
+
+	case v1.StatusReasonAlreadyExists:
+		return "The resource you are trying to create already exists",
+			"Either use a different name for your resource or update the existing resource instead"
+
+	case v1.StatusReasonConflict:
+		return "The requested operation conflicts with an existing resource or operation",
+			"Retrieve the latest state of the resource and retry your operation"
+
+	case v1.StatusReasonGone:
+		return "The requested resource is no longer available",
+			"The resource has been deleted or moved. Update your configuration to reference existing resources"
+
+	case v1.StatusReasonInvalid:
+		return "The provided resource specification is invalid",
+			"Review the resource specification and correct any validation errors"
+
+	case v1.StatusReasonServerTimeout:
+		return "The server timed out while processing the request",
+			"The server is temporarily unable to handle the request. Try again later"
+
+	case v1.StatusReasonTimeout:
+		return "The operation could not be completed within the specified time",
+			"Consider increasing timeout values or retry the operation"
+
+	case v1.StatusReasonTooManyRequests:
+		return "Too many requests are being sent to the server",
+			"Reduce the rate of requests or wait before retrying"
+
+	case v1.StatusReasonBadRequest:
+		return "The request was invalid or cannot be served",
+			"Review and correct the format of your request"
+
+	case v1.StatusReasonMethodNotAllowed:
+		return "The requested operation is not supported",
+			"Verify that the operation is valid for this type of resource"
+
+	case v1.StatusReasonInternalError:
+		return "An internal error occurred while processing the request",
+			"This is a server-side issue. Contact your cluster administrator if the problem persists"
+
+	case v1.StatusReasonExpired:
+		return "The requested resource has expired",
+			"The resource needs to be recreated or refreshed"
+
+	case v1.StatusReasonServiceUnavailable:
+		return "The service is currently unavailable",
+			"The server is temporarily unable to handle requests. Try again later"
+
+	default:
+		return "An unexpected error occurred while processing the request",
+			"Review the error details and ensure your request is valid"
+	}
+}
+
+// handleStatusCause processes specific validation errors and field-level issues
+func handleStatusCause(cause v1.StatusCause, kind string) (probableCause, remedy string) {
+	switch cause.Type {
+	case v1.CauseTypeFieldValueNotFound:
+		return fmt.Sprintf("The specified value for field '%s' was not found", cause.Field),
+			fmt.Sprintf("Ensure the value referenced in field '%s' exists before creating this resource", cause.Field)
+
+	case v1.CauseTypeFieldValueRequired:
+		return fmt.Sprintf("Required field '%s' was not provided in the %s specification", cause.Field, kind),
+			fmt.Sprintf("Add the required field '%s' to your %s manifest", cause.Field, kind)
+
+	case v1.CauseTypeFieldValueDuplicate:
+		return fmt.Sprintf("Duplicate value found for field '%s'", cause.Field),
+			fmt.Sprintf("Ensure the value for field '%s' is unique", cause.Field)
+
+	case v1.CauseTypeFieldValueInvalid:
+		return fmt.Sprintf("Invalid value provided for field '%s': %s", cause.Field, cause.Message),
+			fmt.Sprintf("Correct the value for field '%s' according to the validation requirements", cause.Field)
+
+	case v1.CauseTypeUnexpectedServerResponse:
+		return "The server returned an unexpected response",
+			"This is likely a server-side issue. Contact your cluster administrator"
+
+	default:
+		return fmt.Sprintf("Issue with field '%s': %s", cause.Field, cause.Message),
+			fmt.Sprintf("Review and correct the specified field according to the error message")
+	}
+}
+
+// ParseKubeStatusErr converts Kubernetes API errors into user-friendly messages
+func ParseKubeStatusErr(err *kubeerror.StatusError) (shortDescription, longDescription, probableCause, remedy []string) {
+	shortDescription = make([]string, 0)
+	longDescription = make([]string, 0)
+	probableCause = make([]string, 0)
+	remedy = make([]string, 0)
+
+	if err == nil {
+		return
+	}
+
+	status := err.Status()
+
+	// Create base description including status code
+	baseDesc := fmt.Sprintf("[Status Code: %d] %s", status.Code, status.Reason)
+	if status.Details != nil {
+		baseDesc = fmt.Sprintf("%s: %s '%s'", baseDesc, status.Details.Kind, status.Details.Name)
+	}
+	shortDescription = append(shortDescription, baseDesc)
+
+	// Add the main error message
+	longDescription = append(longDescription, status.Message)
+
+	// Add reason-based guidance
+	pc, rem := handleStatusReason(status.Reason)
+	probableCause = append(probableCause, pc)
+	remedy = append(remedy, rem)
+
+	// Process detailed causes if available
+	if status.Details != nil && len(status.Details.Causes) > 0 {
+		for _, cause := range status.Details.Causes {
+			// Add detailed cause description
+			longDescription = append(longDescription,
+				fmt.Sprintf("Field '%s': %s", cause.Field, cause.Message))
+
+			// Get cause-specific messages
+			pc, rem := handleStatusCause(cause, status.Details.Kind)
+			probableCause = append(probableCause, pc)
+			remedy = append(remedy, rem)
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
**Description**

This PR fixes #638

**Notes for Reviewers**

- Added common utility functions for parsing Kubernetes status errors, now used across all relevant Kubernetes error functions.

- Error messages have been updated but may require further review and adjustments.

**Before**:

![image](https://github.com/user-attachments/assets/5ba20939-3f40-4653-8858-b4f98d9313e8)

**After**:

Yet to be attached (issues with local setup, will resolve and attach screenshot)




**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
