### PR TITLE
fix: use ~/.meshery directory for temporary files instead of working 

### DIFF
--- a/utils/kubernetes/kompose/convert.go
+++ b/utils/kubernetes/kompose/convert.go
@@ -47,8 +47,8 @@ func Convert(dockerCompose DockerComposeFile) (string, error) {
 	}
 
 	defer func() {
-		os.Remove("temp.data")
-		os.Remove("result.yaml")
+		os.Remove(tempFilePath)
+		os.Remove(resultFilePath)
 	}()
 
 	formatComposeFile(&dockerCompose)
@@ -73,7 +73,7 @@ func Convert(dockerCompose DockerComposeFile) (string, error) {
 		return "", ErrCvrtKompose(err)
 	}
 
-	result, err := os.ReadFile("result.yaml")
+	result, err := os.ReadFile(resultFilePath)
 	if err != nil {
 		return "", ErrCvrtKompose(err)
 	}

--- a/utils/kubernetes/kompose/convert.go
+++ b/utils/kubernetes/kompose/convert.go
@@ -2,6 +2,7 @@ package kompose
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/kubernetes/kompose/client"
@@ -30,8 +31,18 @@ func IsManifestADockerCompose(manifest []byte, schemaURL string) error {
 // converts a given docker-compose file into kubernetes manifests
 // expects a validated docker-compose file
 func Convert(dockerCompose DockerComposeFile) (string, error) {
-	err := utils.CreateFile(dockerCompose, "temp.data", "./")
+	// Get user's home directory
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
+		return "", ErrCvrtKompose(err)
+	}
+
+	// Construct path to .meshery directory
+	mesheryDir := filepath.Join(homeDir, ".meshery")
+	tempFilePath := filepath.Join(mesheryDir, "temp.data")
+	resultFilePath := filepath.Join(mesheryDir, "result.yaml")
+
+	if err := utils.CreateFile(dockerCompose, "temp.data", mesheryDir); err != nil {
 		return "", ErrCvrtKompose(err)
 	}
 
@@ -52,8 +63,8 @@ func Convert(dockerCompose DockerComposeFile) (string, error) {
 	}
 
 	ConvertOpt := client.ConvertOptions{
-		InputFiles:              []string{"temp.data"},
-		OutFile:                 "result.yaml",
+		InputFiles:              []string{tempFilePath},
+		OutFile:                 resultFilePath,
 		GenerateNetworkPolicies: true,
 	}
 


### PR DESCRIPTION
…directory

**Description**

This PR fixes #648 

**Notes for Reviewers**

Addresses the issue of temporary file handling during Docker Compose to Kubernetes manifest conversion in Meshery. 

Previously, temporary files were being created in the working directory (`./`) which caused permission issues in a containerized environment.

>  NOTE: using `~/.meshery` instead of `./` is a hypothesis, if this fails we might want to try using `os.TempDir()` or `os.CreateTemp()`  

The Problem:
- Temporary files (temp.data and result.yaml) were being created in the current working directory
- This led to permission denied errors in containerized environments where the working directory might not be writable

The Solution:
- Created a dedicated ~/.meshery directory for temporary file operations

Testing Done:
- Works fine locally


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
