### PR TITLE
[CI] Avoid model generator workflow to push formatting changes in SVGs

### DIFF
--- a/utils/csv/csv.go
+++ b/utils/csv/csv.go
@@ -88,7 +88,7 @@ func (c *CSV[E]) Parse(ch chan E, errorChan chan error) error {
 					}
 
 					// To keep uniform formatting. This avoids formatting changes to be pushed in commits
-					if attribute == "svgwhite" || attribute == "svgcolor" {
+					if attribute == "svgwhite" || attribute == "svgcolor" || attribute == "svgcomplete" {
 						value = strings.ReplaceAll(value, "\n", "")
 					}
 					

--- a/utils/csv/csv.go
+++ b/utils/csv/csv.go
@@ -86,6 +86,12 @@ func (c *CSV[E]) Parse(ch chan E, errorChan chan error) error {
 							attribute = key
 						}
 					}
+
+					// To keep uniform formatting. This avoids formatting changes to be pushed in commits
+					if attribute == "svgwhite" || attribute == "svgcolor" {
+						value = strings.ReplaceAll(value, "\n", "")
+					}
+					
 					data[attribute] = value
 				}
 			}


### PR DESCRIPTION
**Description**

This PR fixes #652

**Notes for Reviewers**
- update.go and generate.go in registry, both use `Parser` function implemented in `csv.go`
- fixing the parsing of svg columns here should fix the unnecessary formatting changes that were being generated
- The formatting of svg columns is kept uniform by removing all new-line characters (\n) 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
