### PR TITLE
Add support for Helm CRD template sanitization to fix YAML parsing for Linkerd

### DIFF
--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -39,14 +39,18 @@ func (gr GitRepo) GetContent() (models.Package, error) {
 	dirPath := filepath.Join(os.TempDir(), owner, repo, branch)
 	_ = os.MkdirAll(dirPath, 0755)
 	filePath := filepath.Join(dirPath, utils.GetRandomAlphabetsOfDigit(5))
-	fd, err := os.Create(filePath) // perform cleanup
+	fd, err := os.Create(filePath)
 	if err != nil {
+		os.RemoveAll(dirPath)
 		return nil, utils.ErrCreateFile(err, filePath)
 	}
 	br := bufio.NewWriter(fd)
 
 	defer func() {
-		_ = br.Flush()
+		br.Flush()
+		fd.Close()
+		os.Remove(filePath)
+		os.RemoveAll(dirPath)
 	}()
 	gw := gitWalker.
 		Owner(owner).

--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -49,8 +49,6 @@ func (gr GitRepo) GetContent() (models.Package, error) {
 	defer func() {
 		br.Flush()
 		fd.Close()
-		os.Remove(filePath)
-		os.RemoveAll(dirPath)
 	}()
 	gw := gitWalker.
 		Owner(owner).


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

Changes:

- Implemented `RemoveHelmPlaceholders` to handle templated CRD files (before: Helm templates breaking YAML parsing)
- Updated `LoadHelmChart` to search entire chart directory for CRDs (before: only look for `crd/` dir)
- Handles Helm template expressions while maintaining valid YAML structure

This change allows the model generator to process CRDs from Helm charts that use templating, avoiding parse errors while maintaining a valid YAML structure.

Tests:

-  Tested with Linkerd CRD chart
-  Verified YAML validity after template removal
-  Checked component generation with sanitized CRDs

![image](https://github.com/user-attachments/assets/da457967-784e-4901-9ed4-fbce4993509a)


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
