### PR TITLE
Fix ignored models not showing up in Registry and add option to toggle visibility of ignored models

### DIFF
--- a/models/meshmodel/registry/v1beta1/model_filter.go
+++ b/models/meshmodel/registry/v1beta1/model_filter.go
@@ -29,6 +29,8 @@ type ModelFilter struct {
 	Components    bool
 	Relationships bool
 	Status        string
+	// When set to true, it will retrieve all models including the ones marked as ignored
+	ShowIgnored bool
 	// When Trim is true it will only send necessary models data
 	// like: component count, relationship count, id and name of model
 	Trim bool
@@ -154,13 +156,11 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 		finder = finder.Order("display_name")
 	}
 
-	status := "enabled"
-
 	if mf.Status != "" {
-		status = mf.Status
+		finder = finder.Where("model_dbs.status = ?", mf.Status)
+	} else if !mf.ShowIgnored {
+		finder = finder.Where("model_dbs.status = ?", "enabled")
 	}
-
-	finder = finder.Where("model_dbs.status = ?", status)
 
 	finder.Count(&count)
 

--- a/models/meshmodel/registry/v1beta1/model_filter.go
+++ b/models/meshmodel/registry/v1beta1/model_filter.go
@@ -29,8 +29,6 @@ type ModelFilter struct {
 	Components    bool
 	Relationships bool
 	Status        string
-	// When set to true, it will retrieve all models including the ones marked as ignored
-	ShowIgnored bool
 	// When Trim is true it will only send necessary models data
 	// like: component count, relationship count, id and name of model
 	Trim bool
@@ -158,8 +156,6 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 
 	if mf.Status != "" {
 		finder = finder.Where("model_dbs.status = ?", mf.Status)
-	} else if !mf.ShowIgnored {
-		finder = finder.Where("model_dbs.status = ?", "enabled")
 	}
 
 	finder.Count(&count)


### PR DESCRIPTION
**Description**

This PR fixes [Meshery issue #13317](https://github.com/meshery/meshery/issues/13317)

**Notes for Reviewers**
- currently, status is set to null string, and thus both enabled and ignored models are being fetched
- if status is set to `enabled` (TODO: a toggle feature on UI, see issue [#13662](https://github.com/meshery/meshery/issues/13662)), then ignored models would be hidden

Before - 
Ignored models were not showing up on registry page

After - 

https://github.com/user-attachments/assets/ec925095-3700-4288-a480-11aa8577ecc0



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
