### PR TITLE
Ensuring consistent indentation and preserving field order during YAML conversion.

### DIFF
--- a/encoding/convert.go
+++ b/encoding/convert.go
@@ -4,12 +4,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ToYaml converts input JSON (or YAML) data into YAML while preserving key order.
+// It unmarshalls data into yaml.Node instead of map[string]interface{} because
+// maps do not preserve field order.
 func ToYaml(data []byte) ([]byte, error) {
-	var out map[string]interface{}
+	var out yaml.Node
 	err := Unmarshal(data, &out)
 	if err != nil {
 		return nil, err
 	}
 
-	return yaml.Marshal(out)
+	if len(out.Content) == 0 {
+		return nil, fmt.Errorf("No content found in the yaml file.")
+	}
+
+	// Recursively set the style of nodes to block style for readable formatting.
+	setBlockStyle(out.Content[0])
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	err = enc.Encode(out.Content[0])
+	return buf.Bytes(), err
 }

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -9,6 +9,13 @@ import (
 
 // Unmarshal parses the JSON/YAML data and stores the result in the value pointed to by out
 func Unmarshal(data []byte, out interface{}) error {
+	if node, ok := out.(*yaml.Node); ok {
+		err := unmarshalYAML(data, node)
+		if err != nil {
+			return err
+		}
+	}
+
 	err := unmarshalJSON(data, out)
 	if err != nil {
 		err = unmarshalYAML(data, out)


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

**Before:** 

- `ToYaml` first unmarshalled to `map[string]interface{}` and since `maps` in Go are unordered, we are losing out on the arrangement of the fields. 

**After:**

- Changed the target type to `yaml.Node`  to preserve field order.
- Added a specific check for Node types since the JSON-first unmarshal was corrupting data without triggering an error.

**next steps:** 
- merge https://github.com/meshery/meshery/pull/13558

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->