### PR TITLE
add: detect both error and errors.ts

### DIFF
--- a/cmd/errorutil/internal/coder/path.go
+++ b/cmd/errorutil/internal/coder/path.go
@@ -66,7 +66,7 @@ func walk(globalFlags globalFlags, update bool, updateAll bool, errorsInfo *mesh
 
 func isErrorGoFile(path string) bool {
 	_, file := filepath.Split(path)
-	return file == "error.go"
+	return file == "error.go" || file == "errors.go"
 }
 
 func includeFile(path string) bool {


### PR DESCRIPTION
**Description**

This PR fixes #678 

**Notes for Reviewers**

**Why?**
Error codes in `errors.go` were not being processed by `errorutil` (only recognises `error.go`), leading to `replace_me` not being replaced.

**Changes**
- Added support for `errors.go` in errorutil since it serves as a collection of errors, aligning with naming conventions.
- Running the workflow again will do the work.

**Next steps**
Further issues to resolve:
- Fix all the duplicate error codes by respecting the old error code and replace the new duplicate error code with replace_me
- For duplicate error names/variables, I'll retain the one with better error details and create an alias for the other

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
