### PR TITLE
Revert check for errors.go in errorutils 

### DIFF
--- a/cmd/errorutil/internal/coder/path.go
+++ b/cmd/errorutil/internal/coder/path.go
@@ -66,7 +66,7 @@ func walk(globalFlags globalFlags, update bool, updateAll bool, errorsInfo *mesh
 
 func isErrorGoFile(path string) bool {
 	_, file := filepath.Split(path)
-	return file == "error.go" || file == "errors.go"
+	return file == "error.go"
 }
 
 func includeFile(path string) bool {

--- a/files/error.go
+++ b/files/error.go
@@ -311,7 +311,7 @@ func ErrUnsupportedFileTypeForConversionToDesign(fileName string, fileType strin
 		"Convert the file to a supported format before processing",
 	}
 
-	return errors.New(ErrFileTypeNotSupportedForDesignConversion, errors.Critical, sdescription, ldescription, probableCause, remedy)
+	return errors.New(ErrFileTypeNotSupportedForDesignConversionCode, errors.Critical, sdescription, ldescription, probableCause, remedy)
 }
 
 var (

--- a/files/errors.go
+++ b/files/errors.go
@@ -11,20 +11,20 @@ import (
 
 var (
 	// Error code
-	ErrUnsupportedExtensionCode                = "meshkit-11282"
-	ErrUnsupportedExtensionForOperationCode    = "meshkit-11283"
-	ErrFailedToIdentifyFileCode                = "meshkit-11284"
-	ErrSanitizingFileCode                      = "meshkit-11285"
-	ErrInvalidYamlCode                         = "meshkit-11286"
-	ErrInvalidJsonCode                         = "meshkit-11287"
-	ErrFailedToExtractTarCode                  = "meshkit-11288"
-	ErrUnsupportedFileTypeCode                 = "meshkit-11289"
-	ErrInvalidKubernetesManifestCode           = "meshkit-11290"
-	ErrInvalidMesheryDesignCode                = "meshkit-11291"
-	ErrInvalidHelmChartCode                    = "meshkit-11292"
-	ErrInvalidDockerComposeCode                = "meshkit-11293"
-	ErrInvalidKustomizationCode                = "meshkit-11294"
-	ErrFileTypeNotSupportedForDesignConversion = "replace_me"
+	ErrUnsupportedExtensionCode                    = "meshkit-11282"
+	ErrUnsupportedExtensionForOperationCode        = "meshkit-11283"
+	ErrFailedToIdentifyFileCode                    = "meshkit-11284"
+	ErrSanitizingFileCode                          = "meshkit-11285"
+	ErrInvalidYamlCode                             = "meshkit-11286"
+	ErrInvalidJsonCode                             = "meshkit-11287"
+	ErrFailedToExtractTarCode                      = "meshkit-11288"
+	ErrUnsupportedFileTypeCode                     = "meshkit-11289"
+	ErrInvalidKubernetesManifestCode               = "meshkit-11290"
+	ErrInvalidMesheryDesignCode                    = "meshkit-11291"
+	ErrInvalidHelmChartCode                        = "meshkit-11292"
+	ErrInvalidDockerComposeCode                    = "meshkit-11293"
+	ErrInvalidKustomizationCode                    = "meshkit-11294"
+	ErrFileTypeNotSupportedForDesignConversionCode = "replace_me"
 )
 
 func ErrUnsupportedExtensionForOperation(operation string, fileName string, fileExt string, supportedExtensions []string) error {


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

- Revert check for `errors.go` in `errorutils` 
- Renames the issue causing file (`errors.go` -> `errors.go`)

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
