### PR TITLE
Fix deprecated functions and update OPA packages

### DIFF
--- a/models/meshmodel/core/policies/rego_policy_relationship.go
+++ b/models/meshmodel/core/policies/rego_policy_relationship.go
@@ -9,10 +9,10 @@ import (
 	"github.com/layer5io/meshkit/models/meshmodel/registry/v1alpha3"
 	"github.com/layer5io/meshkit/utils"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
-	"github.com/open-policy-agent/opa/topdown/print"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/topdown/print"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,5 +117,4 @@ func (r *Rego) RegoPolicyHandler(designFile pattern.PatternFile, regoQueryString
 	}
 
 	return evaluationResponse, nil
-
 }

--- a/models/oci/oci.go
+++ b/models/oci/oci.go
@@ -147,7 +147,7 @@ func PushToOCIRegistry(dirPath, registryAdd, repositoryAdd, imageTag, username, 
 	opts := oras.PackManifestOptions{
 		Layers: fileDescriptors,
 	}
-	manifestDescriptor, packageErr := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1_RC4, artifactType, opts)
+	manifestDescriptor, packageErr := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1, artifactType, opts)
 	if packageErr != nil {
 		return ErrGettingLayer(packageErr)
 	}


### PR DESCRIPTION
**Description**

This PR fixes issue #677

1. broker/nats/nats.go
Removed deprecated nats.EncodedConn and related methods:
Replaced nats.EncodedConn with nats.Conn.
Removed nats.NewEncodedConn and handled message encoding manually using encoding/json.
Updated methods to use nats.Conn for publishing and subscribing messages.

2. models/meshmodel/core/policies/rego_policy_relationship.go:
Updated OPA packages to use v1 versions:

3. models/oci/oci.go
Replaced deprecated oras.PackManifestVersion1_1_RC4

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
