### PR TITLE
Revert "Enhance `Import Model` Modal"

### DIFF
--- a/schemas/configuration/modelImport.json
+++ b/schemas/configuration/modelImport.json
@@ -23,7 +23,7 @@
           "file": {
             "type": "string",
             "format": "file",
-            "description": "Browse the model file from your file system. Ensure it's an OCI artifact in .tar, .tar.gz, or .tgz format.",
+            "description": "Browse the filter file from your file system",
             "x-rjsf-grid-area": "12"
           }
         },

--- a/schemas/configuration/uiSchemaModelImport.json
+++ b/schemas/configuration/uiSchemaModelImport.json
@@ -2,10 +2,5 @@
   "uploadType": {
     "ui:widget": "radio"
   },
-
-  "url":{
-    "ui:disabled": true
-  },
-
   "ui:order": ["uploadType", "file", "url"]
 }


### PR DESCRIPTION
Reverts meshery/meshkit#689

Reverting this change because it was planned differently after discussion.

New changes - 
- URL import works fine, added detailed tooltip message for it
- schema moved and fetched from sistent

New PRs for this change - https://github.com/layer5io/sistent/pull/946 and https://github.com/meshery/meshery/pull/13806