### PR TITLE
Add ability to resolve OpenAPI schema references during component generation

### DIFF
--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -61,8 +61,15 @@ func Generate(resource string) (component.ComponentDefinition, error) {
 	cmp := component.ComponentDefinition{}
 	cmp.SchemaVersion = v1beta1.ComponentSchemaVersion
 
+	resolvedResource, err := GetResolvedManifest(resource)
+	if errors.Is(err, ErrNoSchemasFound) {
+		resolvedResource = resource
+	} else if err != nil {
+		return cmp, err
+	}
+
 	cmp.Metadata = component.ComponentDefinition_Metadata{}
-	crdCue, err := utils.YamlToCue(resource)
+	crdCue, err := utils.YamlToCue(resolvedResource)
 	if err != nil {
 		return cmp, err
 	}

--- a/utils/component/openapi_generator.go
+++ b/utils/component/openapi_generator.go
@@ -24,7 +24,7 @@ func GenerateFromOpenAPI(resource string, pkg models.Package) ([]component.Compo
 	if resource == "" {
 		return nil, nil
 	}
-	resource, err := getResolvedManifest(resource)
+	resource, err := GetResolvedManifest(resource)
 	if err != nil && errors.Is(err, ErrNoSchemasFound) {
 		return nil, nil
 	}
@@ -174,7 +174,7 @@ func getResourceScope(manifest string, kind string) (bool, error) {
 	return false, nil // Resource is cluster-scoped
 }
 
-func getResolvedManifest(manifest string) (string, error) {
+func GetResolvedManifest(manifest string) (string, error) {
 	var m map[string]interface{}
 
 	err := yaml.Unmarshal([]byte(manifest), &m)


### PR DESCRIPTION
**Description**

This PR fixes https://github.com/meshery/meshery/issues/14117

**Notes for Reviewers**

**Implementation Details**
1. `Generate()` is a common function used by both Artifact Hub and GitHub to Generate Component Definition from a single CRD. Thus, resolving schemas here would be ideal.
2. `GetResolvedManifest` already implemented was re-used for this purpose, it resolves $ref fields that refer to standard OpenAPI component schema paths (e.g., `#/components/schemas/...`); external or non-standard references are not handled.

**Test**
Tested with a test CRD containing schema references using `mesheryctl registry generate` - [Link to Test CRD](https://github.com/riyaa14/meshery-testing/blob/main/test-crds/crd-with-ref.yaml)

**Before** 

<img width="1142" alt="Screenshot 2025-04-07 at 3 13 22 AM" src="https://github.com/user-attachments/assets/f18400fb-75d5-4ff0-a573-b69449292cfa" />


**After**

<img width="1182" alt="Screenshot 2025-04-07 at 3 12 08 AM" src="https://github.com/user-attachments/assets/f1de4486-8c88-4623-915b-432c691848f1" />


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
