### PR TITLE
Updated .golangci.yml from v1 to v2

### DIFF
--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,63 @@
+linters-settings:
+   go-mod-tidy:
+      enabled: true
+   gci:
+      enabled: true
+      max-len: 120
+      line-length: 120
+   goconst:
+      enabled: true
+   gocritic:
+      enabled: true
+      disable:
+         - parallelize
+         - nesting
+         - hugeParam
+         - hugeStruct
+         - nestParam
+         - prealloc
+   govet:
+      enabled: true
+      shadow: true
+      tests: true
+   golint:
+      enabled: true
+      min-confidence: 0.8
+   unused:
+      enabled: true
+      check-exported: true
+      check-packages: true
+      check-generated: true
+      tests: true
+      allow-unused-type-export: true
+   cyclop:
+      enabled: true
+      average-strictness: 7
+   scopelint:
+      enabled: true
+      tests: true
+
+# Configuration for golangci-lint that is suitable for a Kubernetes operator project built with Golang
+linters:
+   enable-all: false
+   disable-all: false
+   linters:
+      - gci
+      - goconst
+      - gocritic
+      - govet
+      - golint
+      - unused
+      - cyclop
+      - scopelint
+   exclude-rules:
+      - testpackage
+issues:
+   exclude-dirs:
+      - vendor
+      - bundle
+      - hack
+      - img
+run:
+   timeout: 5m
+   enable-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,64 +1,73 @@
-linters-settings:
-  go-mod-tidy:
-    enabled: true
-  gci:
-    enabled: true
-    max-len: 120
-    line-length: 120
-  goconst:
-    enabled: true
-  gocritic:
-    enabled: true
-    disable:
-      - parallelize
-      - nesting
-      - hugeParam
-      - hugeStruct
-      - nestParam
-      - prealloc
-  govet:
-    enabled: true
-    shadow: true
-    tests: true
-  golint:
-    enabled: true
-    min-confidence: 0.8
-  unused:
-    enabled: true
-    check-exported: true
-    check-packages: true
-    check-generated: true
-    tests: true
-    allow-unused-type-export: true
-  cyclop:
-    enabled: true
-    average-strictness: 7
-  scopelint:
-    enabled: true
-    tests: true
+version: '2'
 
-
-# Configuration for golangci-lint that is suitable for a Kubernetes operator project built with Golang
-linters:
-  enable-all: false
-  disable-all: false
-  linters:
-    - gci
-    - goconst
-    - gocritic
-    - govet
-    - golint
-    - unused
-    - cyclop
-    - scopelint
-  exclude-rules:
-    - testpackage
-issues: 
- exclude-dirs: 
-    - vendor
-    - bundle
-    - hack
-    - img
 run:
-  timeout: 5m
-  enable-cache: true
+   enable-cache: true
+
+linters:
+   default: none
+   enable:
+      - goconst
+      - gocritic
+      - govet
+      - unused
+      - cyclop
+
+   settings:
+      goconst:
+         find-duplicates: true
+      gocritic:
+         disable:
+            - parallelize
+            - nesting
+            - hugeParam
+            - hugeStruct
+            - nestParam
+            - prealloc
+      govet:
+         shadow: true
+         tests: true
+      unused:
+         check-exported: true
+         check-packages: true
+         check-generated: true
+         tests: true
+         allow-unused-type-export: true
+      cyclop:
+         average-strictness: 12
+
+   exclusions:
+      paths:
+         - vendor
+         - bundle
+         - hack
+         - img
+         - third_party$
+         - builtin$
+         - examples$
+
+      rules:
+         - text: testpackage
+           path: _test\.go
+
+      generated: lax
+      presets:
+         - comments
+         - common-false-positives
+         - legacy
+         - std-error-handling
+
+formatters:
+   enable:
+      - gci
+
+   settings:
+      gci:
+         max-len: 120
+         line-length: 120
+
+   exclusions:
+      generated: lax
+      paths:
+         - third_party$
+         - builtin$
+         - examples$


### PR DESCRIPTION
**Description**

This PR fixes #710 

**Notes for Reviewers**
This PR updates the `.golangci.yml` configuration file to the v2 format.

**Why?**

Our previous configuration was in an old format (likely v1) which is no longer supported by the version of `golangci-lint` currently used, causing the `golangci-lint run` command to fail with a config loading error (`unsupported version of the configuration: ""`).
![Screenshot From 2025-04-20 18-07-37](https://github.com/user-attachments/assets/93df9778-8ee8-4c16-a5cd-9df76d9b51c7)
**How?**

An automatic migration attempt (`golangci-lint migrate`) failed due to our old config's structure not perfectly matching the v1 schema expected by the tool's validator. I then attempted with `--skip-validation`, which produced an incomplete config. Therefore, the configuration was manually migrated to the v2 format based on the official documentation.

**Key Changes in the New Config (v2 vs Old):**

*   The top-level `linters-settings` section is gone; linter settings are now under `linters.settings`.
*   There's a new `formatters` section; `gci` (a formatter) and its settings are moved there.
*   Exclusions (`exclude-dirs`, `exclude-rules`) are now handled under `linters.exclusions`. Exclusion rules require at least two matching criteria in v2 (e.g., `text` and `path`).
*   `linters.enable-all` and `linters.disable-all` are replaced by `linters.default: none`.
*   The `run.timeout` option is removed as it's ignored in v2.

**What Couldn't Be Migrated / What Was Removed:**

*   The `golint` and `scopelint` linters were not found in the list of supported linters for the current `golangci-lint` version (`golangci-lint help linters`) and have been removed from the configuration.
*   The `go-mod-tidy` linter was also not supported and was removed.
*   Original comments in the config file are lost.

**Outcome:**

The `golangci-lint run` command now loads the configuration successfully and runs the analysis with the migrated linters and settings. The PR includes the updated `.golangci.yml` file.

![Screenshot From 2025-04-20 18-11-21](https://github.com/user-attachments/assets/3e74d9d6-4db6-4636-b167-c6ea0c66a780)

All the changes were done referring to the documentation for golangci-lint: 
- https://golangci-lint.run/product/migration-guide/
-  https://golangci-lint.run/usage/configuration/

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 