### PR TITLE
fix(app): fixes lint issues

### DIFF
--- a/converter/tests/helm_test.go
+++ b/converter/tests/helm_test.go
@@ -139,7 +139,9 @@ func extractManifestFromChart(chartData []byte) (bool, string) {
 		}
 		if strings.HasSuffix(hdr.Name, "templates/manifest.yaml") {
 			buf := new(bytes.Buffer)
-			io.Copy(buf, tr)
+			if _, err := io.Copy(buf, tr); err != nil {
+    			return false, ""
+			}
 			return true, buf.String()
 		}
 	}

--- a/generators/github/url.go
+++ b/generators/github/url.go
@@ -55,6 +55,9 @@ func (u URL) GetContent() (models.Package, error) {
 	if strings.HasSuffix(url, ".yml") || strings.HasSuffix(url, ".yaml") {
 
 		data, err := os.ReadFile(downloadfilePath)
+		if err != nil {
+			return nil, err
+		}
 		_, err = w.Write(data)
 		if err != nil {
 			return nil, err

--- a/go.sum
+++ b/go.sum
@@ -416,6 +416,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/meshery/schemas v0.8.22 h1:JQ7PoEheiXdkIG/h965L+DB7p/JdGEgs3i5r0EniSt4=
+github.com/meshery/schemas v0.8.22/go.mod h1:tuAmsG9WJRjZ0Iv12HIAhKZbWpfpkTRjfPNThKbr7HA=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/utils/component/generator.go
+++ b/utils/component/generator.go
@@ -72,7 +72,7 @@ func IncludeComponentBasedOnGroup(resource string, groupFilter string) (bool, er
 	group, err := extractCueValueFromPath(crdCue, DefaultPathConfig.GroupPath)
 
 	if err != nil {
-		logrus.Info("Failed to extract group from crd %v", err)
+		logrus.Infof("Failed to extract group from crd %v", err)
 	}
 
 	return group == groupFilter, nil


### PR DESCRIPTION
## **Description**

This PR partially fixes #710 

### **Notes for Reviewers**
- io.Copy(buf, tr) needed to be checked for any potential errors that may arise
- We shuld use logrus.Infof for formatting %v err
- data, err := os.ReadFile(downloadfilePath)  	_, err = w.Write(data) the err is being over written here before it was checked so we shud break it into 2 separate checks

there are few more issues caused due to depreciation of the packages:
```
$ make check
golangci-lint run -c .golangci.yml -v ./...
INFO golangci-lint has version 1.64.7 built with go1.24.1 from 8cffdb7d on 2025-03-11T23:26:51Z 
INFO [config_reader] Used config file .golangci.yml 
INFO [goenv] Read go env for 3.735614ms: map[string]string{"GOCACHE":"/home/codespace/.cache/go-build", "GOROOT":"/usr/local/go"} 
INFO [lintersdb] Active 6 linters: [errcheck gosimple govet ineffassign staticcheck unused] 
INFO [loader] Go packages loading at mode 8767 (exports_file|name|types_sizes|files|imports|compiled_files|deps) took 4.776055082s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 65.675712ms 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 49, after processing: 12 
INFO [runner] Processors filtering stat (in/out): generated_file_filter: 49/49, max_per_file_from_linter: 12/12, max_same_issues: 12/12, severity-rules: 12/12, filename_unadjuster: 49/49, invalid_issue: 49/49, skip_dirs: 49/49, identifier_marker: 49/49, nolint_filter: 14/12, diff: 12/12, source_code: 12/12, path_prettifier: 12/12, path_relativity: 49/49, exclusion_paths: 49/49, exclusion_rules: 49/14, fixer: 12/12, max_from_linter: 12/12, sort_results: 12/12, path_absoluter: 49/49, cgo: 49/49, uniq_by_line: 12/12, path_shortener: 12/12, skip_files: 49/49 
INFO [runner] processing took 2.613364ms with stages: exclusion_rules: 1.185511ms, nolint_filter: 830.147µs, generated_file_filter: 267.55µs, skip_dirs: 188.191µs, source_code: 52.078µs, path_relativity: 29.966µs, identifier_marker: 26.078µs, cgo: 6.211µs, max_same_issues: 5.18µs, invalid_issue: 4.989µs, path_absoluter: 4.789µs, uniq_by_line: 3.356µs, path_shortener: 2.755µs, filename_unadjuster: 1.813µs, max_from_linter: 1.684µs, max_per_file_from_linter: 802ns, path_prettifier: 741ns, exclusion_paths: 421ns, diff: 280ns, fixer: 262ns, sort_results: 241ns, skip_files: 220ns, severity-rules: 99ns 
INFO [runner] linters took 409.465594ms with stages: goanalysis_metalinter: 406.748359ms 
models/oci/oci.go:150:63: SA1019: oras.PackManifestVersion1_1_RC4 is deprecated: This constant is deprecated and not recommended for future use. Use [PackManifestVersion1_1] instead. (staticcheck)
        manifestDescriptor, packageErr := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1_RC4, artifactType, opts)
                                                                     ^
broker/nats/nats.go:28:6: SA1019: nats.EncodedConn is deprecated: Encoded connections are no longer supported. (staticcheck)
        ec *nats.EncodedConn
            ^
broker/nats/nats.go:60:13: SA1019: nats.NewEncodedConn is deprecated: Encoded connections are no longer supported. (staticcheck)
        ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
                   ^
broker/nats/nats.go:82:2: SA1019: n.ec.Close is deprecated: Encoded connections are no longer supported. (staticcheck)
        n.ec.Close()
        ^
broker/nats/nats.go:87:9: SA1019: n.ec.Publish is deprecated: Encoded connections are no longer supported. (staticcheck)
        err := n.ec.Publish(subject, message)
               ^
broker/nats/nats.go:96:9: SA1019: n.ec.BindSendChan is deprecated: Encoded connections are no longer supported. (staticcheck)
        err := n.ec.BindSendChan(subject, msgch)
               ^
broker/nats/nats.go:108:12: SA1019: n.ec.QueueSubscribe is deprecated: Encoded connections are no longer supported. (staticcheck)
        _, err := n.ec.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
                  ^
broker/nats/nats.go:122:12: SA1019: n.ec.BindRecvQueueChan is deprecated: Encoded connections are no longer supported. (staticcheck)
        _, err := n.ec.BindRecvQueueChan(subject, queue, msgch)
                  ^
models/meshmodel/core/policies/rego_policy_relationship.go:13:2: SA1019: "github.com/open-policy-agent/opa/rego" is deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x, but its use is not recommended. For newer features and behaviours, such as defaulting to the Rego v1 syntax, use the corresponding components in the [github.com/open-policy-agent/opa/v1] package instead. See https://www.openpolicyagent.org/docs/latest/v0-compatibility/ for more information. (staticcheck)
        "github.com/open-policy-agent/opa/rego"
        ^
models/meshmodel/core/policies/rego_policy_relationship.go:14:2: SA1019: "github.com/open-policy-agent/opa/storage" is deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x, but its use is not recommended. For newer features and behaviours, such as defaulting to the Rego v1 syntax, use the corresponding components in the [github.com/open-policy-agent/opa/v1] package instead. See https://www.openpolicyagent.org/docs/latest/v0-compatibility/ for more information. (staticcheck)
        "github.com/open-policy-agent/opa/storage"
        ^
models/meshmodel/core/policies/rego_policy_relationship.go:15:2: SA1019: "github.com/open-policy-agent/opa/storage/inmem" is deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x, but its use is not recommended. For newer features and behaviours, such as defaulting to the Rego v1 syntax, use the corresponding components in the [github.com/open-policy-agent/opa/v1] package instead. See https://www.openpolicyagent.org/docs/latest/v0-compatibility/ for more information. (staticcheck)
        "github.com/open-policy-agent/opa/storage/inmem"
        ^
models/meshmodel/core/policies/rego_policy_relationship.go:16:2: SA1019: "github.com/open-policy-agent/opa/topdown/print" is deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x, but its use is not recommended. For newer features and behaviours, such as defaulting to the Rego v1 syntax, use the corresponding components in the [github.com/open-policy-agent/opa/v1] package instead. See https://www.openpolicyagent.org/docs/latest/v0-compatibility/ for more information. (staticcheck)
        "github.com/open-policy-agent/opa/topdown/print"
        ^
INFO File cache stats: 3 entries of total size 14.7KiB 
INFO Memory: 54 samples, avg is 36.4MB, max is 98.9MB 
INFO Execution took 5.258640547s                  
make: *** [Makefile:6: check] Error 1
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
