### PR TITLE
fix [catalog]: handle time.TIme & nil createdAt time in ArtifactHub package buiilder

### DIFF
--- a/utils/catalog/package.go
+++ b/utils/catalog/package.go
@@ -2,12 +2,22 @@ package catalog
 
 import (
 	"fmt"
-	"github.com/meshery/meshkit/models/catalog/v1alpha1"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/meshery/meshkit/models/catalog/v1alpha1"
 )
 
-func BuildArtifactHubPkg(name, downloadURL, user, version, createdAt string, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
+func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *time.Time, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
+	
+	var createdAtStr string
+    if createdAt != nil {
+        createdAtStr = createdAt.Format(time.RFC3339)
+    } else {
+        createdAtStr = time.Now().Format(time.RFC3339)
+    }
+
 	artifacthubPkg := &ArtifactHubMetadata{
 		Name:        toKebabCase(name),
 		DisplayName: name,
@@ -27,7 +37,7 @@ func BuildArtifactHubPkg(name, downloadURL, user, version, createdAt string, cat
 		},
 		HomeURL:   "https://docs.meshery.io/concepts/logical/designs",
 		Version:   valueOrElse(version, "0.0.1"),
-		CreatedAt: createdAt,
+		CreatedAt: createdAtStr,
 		License:   "Apache-2.0",
 		LogoURL:   "https://raw.githubusercontent.com/meshery/meshery.io/0b8585231c6e2b3251d38f749259360491c9ee6b/assets/images/brand/meshery-logo.svg",
 		Install:   "mesheryctl design import -f",

--- a/utils/catalog/package.go
+++ b/utils/catalog/package.go
@@ -11,11 +11,11 @@ import (
 
 func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *time.Time, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
 	
-	var createdAtStr string
+	var createdAtStr time.Time
     if createdAt != nil {
-        createdAtStr = createdAt.Format(time.RFC3339)
+        createdAtStr = *createdAt
     } else {
-        createdAtStr = time.Now().Format(time.RFC3339)
+        createdAtStr = time.Now()
     }
 
 	artifacthubPkg := &ArtifactHubMetadata{
@@ -37,7 +37,7 @@ func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *tim
 		},
 		HomeURL:   "https://docs.meshery.io/concepts/logical/designs",
 		Version:   valueOrElse(version, "0.0.1"),
-		CreatedAt: createdAtStr,
+		CreatedAt: createdAtStr.Format(time.RFC3339),
 		License:   "Apache-2.0",
 		LogoURL:   "https://raw.githubusercontent.com/meshery/meshery.io/0b8585231c6e2b3251d38f749259360491c9ee6b/assets/images/brand/meshery-logo.svg",
 		Install:   "mesheryctl design import -f",

--- a/utils/catalog/package.go
+++ b/utils/catalog/package.go
@@ -10,7 +10,6 @@ import (
 )
 
 func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *time.Time, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
-	
 	var createdTime time.Time
     if createdAt != nil {
         createdTime = *createdAt

--- a/utils/catalog/package.go
+++ b/utils/catalog/package.go
@@ -11,11 +11,11 @@ import (
 
 func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *time.Time, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
 	var createdTime time.Time
-    if createdAt != nil {
-        createdTime = *createdAt
-    } else {
-        createdTime = time.Now()
-    }
+	if createdAt != nil {
+		createdTime = *createdAt
+	} else {
+		createdTime = time.Now()
+	}
 
 	artifacthubPkg := &ArtifactHubMetadata{
 		Name:        toKebabCase(name),

--- a/utils/catalog/package.go
+++ b/utils/catalog/package.go
@@ -11,11 +11,11 @@ import (
 
 func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *time.Time, catalogData *v1alpha1.CatalogData) *ArtifactHubMetadata {
 	
-	var createdAtStr time.Time
+	var createdTime time.Time
     if createdAt != nil {
-        createdAtStr = *createdAt
+        createdTime = *createdAt
     } else {
-        createdAtStr = time.Now()
+        createdTime = time.Now()
     }
 
 	artifacthubPkg := &ArtifactHubMetadata{
@@ -37,7 +37,7 @@ func BuildArtifactHubPkg(name, downloadURL, user, version string, createdAt *tim
 		},
 		HomeURL:   "https://docs.meshery.io/concepts/logical/designs",
 		Version:   valueOrElse(version, "0.0.1"),
-		CreatedAt: createdAtStr.Format(time.RFC3339),
+		CreatedAt: createdTime.Format(time.RFC3339),
 		License:   "Apache-2.0",
 		LogoURL:   "https://raw.githubusercontent.com/meshery/meshery.io/0b8585231c6e2b3251d38f749259360491c9ee6b/assets/images/brand/meshery-logo.svg",
 		Install:   "mesheryctl design import -f",


### PR DESCRIPTION
**Description**
Now the BuilderArtifactHubPkg function accepts *time.Time (i.e a pointer) instead of string.
The function now the handles the nil case also.

This PR fixes #556 

**Note for Reviewers**
Original functionality is maintained, adding retention for golang format. 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
