### PR TITLE
Fix/ignore list resources in crds

### DIFF
--- a/utils/component/openapi_generator.go
+++ b/utils/component/openapi_generator.go
@@ -57,10 +57,14 @@ func GenerateFromOpenAPI(resource string, pkg models.Package) ([]component.Compo
 		if err != nil {
 			continue
 		}
+
 		kind, err := kindCue.String()
 		if err != nil {
 			fmt.Printf("%v", err)
 			continue
+		}
+        if strings.HasSuffix(kind, "List") {
+			continue // Skip <resource>List types like PodList, DeploymentList, etc.
 		}
 
 		crd, err := fieldVal.MarshalJSON()

--- a/utils/manifests/generateComponent.go
+++ b/utils/manifests/generateComponent.go
@@ -37,16 +37,17 @@ func GenerateComponents(ctx context.Context, manifest string, resource int, cfg 
 			}
 			parsedCrd = cueCtx.BuildExpr(expr)
 		}
-		kindVal := parsedCrd.LookupPath(cue.ParsePath("spec.names.kind"))
-		if kindVal.Exists() {
-			kindStr, err := kindVal.String()
-			if err != nil {
-				continue // skip if unable to convert to string
-			}
-            if strings.HasSuffix(kindStr, "List") {
-				continue // skip List kinds
-			}
-		}
+kindVal, err := cfg.CrdFilter.NameExtractor(parsedCrd)
+if err == nil {
+	kindStr, strErr := kindVal.String()
+	if strErr != nil {
+		// TODO: Add logging for this error to aid debugging.
+		continue // skip if unable to convert to string
+	}
+	if strings.HasSuffix(kindStr, "List") {
+		continue // skip List kinds
+	}
+}
 
 		outDef, err := getDefinitions(parsedCrd, resource, cfg, ctx)
 		if err != nil {


### PR DESCRIPTION

🔧 Summary

This PR addresses Meshery issue #15337 by excluding Kubernetes resources that end with the "List" suffix (such as PodList, DeploymentList, etc.) from component generation.


---

✅ Changes Made

openapi_generator.go:
Added logic to skip resources whose kind ends with "List" during the OpenAPI-based component generation.

generateComponent.go:
Implemented a similar check to ignore "List" kinds from CRDs, ensuring they are not parsed into Meshery components.



---

🧠 Rationale

Kubernetes generates <resource>List types for listing resources, which do not represent actual resources.
Including them in Meshery’s component model is unnecessary and misaligns with Meshery’s intended functionality.


---

🔗 Linked Issue

https://github.com/meshery/meshery/issues/15337
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
