### PR TITLE
fix: skip meshery-integration-template model during registry generate

### DIFF
--- a/registry/model.go
+++ b/registry/model.go
@@ -839,7 +839,7 @@ func InvokeGenerationFromSheet(wg *sync.WaitGroup, path string, modelsheetID, co
 	// Iterate models from the spreadsheet
 	for _, model := range modelCSVHelper.Models {
 		if model.Model == "meshery-integration-template" {
-			log.Info("Skipping meshery-integration-template model")
+			log.Info("Skipping meshery-integration-template example model")
 			continue
 		}
 		if modelName != "" && modelName != model.Model {

--- a/registry/model.go
+++ b/registry/model.go
@@ -33,6 +33,8 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
+const mesheryIntegrationTemplateModel = "meshery-integration-template"
+
 var modelToCompGenerateTracker = store.NewGenericThreadSafeStore[compGenerateTracker]()
 
 type compGenerateTracker struct {
@@ -838,7 +840,7 @@ func InvokeGenerationFromSheet(wg *sync.WaitGroup, path string, modelsheetID, co
 	}()
 	// Iterate models from the spreadsheet
 	for _, model := range modelCSVHelper.Models {
-		if model.Model == "meshery-integration-template" {
+		if model.Model == mesheryIntegrationTemplateModel {
 			log.Info("Skipping meshery-integration-template example model")
 			continue
 		}

--- a/registry/model.go
+++ b/registry/model.go
@@ -838,7 +838,10 @@ func InvokeGenerationFromSheet(wg *sync.WaitGroup, path string, modelsheetID, co
 	}()
 	// Iterate models from the spreadsheet
 	for _, model := range modelCSVHelper.Models {
-
+		if model.Model == "meshery-integration-template" {
+			log.Info("Skipping meshery-integration-template model")
+			continue
+		}
 		if modelName != "" && modelName != model.Model {
 			continue
 		}


### PR DESCRIPTION
**Description**

This PR fixes #meshery/meshery#14702

- in Meshery Integrations SpreadSheet, `meshery-integration-template` row provides a example template with default values for new rows.
- This PR adds a simple condition to skip processing it as asked in the #meshery/meshery#14702


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
