### PR TITLE
chore: return internal endpoint (cluster ip) instead of external (host machine) in GetEndpointForPort

### DIFF
--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -132,7 +132,7 @@ func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return endpoint.External.String(), nil
+	return endpoint.Internal.String(), nil
 }
 
 func getImageVersionOfContainer(container v1.PodTemplateSpec, containerName string) string {


### PR DESCRIPTION
**Description**

Current version of GetEndpointForPort returns external endpoint which is <locathost>:<port>, which is not accessible within the meshery pod. 

The correct approach is to use meshery-broker service cluster ip, which is available from `endpoint.Internal`

here are screenshots with working buttons:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e616ba13-6ade-46a9-8bf5-03683d4d69f6" />

<img width="1904" height="934" alt="image" src="https://github.com/user-attachments/assets/90ddfc3b-8418-455f-8239-faae53cad513" />


<img width="1904" height="934" alt="image" src="https://github.com/user-attachments/assets/fb6c396c-1059-4be3-ad57-0d7bd9b195e9" />


I searched, looks like this connectivity api is the only place of usage, so we can update in meshkit.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
