### PR TITLE
Feat/connection definition registration logic

### DIFF
--- a/models/meshmodel/core/v1beta1/connection.go
+++ b/models/meshmodel/core/v1beta1/connection.go
@@ -1,0 +1,80 @@
+package v1beta1
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/meshkit/models/meshmodel/entity"
+	"github.com/meshery/schemas/models/v1beta1/connection"
+	v1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ConnectionDefinition represents a connection definition entity
+type ConnectionDefinition struct {
+	ID         uuid.UUID               `json:"-" gorm:"primarykey"`
+	Kind       string                  `json:"kind,omitempty" yaml:"kind"`
+	Version    string                  `json:"version,omitempty" yaml:"version"`
+	ModelID    uuid.UUID               `json:"-" gorm:"column:modelID"`
+	Model      v1beta1.ModelDefinition `json:"model"`
+	SubType    string                  `json:"subType" yaml:"subType"`
+	Connection connection.Connection   `json:"connection" yaml:"connection"`
+	CreatedAt  time.Time               `json:"-"`
+	UpdatedAt  time.Time               `json:"-"`
+}
+
+func (c ConnectionDefinition) GetID() uuid.UUID {
+	return c.ID
+}
+
+func (c *ConnectionDefinition) GenerateID() (uuid.UUID, error) {
+	return uuid.NewV4()
+}
+
+func (c ConnectionDefinition) Type() entity.EntityType {
+	return entity.ConnectionDefinition
+}
+
+func (c *ConnectionDefinition) GetEntityDetail() string {
+	return fmt.Sprintf("type: %s, definition version: %s, name: %s, model: %s, version: %s", c.Type(), c.Version, c.Kind, c.Model.Name, c.Model.Version)
+}
+
+func (c *ConnectionDefinition) Create(db *database.Handler, hostID uuid.UUID) (uuid.UUID, error) {
+	id, idErr := c.GenerateID()
+	if idErr != nil {
+		return uuid.UUID{}, idErr
+	}
+	c.ID = id
+
+	// Wrap both database operations in a transaction for atomicity
+	err := db.Transaction(func(tx *gorm.DB) error {
+		// Create a new handler for the transaction scope
+		txHandler := &database.Handler{DB: tx, Mutex: db.Mutex}
+
+		// Create the Model first
+		mid, txErr := c.Model.Create(txHandler, hostID)
+		if txErr != nil {
+			return txErr
+		}
+		c.ModelID = mid
+
+		// Create the ConnectionDefinition
+		if txErr := tx.Omit(clause.Associations).Create(&c).Error; txErr != nil {
+			return txErr
+		}
+		return nil
+	})
+
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return c.ID, nil
+}
+
+func (c *ConnectionDefinition) UpdateStatus(db *database.Handler, status entity.EntityStatus) error {
+	// TODO: Implement status update logic for connection definitions
+	return nil
+}

--- a/models/meshmodel/entity/types.go
+++ b/models/meshmodel/entity/types.go
@@ -13,6 +13,7 @@ const (
 	RelationshipDefinition EntityType = "relationship"
 	Model                  EntityType = "model"
 	Category               EntityType = "category"
+	ConnectionDefinition   EntityType = "connection"
 )
 
 // Each entity will have it's own Filter implementation via which it exposes the nobs and dials to fetch entities

--- a/models/registration/dir.go
+++ b/models/registration/dir.go
@@ -66,7 +66,7 @@ func processDir(dirPath string, pkg *PackagingUnit, regErrStore RegistrationErro
 	var tempDirs []string
 	defer func() {
 		for _, tempDir := range tempDirs {
-			os.RemoveAll(tempDir)
+			_ = os.RemoveAll(tempDir)
 		}
 	}()
 

--- a/models/registration/dir.go
+++ b/models/registration/dir.go
@@ -12,6 +12,7 @@ import (
 	meshkitFileUtils "github.com/meshery/meshkit/files"
 	"github.com/meshery/meshkit/utils"
 
+	corev1beta1 "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/model"
@@ -206,6 +207,18 @@ func processDir(dirPath string, pkg *PackagingUnit, regErrStore RegistrationErro
 				return nil
 			}
 			pkg.Relationships = append(pkg.Relationships, *rel)
+		case entity.ConnectionDefinition:
+			conn, err := utils.Cast[*corev1beta1.ConnectionDefinition](e)
+			if err != nil {
+				connectionName := ""
+				if conn != nil {
+					connectionName = conn.Kind
+				}
+				regErrStore.InsertEntityRegError("", "", entityType, connectionName, ErrGetEntity(err))
+				regErrStore.AddInvalidDefinition(path, ErrGetEntity(err))
+				return nil
+			}
+			pkg.Connections = append(pkg.Connections, *conn)
 		default:
 			// Unhandled entity type
 			return nil

--- a/models/registration/register.go
+++ b/models/registration/register.go
@@ -1,7 +1,7 @@
 package registration
 
 import (
-	"github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
+	corev1beta1 "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	meshmodel "github.com/meshery/meshkit/models/meshmodel/registry"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
@@ -15,7 +15,8 @@ type PackagingUnit struct {
 	Model         model.ModelDefinition
 	Components    []component.ComponentDefinition
 	Relationships []relationship.RelationshipDefinition
-	_             []v1beta1.PolicyDefinition
+	Connections   []corev1beta1.ConnectionDefinition
+	_             []corev1beta1.PolicyDefinition
 }
 
 type RegistrationHelper struct {
@@ -47,8 +48,8 @@ register will return an error if it is not able to register the `model`.
 If there are errors when registering other entities, they are handled properly but does not stop the registration process.
 */
 func (rh *RegistrationHelper) register(pkg PackagingUnit) {
-	if len(pkg.Components) == 0 && len(pkg.Relationships) == 0 {
-		//silently exit if the model does not conatin any components or relationships
+	if len(pkg.Components) == 0 && len(pkg.Relationships) == 0 && len(pkg.Connections) == 0 {
+		//silently exit if the model does not contain any components, relationships, or connections
 		return
 	}
 	ignored := model.ModelDefinitionStatusIgnored
@@ -100,9 +101,10 @@ func (rh *RegistrationHelper) register(pkg PackagingUnit) {
 
 	hostname := model.Registrant.Kind
 
-	// Prepare slices to hold successfully registered components and relationships
+	// Prepare slices to hold successfully registered components, relationships, and connections
 	var registeredComponents []component.ComponentDefinition
 	var registeredRelationships []relationship.RelationshipDefinition
+	var registeredConnections []corev1beta1.ConnectionDefinition
 	// 2. Register components
 	for _, comp := range pkg.Components {
 		status := *comp.Status
@@ -148,9 +150,23 @@ func (rh *RegistrationHelper) register(pkg PackagingUnit) {
 		}
 	}
 
-	// Update pkg with only successfully registered components and relationships
+	// 4. Register connections
+	for _, conn := range pkg.Connections {
+		conn.Model = model
+		_, _, err := rh.regManager.RegisterEntity(model.Registrant, &conn)
+		if err != nil {
+			err = ErrRegisterEntity(err, string(conn.Type()), conn.Kind)
+			rh.regErrStore.InsertEntityRegError(hostname, model.DisplayName, entity.ConnectionDefinition, conn.Kind, err)
+		} else {
+			// Successful registration, add to successfulConnections
+			registeredConnections = append(registeredConnections, conn)
+		}
+	}
+
+	// Update pkg with only successfully registered components, relationships, and connections
 	pkg.Components = registeredComponents
 	pkg.Relationships = registeredRelationships
+	pkg.Connections = registeredConnections
 	pkg.Model = model
 	// Store the successfully registered PackagingUnit
 	rh.PkgUnits = append(rh.PkgUnits, pkg)

--- a/models/registration/utils.go
+++ b/models/registration/utils.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 
 	"github.com/meshery/meshkit/encoding"
+	corev1beta1 "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/schemas/models/v1alpha3"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
-	"github.com/meshery/schemas/models/v1beta1"
+	schemav1beta1 "github.com/meshery/schemas/models/v1beta1"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/model"
 )
@@ -23,14 +24,14 @@ func getEntity(byt []byte) (et entity.Entity, _ error) {
 		return nil, ErrGetEntity(fmt.Errorf("Does not contain versionmeta"))
 	}
 	switch sv.SchemaVersion {
-	case v1beta1.ComponentSchemaVersion:
+	case schemav1beta1.ComponentSchemaVersion:
 		var compDef component.ComponentDefinition
 		err := encoding.Unmarshal(byt, &compDef)
 		if err != nil {
 			return nil, ErrGetEntity(fmt.Errorf("Invalid component definition: %s", err.Error()))
 		}
 		et = &compDef
-	case v1beta1.ModelSchemaVersion:
+	case schemav1beta1.ModelSchemaVersion:
 		var model model.ModelDefinition
 		err := encoding.Unmarshal(byt, &model)
 		if err != nil {
@@ -44,8 +45,15 @@ func getEntity(byt []byte) (et entity.Entity, _ error) {
 			return nil, ErrGetEntity(fmt.Errorf("Invalid relationship definition: %s", err.Error()))
 		}
 		et = &rel
+	case "connections.meshery.io/v1beta1":
+		var connDef corev1beta1.ConnectionDefinition
+		err := encoding.Unmarshal(byt, &connDef)
+		if err != nil {
+			return nil, ErrGetEntity(fmt.Errorf("invalid connection definition: %s", err.Error()))
+		}
+		et = &connDef
 	default:
-		return nil, ErrGetEntity(fmt.Errorf("Not a valid component definition, model definition, or relationship definition"))
+		return nil, ErrGetEntity(fmt.Errorf("not a valid component definition, model definition, relationship definition, or connection definition"))
 	}
 	return et, nil
 }

--- a/models/registration/utils.go
+++ b/models/registration/utils.go
@@ -21,28 +21,28 @@ func getEntity(byt []byte) (et entity.Entity, _ error) {
 	var sv schemaVersion
 	err := encoding.Unmarshal(byt, &sv)
 	if err != nil || sv.SchemaVersion == "" {
-		return nil, ErrGetEntity(fmt.Errorf("Does not contain versionmeta"))
+		return nil, ErrGetEntity(fmt.Errorf("does not contain versionmeta"))
 	}
 	switch sv.SchemaVersion {
 	case schemav1beta1.ComponentSchemaVersion:
 		var compDef component.ComponentDefinition
 		err := encoding.Unmarshal(byt, &compDef)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid component definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid component definition: %s", err.Error()))
 		}
 		et = &compDef
 	case schemav1beta1.ModelSchemaVersion:
 		var model model.ModelDefinition
 		err := encoding.Unmarshal(byt, &model)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid model definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid model definition: %s", err.Error()))
 		}
 		et = &model
 	case v1alpha3.RelationshipSchemaVersion:
 		var rel relationship.RelationshipDefinition
 		err := encoding.Unmarshal(byt, &rel)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid relationship definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid relationship definition: %s", err.Error()))
 		}
 		et = &rel
 	case "connections.meshery.io/v1beta1":


### PR DESCRIPTION
**Description**
This PR adds comprehensive registration logic and processing support for ConnectionDefinition entities in the MeshKit registry. It enables the registration, processing, and management of connection definitions alongside existing component and relationship definitions.

**This PR fixes #2080**

**Notes for Reviewers**

### 🎯 **What This PR Does**
This PR implements **Part 3** of the ConnectionDefinition support, focusing on registration logic and entity processing. It builds upon the core entity structure and database integration from previous PRs.

### 📁 **Files Modified**

#### **New Files:**
- `models/meshmodel/core/v1beta1/connection.go` - ConnectionDefinition struct and Entity interface implementation

#### **Modified Files:**
- `models/meshmodel/entity/types.go` - Added ConnectionDefinition entity type
- `models/registration/register.go` - Added connection registration logic to PackagingUnit and registration pipeline
- `models/registration/dir.go` - Added connection definition processing in directory walker
- `models/registration/utils.go` - Added connection definition unmarshaling support

### 🔧 **Key Features Implemented**

#### **1. Registration Pipeline Integration**
- Added `Connections []corev1beta1.ConnectionDefinition` to `PackagingUnit` struct
- Updated registration logic to include connection definitions in step 4
- Added proper error handling and success tracking for connection registrations
- Integrated with existing component and relationship registration patterns

#### **2. Entity Processing**
- Added connection definition case to the entity processing switch statement
- Implemented proper error handling for connection p