### PR TITLE
feat: Add ConnectionDefinition support to registration utilities

### DIFF
--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
-	models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
+	corev1beta1 "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
 	"github.com/meshery/schemas/models/v1beta1/category"
@@ -97,9 +97,10 @@ func NewRegistryManager(db *database.Handler) (*RegistryManager, error) {
 		&connection.Connection{},
 		&component.ComponentDefinition{},
 		&relationship.RelationshipDefinition{},
-		&models.PolicyDefinition{},
+		&corev1beta1.PolicyDefinition{},
 		&model.ModelDefinition{},
 		&category.CategoryDefinition{},
+		&corev1beta1.ConnectionDefinition{},
 	)
 	if err != nil {
 		return nil, err
@@ -173,8 +174,8 @@ func (rm *RegistryManager) GetRegistrant(e entity.Entity) connection.Connection 
 }
 
 // to be removed
-func (rm *RegistryManager) GetRegistrants(f *models.HostFilter) ([]models.MeshModelHostsWithEntitySummary, int64, error) {
-	var result []models.MesheryHostSummaryDB
+func (rm *RegistryManager) GetRegistrants(f *corev1beta1.HostFilter) ([]corev1beta1.MeshModelHostsWithEntitySummary, int64, error) {
+	var result []corev1beta1.MesheryHostSummaryDB
 	var totalConnectionsCount int64
 	db := rm.db
 
@@ -213,7 +214,7 @@ func (rm *RegistryManager) GetRegistrants(f *models.HostFilter) ([]models.MeshMo
 		return nil, 0, err
 	}
 
-	var response []models.MeshModelHostsWithEntitySummary
+	var response []corev1beta1.MeshModelHostsWithEntitySummary
 	nonRegistantCount := int64(0)
 	for _, r := range result {
 
@@ -222,9 +223,9 @@ func (rm *RegistryManager) GetRegistrants(f *models.HostFilter) ([]models.MeshMo
 			continue
 		}
 
-		res := models.MeshModelHostsWithEntitySummary{
+		res := corev1beta1.MeshModelHostsWithEntitySummary{
 			Connection: r.Connection,
-			Summary: models.EntitySummary{
+			Summary: corev1beta1.EntitySummary{
 				Models:        r.Models,
 				Components:    r.Components,
 				Relationships: r.Relationships,

--- a/models/registration/utils.go
+++ b/models/registration/utils.go
@@ -4,48 +4,56 @@ import (
 	"fmt"
 
 	"github.com/meshery/meshkit/encoding"
+	corev1beta1 "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/schemas/models/v1alpha3"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
-	"github.com/meshery/schemas/models/v1beta1"
+	schemav1beta1 "github.com/meshery/schemas/models/v1beta1"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/model"
 )
 
 // TODO: refactor this and use CUE
-func getEntity(byt []byte) (et entity.Entity, _ error) {
+func GetEntity(byt []byte) (et entity.Entity, _ error) {
 	type schemaVersion struct {
 		SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion"`
 	}
 	var sv schemaVersion
 	err := encoding.Unmarshal(byt, &sv)
 	if err != nil || sv.SchemaVersion == "" {
-		return nil, ErrGetEntity(fmt.Errorf("Does not contain versionmeta"))
+		return nil, ErrGetEntity(fmt.Errorf("does not contain versionmeta"))
 	}
 	switch sv.SchemaVersion {
-	case v1beta1.ComponentSchemaVersion:
+	case schemav1beta1.ComponentSchemaVersion:
 		var compDef component.ComponentDefinition
 		err := encoding.Unmarshal(byt, &compDef)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid component definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid component definition: %s", err.Error()))
 		}
 		et = &compDef
-	case v1beta1.ModelSchemaVersion:
+	case schemav1beta1.ModelSchemaVersion:
 		var model model.ModelDefinition
 		err := encoding.Unmarshal(byt, &model)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid model definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid model definition: %s", err.Error()))
 		}
 		et = &model
 	case v1alpha3.RelationshipSchemaVersion:
 		var rel relationship.RelationshipDefinition
 		err := encoding.Unmarshal(byt, &rel)
 		if err != nil {
-			return nil, ErrGetEntity(fmt.Errorf("Invalid relationship definition: %s", err.Error()))
+			return nil, ErrGetEntity(fmt.Errorf("invalid relationship definition: %s", err.Error()))
 		}
 		et = &rel
+	case "connections.meshery.io/v1beta1":
+		var connDef corev1beta1.ConnectionDefinition
+		err := encoding.Unmarshal(byt, &connDef)
+		if err != nil {
+			return nil, ErrGetEntity(fmt.Errorf("invalid connection definition: %s", err.Error()))
+		}
+		et = &connDef
 	default:
-		return nil, ErrGetEntity(fmt.Errorf("Not a valid component definition, model definition, or relationship definition"))
+		return nil, ErrGetEntity(fmt.Errorf("not a valid component definition, model definition, relationship definition, or connection definition"))
 	}
 	return et, nil
 }


### PR DESCRIPTION
This PR fixes the issue where ConnectionDefinition entities weren't being imported properly - they just got ignored during model import. I added the missing connections.meshery.io case to FindEntityType in utils/utils.go, which was the main blocker. Also made getEntity public as GetEntity in models/registration/utils.go for testing purposes. Updated PackagingUnit in models/registration/register.go to include connections and added the registration logic. Added connection file handling in directory processing in models/registration/dir.go. Finally, added connection support to the database schema in models/meshmodel/registry/registry.go.

I tested this with a sample ConnectionDefinition JSON and it works correctly - FindEntityType identifies it as a connection, GetEntity parses it properly, and the whole pipeline works end-to-end. Before this fix, connection definitions were being silently ignored during model import. Now the registry can handle all entity types: components, relationships, and connections.

related to https://github.com/meshery/meshkit/issues/762
Notes for Reviewers

[Signed commits](https://github.com/meshery/meshkit/pull/CONTRIBUTING.md)
 Yes, I signed my commits.