### PR TITLE
support ignored as valid status value in CSV input

### DIFF
--- a/registry/component.go
+++ b/registry/component.go
@@ -58,11 +58,18 @@ type ComponentCSV struct {
 // The Component Definition generated assumes or is only for components which have registrant as "meshery"
 func (c *ComponentCSV) CreateComponentDefinition(isModelPublished bool, defVersion string) (component.ComponentDefinition, error) {
 	status := entity.Enabled
+
+	if strings.HasSuffix(c.Component, "List") {
+		status = entity.Ignored
+	}
+
 	if c.Status != "" {
-		if utils.ReplaceSpacesAndConvertToLowercase(c.Status) == "false" {
+		normalized := utils.ReplaceSpacesAndConvertToLowercase(c.Status)
+		if normalized == "false" || normalized == "ignored" {
 			status = entity.Ignored
 		}
 	}
+
 	componentDefinition := &component.ComponentDefinition{
 		SchemaVersion: schmeaVersion.ComponentSchemaVersion,
 		DisplayName:   c.Component,

--- a/registry/component.go
+++ b/registry/component.go
@@ -101,11 +101,19 @@ var compStyleValues = []string{
 
 func (c *ComponentCSV) UpdateCompDefinition(compDef *component.ComponentDefinition) error {
 	status := entity.Enabled
+
+	if strings.HasSuffix(c.Component, "List") {
+		status = entity.Ignored
+	}
+
 	if c.Status != "" {
-		if utils.ReplaceSpacesAndConvertToLowercase(c.Status) == "false" {
+		normalized := utils.ReplaceSpacesAndConvertToLowercase(c.Status)
+		if normalized == "false" || normalized == "ignored" {
 			status = entity.Ignored
 		}
 	}
+	Log.Info(fmt.Sprintf("Component [%s]: Status from CSV = [%s], Final status = [%s]", c.Component, c.Status, status))
+
 	compDef.Status = (*component.ComponentDefinitionStatus)(&status)
 	var existingAddditionalProperties map[string]interface{}
 	if c.Description != "" {


### PR DESCRIPTION
**Description**

This PR fixes [#15337](https://github.com/meshery/meshery/issues/15337)

This PR updates the logic in component status assignment to also treat `"ignored"` as a valid value for ignoring components, in addition to the existing `"false"`.

- Previously, only `"false"` was treated as a signal to set component status to `Ignored`.
- Now, if the `Status` column in the CSV contains `"ignored"` or `"false"` , the component will be ignored during registry generation.

Component	           Status
DeploymentList	
Service                      ignored
Pod	                           false

All three components above will now be correctly treated as `Ignored`.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
