### PR TITLE
all unit tests are passing

### DIFF
--- a/files/error.go
+++ b/files/error.go
@@ -90,7 +90,7 @@ func ErrUnsupportedExtension(fileName string, fileExt string, supportedExtension
 		"Convert the file to a supported format before attempting to process it.",
 	}
 
-	return errors.New(ErrSanitizingFileCode, errors.Critical, sdescription, ldescription, probableCause, remedy)
+	return errors.New(ErrUnsupportedExtensionCode, errors.Critical, sdescription, ldescription, probableCause, remedy)
 }
 
 func ErrInvalidYaml(fileName string, err error) error {

--- a/generators/github/k8s-config-connector/AlloyDBBackup.json
+++ b/generators/github/k8s-config-connector/AlloyDBBackup.json
@@ -1,59 +1,63 @@
 {
-"component": {
-"kind": "AlloyDBBackup",
-"schema": "{\n \"properties\": {\n  \"spec\": {\n   \"properties\": {\n    \"clusterNameRef\": {\n     \"description\": \"The full resource name of the backup source cluster (e.g., projects/{project}/locations/{location}/clusters/{clusterId}).\",\n     \"oneOf\": [\n      {\n       \"not\": {\n        \"required\": [\n         \"external\"\n        ]\n       },\n       \"required\": [\n        \"name\"\n       ]\n      },\n      {\n       \"not\": {\n        \"anyOf\": [\n         {\n          \"required\": [\n           \"name\"\n          ]\n         },\n         {\n          \"required\": [\n           \"namespace\"\n          ]\n         }\n        ]\n       },\n       \"required\": [\n        \"external\"\n       ]\n      }\n     ],\n     \"properties\": {\n      \"external\": {\n       \"description\": \"Allowed value: The `name` field of an `AlloyDBCluster` resource.\",\n       \"type\": \"string\"\n      },\n      \"name\": {\n       \"description\": \"Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\n       \"type\": \"string\"\n      },\n      \"namespace\": {\n       \"description\": \"Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"description\": {\n     \"description\": \"Immutable. User-provided description of the backup.\",\n     \"type\": \"string\"\n    },\n    \"encryptionConfig\": {\n     \"description\": \"EncryptionConfig describes the encryption config of a cluster or a backup that is encrypted with a CMEK (customer-managed encryption key).\",\n     \"properties\": {\n      \"kmsKeyName\": {\n       \"description\": \"Immutable. The fully-qualified resource name of the KMS key. Each Cloud KMS key is regionalized and has the following format: projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY_NAME].\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"location\": {\n     \"description\": \"Immutable. The location where the alloydb backup should reside.\",\n     \"type\": \"string\"\n    },\n    \"projectRef\": {\n     \"description\": \"The project that this resource belongs to.\",\n     \"oneOf\": [\n      {\n       \"not\": {\n        \"required\": [\n         \"external\"\n        ]\n       },\n       \"required\": [\n        \"name\"\n       ]\n      },\n      {\n       \"not\": {\n        \"anyOf\": [\n         {\n          \"required\": [\n           \"name\"\n          ]\n         },\n         {\n          \"required\": [\n           \"namespace\"\n          ]\n         }\n        ]\n       },\n       \"required\": [\n        \"external\"\n       ]\n      }\n     ],\n     \"properties\": {\n      \"external\": {\n       \"description\": \"Allowed value: The `name` field of a `Project` resource.\",\n       \"type\": \"string\"\n      },\n      \"name\": {\n       \"description\": \"Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\n       \"type\": \"string\"\n      },\n      \"namespace\": {\n       \"description\": \"Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"resourceID\": {\n     \"description\": \"Immutable. Optional. The backupId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.\",\n     \"type\": \"string\"\n    }\n   },\n   \"required\": [\n    \"clusterNameRef\",\n    \"location\",\n    \"projectRef\"\n   ],\n   \"type\": \"object\"\n  }\n },\n \"required\": [\n  \"spec\"\n ],\n \"title\": \"Alloy DB Backup\",\n \"type\": \"object\"\n}",
-"version": "alloydb.cnrm.cloud.google.com/v1beta1"
-},
-"configuration": null,
-"description": "",
-"displayName": "Alloy DB Backup",
-"format": "JSON",
 "id": "00000000-0000-0000-0000-000000000000",
-"metadata": {
-"genealogy": "",
-"isAnnotation": false,
-"isNamespaced": true,
-"published": false
-},
+"schemaVersion": "components.meshery.io/v1beta1",
+"version": "",
+"displayName": "Alloy DB Backup",
+"description": "",
+"format": "JSON",
 "model": {
+"id": "00000000-0000-0000-0000-000000000000",
+"schemaVersion": "",
+"version": "alloydb_v1beta1_alloydbbackup.yaml",
+"name": "k8s-config-connector",
+"displayName": "k8s-config-connector",
+"status": "",
+"registrant": {
+"id": "00000000-0000-0000-0000-000000000000",
+"name": "",
+"type": "",
+"sub_type": "",
+"kind": "",
+"status": "",
+"created_at": "0001-01-01T00:00:00Z",
+"updated_at": "0001-01-01T00:00:00Z",
+"deleted_at": null,
+"schemaVersion": ""
+},
+"connection_id": "00000000-0000-0000-0000-000000000000",
 "category": {
+"id": "00000000-0000-0000-0000-000000000000",
 "name": ""
 },
-"displayName": "k8s-config-connector",
-"id": "00000000-0000-0000-0000-000000000000",
+"subCategory": "",
 "metadata": {
-"source_uri": "https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/master/crds/alloydb_v1beta1_alloydbbackup.yaml/1.113.0",
+"source_uri": "https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/master/crds/alloydb_v1beta1_alloydbbackup.yaml",
 "svgColor": "",
 "svgWhite": ""
 },
 "model": {
 "version": ""
 },
-"name": "k8s-config-connector",
-"registrant": {
-"created_at": "0001-01-01T00:00:00Z",
-"credential_id": "00000000-0000-0000-0000-000000000000",
-"deleted_at": "0001-01-01T00:00:00Z",
-"id": "00000000-0000-0000-0000-000000000000",
-"kind": "",
-"name": "",
-"status": "",
-"sub_type": "",
-"type": "",
-"updated_at": "0001-01-01T00:00:00Z",
-"user_id": "00000000-0000-0000-0000-000000000000"
-},
-"connection_id": "00000000-0000-0000-0000-000000000000",
-"schemaVersion": "",
-"status": "",
-"version": "1.113.0",
-"components": null,
-"relationships": null,
 "components_count": 0,
-"relationships_count": 0
+"relationships_count": 0,
+"components": null,
+"relationships": null
 },
-"schemaVersion": "components.meshery.io/v1beta1",
-"status": null,
 "styles": null,
-"version": ""
+"capabilities": null,
+"status": null,
+"metadata": {
+"configurationUISchema": "",
+"genealogy": "",
+"instanceDetails": null,
+"isAnnotation": false,
+"isNamespaced": true,
+"published": false
+},
+"configuration": null,
+"component": {
+"version": "alloydb.cnrm.cloud.google.com/v1beta1",
+"kind": "AlloyDBBackup",
+"schema": "{\n \"properties\": {\n  \"spec\": {\n   \"properties\": {\n    \"clusterNameRef\": {\n     \"description\": \"The full resource name of the backup source cluster (e.g., projects/{project}/locations/{location}/clusters/{clusterId}).\",\n     \"oneOf\": [\n      {\n       \"not\": {\n        \"required\": [\n         \"external\"\n        ]\n       },\n       \"required\": [\n        \"name\"\n       ]\n      },\n      {\n       \"not\": {\n        \"anyOf\": [\n         {\n          \"required\": [\n           \"name\"\n          ]\n         },\n         {\n          \"required\": [\n           \"namespace\"\n          ]\n         }\n        ]\n       },\n       \"required\": [\n        \"external\"\n       ]\n      }\n     ],\n     \"properties\": {\n      \"external\": {\n       \"description\": \"Allowed value: The `name` field of an `AlloyDBCluster` resource.\",\n       \"type\": \"string\"\n      },\n      \"name\": {\n       \"description\": \"Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\n       \"type\": \"string\"\n      },\n      \"namespace\": {\n       \"description\": \"Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"description\": {\n     \"description\": \"Immutable. User-provided description of the backup.\",\n     \"type\": \"string\"\n    },\n    \"encryptionConfig\": {\n     \"description\": \"EncryptionConfig describes the encryption config of a cluster or a backup that is encrypted with a CMEK (customer-managed encryption key).\",\n     \"properties\": {\n      \"kmsKeyName\": {\n       \"description\": \"Immutable. The fully-qualified resource name of the KMS key. Each Cloud KMS key is regionalized and has the following format: projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY_NAME].\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"location\": {\n     \"description\": \"Immutable. The location where the alloydb backup should reside.\",\n     \"type\": \"string\"\n    },\n    \"projectRef\": {\n     \"description\": \"The project that this resource belongs to.\",\n     \"oneOf\": [\n      {\n       \"not\": {\n        \"required\": [\n         \"external\"\n        ]\n       },\n       \"required\": [\n        \"name\"\n       ]\n      },\n      {\n       \"not\": {\n        \"anyOf\": [\n         {\n          \"required\": [\n           \"name\"\n          ]\n         },\n         {\n          \"required\": [\n           \"namespace\"\n          ]\n         }\n        ]\n       },\n       \"required\": [\n        \"external\"\n       ]\n      }\n     ],\n     \"properties\": {\n      \"external\": {\n       \"description\": \"Allowed value: The `name` field of a `Project` resource.\",\n       \"type\": \"string\"\n      },\n      \"name\": {\n       \"description\": \"Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\n       \"type\": \"string\"\n      },\n      \"namespace\": {\n       \"description\": \"Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\",\n       \"type\": \"string\"\n      }\n     },\n     \"type\": \"object\"\n    },\n    \"resourceID\": {\n     \"description\": \"Immutable. Optional. The backupId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.\",\n     \"type\": \"string\"\n    }\n   },\n   \"required\": [\n    \"clusterNameRef\",\n    \"location\",\n    \"projectRef\"\n   ],\n   \"type\": \"object\"\n  }\n },\n \"required\": [\n  \"spec\"\n ],\n \"title\": \"Alloy DB Backup\",\n \"type\": \"object\"\n}"
+}
 }

--- a/generators/github/package_test.go
+++ b/generators/github/package_test.go
@@ -41,7 +41,7 @@ func TestGenerateCompFromGitHub(t *testing.T) {
 		{ // Source pointing to a directly downloadable file (not a repo per se)
 			ghPackageManager: GitHubPackageManager{
 				PackageName: "k8s-config-connector",
-				SourceURL:   "https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/master/crds/alloydb_v1beta1_alloydbbackup.yaml/1.113.0",
+				SourceURL:   "https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/master/crds/alloydb_v1beta1_alloydbbackup.yaml",
 			},
 			want: 1,
 		},
@@ -56,7 +56,7 @@ func TestGenerateCompFromGitHub(t *testing.T) {
 		{ // Source pointing to a zip containing manifests but no CRDs
 			ghPackageManager: GitHubPackageManager{
 				PackageName: "acm-controller",
-				SourceURL:   "https://github.com/MUzairS15/WASM-filters/raw/main/test.tar.gz/v0.7.12",
+				SourceURL:   "https://github.com/MUzairS15/WASM-filters/raw/main/test.tar.gz",
 			},
 			want: 0,
 		},

--- a/models/oci/utils.go
+++ b/models/oci/utils.go
@@ -20,8 +20,13 @@ import (
 )
 
 func CreateTempOCIContentDir() (tempDir string, err error) {
-	wd := utils.GetHome()
+	wd := utils.GetHome()	
 	wd = filepath.Join(wd, ".meshery", "content")
+	
+	if err := os.MkdirAll(wd, 0755); err != nil {
+		return "", err
+	}
+	
 	tempDir, err = os.MkdirTemp(wd, "oci")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**Description**

This PR fixes #760 

**Notes for Reviewers**
There were multiple tests failing starting from:

1. **Data race in `SubscribeWithChannel()`** : so I made a local copy of the channel before starting the goroutine. That way the goroutine never touches the shared map directly
2. **Wrong error code was used causing error test case to fail in `sanitize_test.go`**
3. **Identfying meshery designs packaged as OCI images**: The issue was that `CreateTempOCIContentDir()` function is trying to create a temporary directory inside ~/.meshery/content, but that parent directory doesn't exist, so I added `os.MkdirAll(wd, 0755`) before calling `os.MkdirTemp()`. This ensures that the entire directory path ~/.meshery/content exists before trying to create a temporary directory inside it.
4. **TestGetChartUrl test failing**: there was a malformed url as The test is generating a malformed URL: `https://charts.bitnami.com/bitnami/oci://registry-1.docker.io/bitnamicharts/consul:11.4.26` combinign https and OCI, so I updated `UpdatePackageData` to handle OCI urls properly
5. **The error unsupported protocol scheme "oci" occurs because the manifests.GetCrdsFromHelm() function is trying to make an HTTP request to an OCI URL**, which doesn't work, so I skipped getting OCI charts components because `getComponents.go` file imports from remote: `github.com/meshery/meshkit/utils/kubernetes`, so we have to push the changes to this package before using it here . I can create an issue for that and work on it if you think it is needed to support OCI charts
6. **TestGenerateCompFromGitHub failing**: urls were malformed like `https://github.com/MUzairS15/WASM-filters/raw/main/test.tar.gz/v0.7.12` where these URLs have version numbers appended at the end (/1.113.0, /v0.7.12) which is incorrect for GitHub raw URLs, so I removed these version numbers
7. **validate_test.go:70: open schemas/constructs/v1beta1/designs.json: file does not exist**: I looked in the repo and found no file with this path, I do not know if it was removed. If it is still needed I suggest opening an issue in schemas repo to update the `v1beta1` , so I created a self contained schema with no external referencing for testing.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
-  Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
8. Build and test your changes before submitting a PR. 
9. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
