### PR TITLE
chore: GetEndpointForPort: check external endpoint first and then check internal

### DIFF
--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -134,17 +134,13 @@ func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
 		return "", ErrGetControllerEndpointForPort(err)
 	}
 
-	// Try external endpoint first if available
-	if endpoint.External != nil && endpoint.External.Address != "" {
-		if utils.TcpCheck(endpoint.External, nil) {
-			return endpoint.External.String(), nil
-		}
-	}
-
-	// Fallback to internal endpoint
-	if endpoint.Internal != nil && endpoint.Internal.Address != "" {
-		if utils.TcpCheck(endpoint.Internal, nil) {
-			return endpoint.Internal.String(), nil
+	// Try endpoints in order of preference: external first, then internal
+	endpoints := []*utils.HostPort{endpoint.External, endpoint.Internal}
+	for _, ep := range endpoints {
+		if ep != nil && ep.Address != "" {
+			if utils.TcpCheck(ep, nil) {
+				return ep.String(), nil
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description**

This PR fixes improves required to make connectivity buttons work. 

As with this pr: https://github.com/meshery/meshkit/pull/770 when we switched to internal endpoint it makes monitoring port be reachable for in-cluster scenario, but out of a cluster it still requires external endpoint.
 
The flow is to check external endpoint and then internal, as most clusters are out of clusters and hence need to use external endpoint :white_check_mark: 

**Notes for Reviewers**

<img width="1882" height="1046" alt="screen-0011" src="https://github.com/user-attachments/assets/d142d7f7-5c4a-4f1a-a1ce-d8ab4cb966ca" />

Working for in-cluster :white_check_mark:  (all 4 green) :white_check_mark: 

----

<img width="1882" height="1046" alt="Screenshot From 2025-08-23 17-43-26" src="https://github.com/user-attachments/assets/40f913b9-3f3e-4c21-b28e-2016391e34bf" />

Working for out of cluster (meshsync green) :white_check_mark: 

- meshsync connectivity check green for out of cluster :white_check_mark: 
- broker is red, but it is correct behavior (from the perspective of connectivity check), because meshery is not connected to broker (independent issue).


The code for both connectibvity checks goes through the same flow, call <nats>:8222/connz and check the response. For meshsync it checks that meshsync is connected  to broker, for broker that meshery is connected to broker.  Example of response from broker connz endpoint for this particular case:
<details>
{
  "server_id": "NAJHPBN37UW4AJNM2FM3QHE653JSJVC3JKZKSZ6WP3IZKU6UGYTHDOIL",
  "now": "2025-08-23T15:41:08.051207846Z",
  "num_connections": 1,
  "total": 1,
  "offset": 0,
  "limit": 1024,
  "connections": [
    {
      "cid": 8,
      "kind": "Client",
      "type": "nats",
      "ip": "192.168.42.135",
      "port": 52988,
      "start": "2025-08-23T15:40:22.333635339Z",
      "last_activity": "2025-08-23T15:40:27.481666285Z",
      "rtt": "1.431811ms",
      "uptime": "45s",
      "idle": "40s",
      "pending_bytes": 0,
      "in_msgs": 395,
      "out_msgs": 0,
      "in_bytes": 1018899,
      "out_bytes": 0,
      "subscriptions": 1,
      "name": "meshsync",
      "lang": "go",
      "version": "1.38.0"
    }
  ]
}

</details>
Hence screenshot above confirms that endpoint is reachable for meshsync. 

Current pr actually needs this https://github.com/meshery/meshkit/pull/792  because without #792 deployment of operator to standalone cluster is not working properly :cry: 

TODO:
Separately need to figure out why meshery is not able to connect to broker. 

Also looks like operator ping always returns green :slightly_smiling_face: .


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
