### PR TITLE
fix: temp comment out key data and cert data propagation from rest config

### DIFF
--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -436,23 +436,31 @@ func createHelmActionConfig(c *Client, cfg ApplyHelmChartConfig) (*action.Config
 		}
 	}
 
-	// Set client certificate data if available
-	if len(c.RestConfig.CertData) > 0 {
-		certFileName, err := setDataAndReturnFilename(c.RestConfig.CertData)
-		if err != nil {
-			return nil, err
-		}
-		kubeConfig.CertFile = &certFileName
-	}
+	// TODO:
+	// during `mesheryctl start -p kubernetes` this block causes error:
+	// [client-cert-data and client-cert are both specified for [cluster-name] client-cert-data will override., client-key-data and client-key are both specified for [cluster-name]; client-key-data will override]
+	// but this block is necessary to deploy out of cluster operator
+	// figure out the issue and uncomment if necessary
+	// --
+	// // Set client certificate data if available
+	// if len(c.RestConfig.CertData) > 0 {
+	// 	certFileName, err := setDataAndReturnFilename(c.RestConfig.CertData)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	kubeConfig.CertFile = &certFileName
+	// }
 
-	// Set client key data if available
-	if len(c.RestConfig.KeyData) > 0 {
-		keyFileName, err := setDataAndReturnFilename(c.RestConfig.KeyData)
-		if err != nil {
-			return nil, err
-		}
-		kubeConfig.KeyFile = &keyFileName
-	}
+	// TODO: same as above
+	// --
+	// // Set client key data if available
+	// if len(c.RestConfig.KeyData) > 0 {
+	// 	keyFileName, err := setDataAndReturnFilename(c.RestConfig.KeyData)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	kubeConfig.KeyFile = &keyFileName
+	// }
 
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(kubeConfig, cfg.Namespace, string(cfg.HelmDriver), cfg.Logger); err != nil {
@@ -468,13 +476,13 @@ func setDataAndReturnFilename(data []byte) (string, error) {
 		return "", err
 	}
 	defer f.Close() // Close file immediately after writing
-	
+
 	_, err = f.Write(data)
 	if err != nil {
 		os.Remove(f.Name()) // Clean up on write error
 		return "", err
 	}
-	
+
 	return f.Name(), nil
 }
 


### PR DESCRIPTION
**Description**

This is a regression from https://github.com/meshery/meshkit/pull/792 

when run `mesheryctl system start -p kubernetes` it fails with 

```sh
[client-cert-data and client-cert are both specified for [cluster-name] client-cert-data will override., client-key-data and client-key are both specified for [cluster-name]; client-key-data will override]
```

Looks like somewhere further in code, the client-cert-data is populated from local kubeconfig. I have temporally commented out this code block, but we also need it for out-of-cluster operator deployment. 
I will need to debug further and come up with a solution which works for both cases. 

<img width="1211" height="196" alt="image" src="https://github.com/user-attachments/assets/f8f3fd59-ffb7-4568-bf85-58a12b159ef4" />



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
