### PR TITLE
ci: github workflow update version of go to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@master
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@master
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
           cache-dependency-path: go.sum
       - name: go mod tidy
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
           cache-dependency-path: go.sum
       - name: test

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run utility
         run: |


### PR DESCRIPTION
**Description**

This PR fixes ci pipelines. 

**Notes for Reviewers**

We have go 1.24 in go.mod and with that pipelines:
- https://github.com/meshery/meshkit/actions/runs/17325135417/job/49187199800
- https://github.com/meshery/meshkit/actions/runs/17325135384/job/49187199746

are failing with 

```sh
Run go run github.com/meshery/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

and 
```sh
go mod tidy
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
make: *** [Makefile:14: tidy] Error 1
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
