### PR TITLE
chore: do not use local kubeconfig when apply helm chart

### DIFF
--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -443,7 +443,7 @@ func createHelmActionConfig(c *Client, cfg ApplyHelmChartConfig) (*action.Config
 	}
 
 	// Set client certificate data if available
-	if len(c.RestConfig.TLSClientConfig.CertData) > 0 {
+	if len(c.RestConfig.CertData) > 0 {
 		certFileName, err := setDataAndReturnFilename(c.RestConfig.CertData)
 		if err != nil {
 			return nil, err
@@ -452,7 +452,7 @@ func createHelmActionConfig(c *Client, cfg ApplyHelmChartConfig) (*action.Config
 	}
 
 	// Set client key data if available
-	if len(c.RestConfig.TLSClientConfig.KeyData) > 0 {
+	if len(c.RestConfig.KeyData) > 0 {
 		keyFileName, err := setDataAndReturnFilename(c.RestConfig.KeyData)
 		if err != nil {
 			return nil, err

--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -421,7 +421,7 @@ func createHelmActionConfig(c *Client, cfg ApplyHelmChartConfig) (*action.Config
 	kubeConfig.KubeConfig = &devNull
 	kubeConfig.APIServer = &c.RestConfig.Host
 	kubeConfig.BearerToken = &c.RestConfig.BearerToken
-	kubeConfig.Insecure = &c.RestConfig.TLSClientConfig.Insecure
+	kubeConfig.Insecure = &c.RestConfig.Insecure
 
 	// Set username and password for basic auth if available
 	if c.RestConfig.Username != "" {
@@ -432,7 +432,7 @@ func createHelmActionConfig(c *Client, cfg ApplyHelmChartConfig) (*action.Config
 	}
 
 	// Only set CA file if not running in insecure mode
-	if !c.RestConfig.TLSClientConfig.Insecure {
+	if !c.RestConfig.Insecure {
 		if len(c.RestConfig.CAData) > 0 {
 			caFileName, err := setDataAndReturnFilename(c.RestConfig.CAData)
 			if err != nil {


### PR DESCRIPTION
## Story

In this pr https://github.com/meshery/meshkit/pull/797 we temporally commented out propagation of cert data and key data to kubernetes client to apply helm. 

This was done to solve the issue with both data field and file field present in kube client configuration (check pr above for details). 

But we need this propagation for out-of-cluster operator deployment. 

The issue is that in [ConfigFlags](https://github.com/kubernetes/cli-runtime/blob/master/pkg/genericclioptions/config_flags.go#L81)  we can only specify CAFile, KeyFile (so only file fields). 

When it converts itelf to RestConfig later on ([line 172](https://github.com/kubernetes/cli-runtime/blob/master/pkg/genericclioptions/config_flags.go#L172)  it only overrides file property. 

## Problem

When ConfigFlags conversion to RESTconfig happens, it reads values from local kube config file and merge them. But overrides only cert-file, key-file property. 
Hence it pick ups cert-data, key-data properties from local kubeconfig. And this leads to an error like `[client-cert-data and client-cert are both specified for [cluster-name] client-cert-data will override., client-key-data and client-key are both specified for [cluster-name]; client-key-data will override]` 

## Solution

Set KubeConfig property to /dev/null disabling read from local kubeconfig only using values from provided override. 
 
 
**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
