### PR TITLE
#769 issue updated and comment is errased

### DIFF
--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
+	"github.com/sirupsen/logrus"
 )
 
 type ChannelBrokerHandler struct {
@@ -35,7 +36,7 @@ func NewChannelBrokerHandler(optsSetters ...OptionsSetter) *ChannelBrokerHandler
 		var err error
 		log, err = logger.New("channel-broker", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: 4, // Info level
+			LogLevel: int(logrus.InfoLevel),
 		})
 		if err != nil {
 			// Fallback to a simple logger if creation fails

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	nats "github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -98,7 +99,7 @@ func New(opts Options) (broker.Handler, error) {
 		var lerr error
 		lg, lerr = logger.New("nats-handler", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: 4, // Info
+			LogLevel: int(logrus.InfoLevel),
 		})
 		if lerr != nil {
 			// fallback to nil; we'll use std log where necessary


### PR DESCRIPTION
This PR fixes #769.

This change replaces hardcoded integer values for log levels in the broker/nats and broker/channel packages with the appropriate logrus.InfoLevel constant. This improves code readability and maintainability.

Notes for Reviewers:

This is a straightforward refactoring to remove magic numbers and align with the logger's intended usage. No functional changes are introduced.



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
