### PR TITLE
resolved #769 and comments are removed

### DIFF
--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
+	"github.com/sirupsen/logrus"
 )
 
 type ChannelBrokerHandler struct {
@@ -35,7 +36,7 @@ func NewChannelBrokerHandler(optsSetters ...OptionsSetter) *ChannelBrokerHandler
 		var err error
 		log, err = logger.New("channel-broker", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: 4, // Info level
+			LogLevel: int(logrus.InfoLevel), // Info level=4
 		})
 		if err != nil {
 			// Fallback to a simple logger if creation fails

--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -36,7 +36,7 @@ func NewChannelBrokerHandler(optsSetters ...OptionsSetter) *ChannelBrokerHandler
 		var err error
 		log, err = logger.New("channel-broker", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: int(logrus.InfoLevel), // Info level=4
+			LogLevel: int(logrus.InfoLevel),
 		})
 		if err != nil {
 			// Fallback to a simple logger if creation fails

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -99,7 +99,7 @@ func New(opts Options) (broker.Handler, error) {
 		var lerr error
 		lg, lerr = logger.New("nats-handler", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: int(logrus.InfoLevel), // InfoLevel=4
+			LogLevel: int(logrus.InfoLevel),
 		})
 		if lerr != nil {
 			// fallback to nil; we'll use std log where necessary

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	nats "github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -98,7 +99,7 @@ func New(opts Options) (broker.Handler, error) {
 		var lerr error
 		lg, lerr = logger.New("nats-handler", logger.Options{
 			Format:   logger.TerminalLogFormat,
-			LogLevel: 4, // Info
+			LogLevel: int(logrus.InfoLevel), // InfoLevel=4
 		})
 		if lerr != nil {
 			// fallback to nil; we'll use std log where necessary


### PR DESCRIPTION
Description
This PR resolves issue #796 by replacing a hardcoded "magic number" for the log level with a descriptive constant from the Logrus library. The main goal is to improve code readability and maintainability.

Notes for Reviewers
Purpose of this PR
This PR resolves issue #796. The change replaces the integer 4 with the named constant logrus.InfoLevel. The main goal is to improve code readability and maintainability.

And as per your command comments are removed ,apologise for being inconvenient.

How was this addressed?
Modified broker/nats.go and broker/channel.go. Replaced the integer 4 with the named constant logrus.InfoLevel. Added the logrus import where necessary.

How to test?
This is a code quality refactor, and existing behavior is unchanged.

Run the unit tests for the broker package to ensure all tests still pass.

Visually inspect the changed lines in nats.go and channel.go to confirm the constant is being used.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.