### PR TITLE
[dependencies] chore: use meshery/meshery-operator instead of layer5io/meshery-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.35.0
-	github.com/layer5io/meshery-operator v0.8.1
+	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/schemas v0.8.34
 	github.com/nats-io/nats.go v1.38.0
 	github.com/open-policy-agent/opa v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,6 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/layer5io/meshery-operator v0.8.1 h1:AP6BTQ8fi5re4+o71vJ3NoQBuwfn+33EIYjabHU0Kxg=
-github.com/layer5io/meshery-operator v0.8.1/go.mod h1:Wi9ODHppoq8ODtzdfiplWYJXYpqsHOJfkJyTMQeNXk4=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -378,6 +376,8 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
+github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
 github.com/meshery/schemas v0.8.34 h1:RiD5JWWQE92d8nkEWy7Lt0guZRAG3XQstX07spfPw7w=
 github.com/meshery/schemas v0.8.34/go.mod h1:6BxRPapEnbH4ATuneUVLb7lOAWSdr8gyvNp1zAgmyKA=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=

--- a/models/controllers/helpers.go
+++ b/models/controllers/helpers.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/layer5io/meshery-operator/api/v1alpha1"
+	"github.com/meshery/meshery-operator/api/v1alpha1"
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 )

--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	opClient "github.com/layer5io/meshery-operator/pkg/client"
+	opClient "github.com/meshery/meshery-operator/pkg/client"
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	v1 "k8s.io/api/core/v1"

--- a/models/controllers/meshsync.go
+++ b/models/controllers/meshsync.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"context"
 
-	opClient "github.com/layer5io/meshery-operator/pkg/client"
+	opClient "github.com/meshery/meshery-operator/pkg/client"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	v1 "k8s.io/api/core/v1"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION


**Description**

This PR fixes updates to use meshery-operator from meshery project.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
