### PR TITLE
fix: skip artifacthub packages with empty chart URLs

### DIFF
--- a/generators/artifacthub/package.go
+++ b/generators/artifacthub/package.go
@@ -51,6 +51,7 @@ func (pkg AhPackage) GenerateComponents(group string) ([]_component.ComponentDef
 	// TODO: Move this to the configuration
 
 	if pkg.ChartUrl == "" {
+		fmt.Printf("WARN: Skipping package %q due to empty chart URL\n", pkg.Name)
 		return components, nil
 	}
 	if strings.HasPrefix(pkg.ChartUrl, "oci://") {


### PR DESCRIPTION
**Description**

This PR modifies the ArtifactHub generator to gracefully handle packages that have missing or empty content_url (Chart URL) fields in the upstream registry. Instead of returning a fatal ErrChartUrlEmpty error—which clutters the logs with upstream data issues—the generator now returns nil components and nil error. This allows the generator to skip invalid packages silently without failing the generation process.

This PR fixes #844 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
