### PR TITLE
Add CI-specific GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -1,0 +1,28 @@
+---
+name: 🛠 Continuous Integration / DevOps
+about: Improve or update workflows or other automation
+title: '[CI]'
+labels: 'area/ci, area/devops, github_actions'
+assignees: ''
+---
+### Current Behavior
+<!-- A brief description of what the problem is. (e.g. I need to be able to...) -->
+
+### Desired Behavior
+<!-- A brief description of what you expected to happen. -->
+
+### Implementation
+<!-- Specifics on the approach to fulfilling the feature request. -->
+
+### Acceptance Tests
+<!-- Stipulations of functional behavior or non-functional items that must be in-place in order for the issue to be closed. -->
+
+---
+### Contributor [Guides](https://docs.meshery.io/project/contributing) and [Handbook](https://meshery.io/community#handbook)
+- 🛠 [Meshery Build & Release Strategy](https://docs.meshery.io/project/contributing/build-and-release)
+- 📚 [Instructions for contributing to documentation](https://docs.meshery.io/project/contributing/contributing-docs)
+- Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
+- 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
+- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
+- 🧪 [Meshery Test Plan Spreadsheet](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit#gid=0)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)


### PR DESCRIPTION
**Description**
This PR adds a CI-specific GitHub issue template to the MeshKit repository by copying the ci.md file from the main Meshery repository.
Notes:

The template is added at .github/ISSUE_TEMPLATE/ci.md.
No modifications were made to the original content.

This PR fixes #849 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
