### PR TITLE
fix: prevent duplicate PR entries in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'MeshKit v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+no-duplicate-categories: true 
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
…d PR entries

**Description**

This PR fixes #851

**Notes for Reviewers**
This PR adds `no-duplicate-categories: true` to the release-drafter configuration (.github/release-drafter.yml).

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
