### PR TITLE
[logger] feat: Add helper functions for logrus level Fatal

### DIFF
--- a/logger/caller_hook_test.go
+++ b/logger/caller_hook_test.go
@@ -195,7 +195,6 @@ func TestCallerHook_DifferentLogLevels(t *testing.T) {
 		{"Infof", func(l Handler) { l.Infof("formatted %s message", "info") }, true},
 		{"Debug", func(l Handler) { l.Debug("debug message") }, false}, // Debug level will be filtered out
 		{"Warn", func(l Handler) { l.Warnf("warn message") }, true},
-		{"Fatalf", func(l Handler) { l.Fatalf("formatted %s message", "fatal") }, true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**Description**

This PR helps with migrating mesheryctl logging from logrus -> meshkit logger  
meshery/meshery#4705
meshery/meshery#6309

**Notes for Reviewers**
Currently have opened PR for refactoring logging in `mesheryctl`  
meshery/meshery/pull/16819  

Test Results:
```
yorisoft@kubuntu:~/meshkit$ go test -v ./logger/... 
=== RUN   TestCallerHook_WithMeshkitLogger 
=== RUN   TestCallerHook_WithMeshkitLogger/caller_hook_populates_caller_info_with_JSON_format === RUN   TestCallerHook_WithMeshkitLogger/caller_hook_populates_caller_info_with_terminal_format 
=== RUN   TestCallerHook_WithMeshkitLogger/caller_hook_disabled_does_not_add_caller_info 
--- PASS: TestCallerHook_WithMeshkitLogger (0.00s) 
    --- PASS: TestCallerHook_WithMeshkitLogger/caller_hook_populates_caller_info_with_JSON_format (0.00s) 
    --- PASS: TestCallerHook_WithMeshkitLogger/caller_hook_populates_caller_info_with_terminal_format (0.00s) 
    --- PASS: TestCallerHook_WithMeshkitLogger/caller_hook_disabled_does_not_add_caller_info (0.00s) 
=== RUN   TestCallerHook_NestedCalls 
=== RUN   TestCallerHook_NestedCalls/caller_hook_detects_correct_caller_through_nested_function_calls 
--- PASS: TestCallerHook_NestedCalls (0.00s) 
    --- PASS: TestCallerHook_NestedCalls/caller_hook_detects_correct_caller_through_nested_function_calls (0.00s) === RUN   TestCallerHook_DifferentLogLevels 
=== RUN   TestCallerHook_DifferentLogLevels/Info 
=== RUN   TestCallerHook_DifferentLogLevels/Infof 
=== RUN   TestCallerHook_DifferentLogLevels/Debug 
=== RUN   TestCallerHook_DifferentLogLevels/Warn 
=== RUN   TestCallerHook_DifferentLogLevels/Fatalf 
--- PASS: TestCallerHook_DifferentLogLevels (0.00s) 
    --- PASS: TestCallerHook_DifferentLogLevels/Info (0.00s) 
    --- PASS: TestCallerHook_DifferentLogLevels/Infof (0.00s) 
    --- PASS: TestCallerHook_DifferentLogLevels/Debug (0.00s) 
    --- PASS: TestCallerHook_DifferentLogLevels/Warn (0.00s) 
    --- PASS: TestCallerHook_DifferentLogLevels/Fatalf (0.00s) 
=== RUN   TestShouldSkipFrame 
    caller_hook_test.go:267: shouldSkipFrame works correctly for test functions 
--- PASS: TestShouldSkipFrame (0.00s) 
=== RUN   TestCallerHook_Levels 
--- PASS: TestCallerHook_Levels (0.00s) 
=== RUN   TestSetDefaultCallerSkippedPaths 
--- PASS: TestSetDefaultCallerSkippedPaths (0.00s) 
PASS 
ok      github.com/meshery/meshkit/logger       (cached) yorisoft@kubuntu:~/meshkit$
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
