### PR TITLE
fix(tracing): disable tracing when no collector is configured

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -25,6 +25,9 @@ type Config struct {
 	Endpoint string `yaml:"endpoint" json:"endpoint"`
 	// Insecure determines whether to use an insecure connection (no TLS)
 	Insecure bool `yaml:"insecure" json:"insecure"`
+	// Adding extra flag to check if tracing is enabled
+	Enabled *bool `yaml:"enabled" json:"enabled"`
+
 }
 
 func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.TracerProvider, error) {
@@ -43,6 +46,10 @@ func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.Tra
 // It sets up OTLP gRPC exporter, resource attributes, and W3C trace context propagation
 func InitTracer(ctx context.Context, cfg Config) (*sdktrace.TracerProvider, error) {
 	// Validate configuration
+	if cfg.Enabled != nil && !*cfg.Enabled {
+    return nil, nil
+    }
+
 	if cfg.ServiceName == "" {
 		return nil, fmt.Errorf("service name is required")
 	}

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -232,3 +232,20 @@ func TestNewTransport(t *testing.T) {
 		t.Error("NewTransport(customTransport) returned nil")
 	}
 }
+func TestInitTracerDisabled(t *testing.T) {
+	ctx := context.Background()
+	enabled := false
+
+	cfg := Config{
+		Enabled: &enabled,
+	}
+
+	tp, err := InitTracer(ctx, cfg)
+	if err != nil {
+		t.Fatalf("expected no error when tracing is disabled, got %v", err)
+	}
+
+	if tp != nil {
+		t.Fatalf("expected nil tracer provider when tracing is disabled")
+	}
+}


### PR DESCRIPTION
**Description**

### Summary
This PR adds support for explicitly disabling OpenTelemetry tracing when no collector
endpoint is configured.

### Changes
- Added an `Enabled` flag to tracing configuration
- Short-circuits tracer initialization when tracing is disabled
- Prevents exporter connection attempts when no collector is present
- Added unit tests to cover disabled tracing behavior

### Why this is needed
Currently, Meshery components attempt to connect to a default OTLP endpoint
even when no collector is configured, resulting in noisy timeout logs.
This change ensures tracing is a no-op unless explicitly enabled.

### Related issue
Fixes: meshery/meshkit#894

###Related PR
This issue is further addressed in meshery/meshery#16908.




**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

