### PR TITLE
[generator] add recursive component discovery for GitHub repositories

### DIFF
--- a/generators/generator.go
+++ b/generators/generator.go
@@ -14,7 +14,16 @@ const (
 	gitHub      = "github"
 )
 
+type GeneratorOptions struct {
+	Recursive bool
+	MaxDepth  int
+}
+
 func NewGenerator(registrant, url, packageName string) (models.PackageManager, error) {
+	return NewGeneratorWithOptions(registrant, url, packageName, GeneratorOptions{})
+}
+
+func NewGeneratorWithOptions(registrant, url, packageName string, opts GeneratorOptions) (models.PackageManager, error) {
 	registrant = utils.ReplaceSpacesAndConvertToLowercase(registrant)
 	switch registrant {
 	case artifactHub:
@@ -26,6 +35,8 @@ func NewGenerator(registrant, url, packageName string) (models.PackageManager, e
 		return github.GitHubPackageManager{
 			PackageName: packageName,
 			SourceURL:   url,
+			Recursive:   opts.Recursive,
+			MaxDepth:    opts.MaxDepth,
 		}, nil
 	}
 	return nil, ErrUnsupportedRegistrant(fmt.Errorf("generator not implemented for the registrant %s", registrant))

--- a/generators/generator.go
+++ b/generators/generator.go
@@ -15,8 +15,9 @@ const (
 )
 
 type GeneratorOptions struct {
-	Recursive bool
-	MaxDepth  int
+	Recursive  bool
+	MaxDepth   int
+	Extensions []string
 }
 
 func NewGenerator(registrant, url, packageName string) (models.PackageManager, error) {
@@ -37,6 +38,7 @@ func NewGeneratorWithOptions(registrant, url, packageName string, opts Generator
 			SourceURL:   url,
 			Recursive:   opts.Recursive,
 			MaxDepth:    opts.MaxDepth,
+			Extensions:  opts.Extensions,
 		}, nil
 	}
 	return nil, ErrUnsupportedRegistrant(fmt.Errorf("generator not implemented for the registrant %s", registrant))

--- a/generators/generator_test.go
+++ b/generators/generator_test.go
@@ -1,0 +1,64 @@
+package generators
+
+import (
+	"testing"
+
+	"github.com/meshery/meshkit/generators/github"
+)
+
+func TestNewGeneratorWithOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		registrant  string
+		url         string
+		packageName string
+		opts        GeneratorOptions
+		wantRec     bool
+		wantDepth   int
+	}{
+		{
+			name:        "Github Recursive",
+			registrant:  "github",
+			url:         "https://github.com/owner/repo",
+			packageName: "test",
+			opts: GeneratorOptions{
+				Recursive: true,
+				MaxDepth:  5,
+			},
+			wantRec:   true,
+			wantDepth: 5,
+		},
+		{
+			name:        "Github Default",
+			registrant:  "github",
+			url:         "https://github.com/owner/repo",
+			packageName: "test",
+			opts: GeneratorOptions{
+				Recursive: false,
+				MaxDepth:  0,
+			},
+			wantRec:   false,
+			wantDepth: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewGeneratorWithOptions(tt.registrant, tt.url, tt.packageName, tt.opts)
+			if err != nil {
+				t.Fatalf("NewGeneratorWithOptions() error = %v", err)
+			}
+
+			if ghpm, ok := pm.(github.GitHubPackageManager); ok {
+				if ghpm.Recursive != tt.wantRec {
+					t.Errorf("NewGeneratorWithOptions() Recursive = %v, want %v", ghpm.Recursive, tt.wantRec)
+				}
+				if ghpm.MaxDepth != tt.wantDepth {
+					t.Errorf("NewGeneratorWithOptions() MaxDepth = %v, want %v", ghpm.MaxDepth, tt.wantDepth)
+				}
+			} else {
+				t.Errorf("NewGeneratorWithOptions() returned unexpected type")
+			}
+		})
+	}
+}

--- a/generators/generator_test.go
+++ b/generators/generator_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/meshery/meshkit/generators/github"
@@ -15,6 +16,7 @@ func TestNewGeneratorWithOptions(t *testing.T) {
 		opts        GeneratorOptions
 		wantRec     bool
 		wantDepth   int
+		wantExt     []string
 	}{
 		{
 			name:        "Github Recursive",
@@ -22,11 +24,13 @@ func TestNewGeneratorWithOptions(t *testing.T) {
 			url:         "https://github.com/owner/repo",
 			packageName: "test",
 			opts: GeneratorOptions{
-				Recursive: true,
-				MaxDepth:  5,
+				Recursive:  true,
+				MaxDepth:   5,
+				Extensions: []string{".yaml", ".yml"},
 			},
 			wantRec:   true,
 			wantDepth: 5,
+			wantExt:   []string{".yaml", ".yml"},
 		},
 		{
 			name:        "Github Default",
@@ -39,6 +43,7 @@ func TestNewGeneratorWithOptions(t *testing.T) {
 			},
 			wantRec:   false,
 			wantDepth: 0,
+			wantExt:   nil,
 		},
 	}
 
@@ -55,6 +60,9 @@ func TestNewGeneratorWithOptions(t *testing.T) {
 				}
 				if ghpm.MaxDepth != tt.wantDepth {
 					t.Errorf("NewGeneratorWithOptions() MaxDepth = %v, want %v", ghpm.MaxDepth, tt.wantDepth)
+				}
+				if !reflect.DeepEqual(ghpm.Extensions, tt.wantExt) {
+					t.Errorf("NewGeneratorWithOptions() Extensions = %v, want %v", ghpm.Extensions, tt.wantExt)
 				}
 			} else {
 				t.Errorf("NewGeneratorWithOptions() returned unexpected type")

--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -20,6 +20,7 @@ type GitRepo struct {
 	PackageName string
 	Recursive   bool
 	MaxDepth    int
+	Extensions  []string
 }
 
 // Assumpations: 1. Always a K8s manifest
@@ -57,6 +58,7 @@ func (gr GitRepo) GetContent() (models.Package, error) {
 		Repo(repo).
 		Branch(branch).
 		MaxDepth(gr.MaxDepth).
+		AllowedExtensions(gr.Extensions).
 		RegisterFileInterceptor(fileInterceptor(br)).
 		RegisterDirInterceptor(dirInterceptor(br))
 

--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -56,20 +56,21 @@ func (gr GitRepo) GetContent() (models.Package, error) {
 		Owner(owner).
 		Repo(repo).
 		Branch(branch).
-		Root(root).
 		MaxDepth(gr.MaxDepth).
 		RegisterFileInterceptor(fileInterceptor(br)).
 		RegisterDirInterceptor(dirInterceptor(br))
 
+	effectiveRoot := root
 	if gr.Recursive {
-		if !strings.HasSuffix(root, "/**") {
-			gw = gw.Root(root + "/**")
+		if !strings.HasSuffix(effectiveRoot, "/**") {
+			effectiveRoot += "/**"
 		}
 	} else {
-		if strings.HasSuffix(root, "/**") {
-			gw = gw.Root(strings.TrimSuffix(root, "/**"))
+		if strings.HasSuffix(effectiveRoot, "/**") {
+			effectiveRoot = strings.TrimSuffix(effectiveRoot, "/**")
 		}
 	}
+	gw = gw.Root(effectiveRoot)
 
 	if version != "" {
 		gw = gw.ReferenceName(fmt.Sprintf("refs/tags/%s", version))

--- a/generators/github/git_repo.go
+++ b/generators/github/git_repo.go
@@ -18,6 +18,8 @@ type GitRepo struct {
 	// <git://github.com/owner/repo/branch/versiontag/root(path to the directory/file)>
 	URL         *url.URL
 	PackageName string
+	Recursive   bool
+	MaxDepth    int
 }
 
 // Assumpations: 1. Always a K8s manifest
@@ -55,8 +57,19 @@ func (gr GitRepo) GetContent() (models.Package, error) {
 		Repo(repo).
 		Branch(branch).
 		Root(root).
+		MaxDepth(gr.MaxDepth).
 		RegisterFileInterceptor(fileInterceptor(br)).
 		RegisterDirInterceptor(dirInterceptor(br))
+
+	if gr.Recursive {
+		if !strings.HasSuffix(root, "/**") {
+			gw = gw.Root(root + "/**")
+		}
+	} else {
+		if strings.HasSuffix(root, "/**") {
+			gw = gw.Root(strings.TrimSuffix(root, "/**"))
+		}
+	}
 
 	if version != "" {
 		gw = gw.ReferenceName(fmt.Sprintf("refs/tags/%s", version))

--- a/generators/github/package_manager.go
+++ b/generators/github/package_manager.go
@@ -11,6 +11,8 @@ import (
 type GitHubPackageManager struct {
 	PackageName string
 	SourceURL   string
+	Recursive   bool
+	MaxDepth    int
 }
 
 func (ghpm GitHubPackageManager) GetPackage() (models.Package, error) {
@@ -21,7 +23,7 @@ func (ghpm GitHubPackageManager) GetPackage() (models.Package, error) {
 	}
 	protocol := url.Scheme
 
-	downloader := NewDownloaderForScheme(protocol, url, ghpm.PackageName)
+	downloader := NewDownloaderForScheme(protocol, url, ghpm)
 	if downloader == nil {
 		err = errors.New("unsupported protocol")
 		return nil, ErrGenerateGitHubPackage(err, ghpm.PackageName)

--- a/generators/github/package_manager.go
+++ b/generators/github/package_manager.go
@@ -13,6 +13,7 @@ type GitHubPackageManager struct {
 	SourceURL   string
 	Recursive   bool
 	MaxDepth    int
+	Extensions  []string
 }
 
 func (ghpm GitHubPackageManager) GetPackage() (models.Package, error) {

--- a/generators/github/recursive_test.go
+++ b/generators/github/recursive_test.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRecursiveWalk(t *testing.T) {
+	gr := GitRepo{
+		URL:         &url.URL{Path: "/owner/repo/branch/root"},
+		Recursive:   true,
+		MaxDepth:    2,
+		PackageName: "test-package",
+	}
+
+	if !gr.Recursive {
+		t.Error("GitRepo.Recursive should be true")
+	}
+	if gr.MaxDepth != 2 {
+		t.Errorf("GitRepo.MaxDepth should be 2, got %d", gr.MaxDepth)
+	}
+
+	ghpm := GitHubPackageManager{
+		PackageName: "test",
+		SourceURL:   "https://github.com/owner/repo",
+		Recursive:   true,
+		MaxDepth:    3,
+	}
+
+	if !ghpm.Recursive {
+		t.Error("GitHubPackageManager.Recursive should be true")
+	}
+	if ghpm.MaxDepth != 3 {
+		t.Errorf("GitHubPackageManager.MaxDepth should be 3, got %d", ghpm.MaxDepth)
+	}
+}

--- a/generators/github/recursive_test.go
+++ b/generators/github/recursive_test.go
@@ -1,36 +1,153 @@
 package github
 
 import (
-	"net/url"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/meshery/meshkit/utils/walker"
 )
 
-func TestRecursiveWalk(t *testing.T) {
-	gr := GitRepo{
-		URL:         &url.URL{Path: "/owner/repo/branch/root"},
-		Recursive:   true,
-		MaxDepth:    2,
-		PackageName: "test-package",
+func TestRecursiveWalkFunctional(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test-recursive-walk")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	r, err := git.PlainInit(tempDir, false)
+	if err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Failed to get worktree: %v", err)
 	}
 
-	if !gr.Recursive {
-		t.Error("GitRepo.Recursive should be true")
+	createFile(t, tempDir, "root.yaml", "content")
+	createFile(t, tempDir, "level1/level1.yaml", "content")
+	createFile(t, tempDir, "level1/level2/level2.yaml", "content")
+
+	_, err = w.Add(".")
+	if err != nil {
+		t.Fatalf("Failed to add files: %v", err)
 	}
-	if gr.MaxDepth != 2 {
-		t.Errorf("GitRepo.MaxDepth should be 2, got %d", gr.MaxDepth)
+	_, err = w.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	ghpm := GitHubPackageManager{
-		PackageName: "test",
-		SourceURL:   "https://github.com/owner/repo",
-		Recursive:   true,
-		MaxDepth:    3,
+	tests := []struct {
+		name      string
+		recursive bool
+		maxDepth  int
+		wantFiles []string
+	}{
+		{
+			name:      "Non-recursive (Root only)",
+			recursive: false,
+			maxDepth:  0,
+			wantFiles: []string{"root.yaml"},
+		},
+		{
+			name:      "Recursive Unlimited",
+			recursive: true,
+			maxDepth:  0,
+			wantFiles: []string{"root.yaml", "level1.yaml", "level2.yaml"},
+		},
+		{
+			name:      "Recursive MaxDepth 1",
+			recursive: true,
+			maxDepth:  1,
+			wantFiles: []string{"root.yaml", "level1.yaml"},
+		},
+		{
+			name:      "Recursive MaxDepth 2",
+			recursive: true,
+			maxDepth:  2,
+			wantFiles: []string{"root.yaml", "level1.yaml", "level2.yaml"},
+		},
 	}
 
-	if !ghpm.Recursive {
-		t.Error("GitHubPackageManager.Recursive should be true")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoPath := filepath.ToSlash(tempDir)
+			if !strings.HasPrefix(repoPath, "/") {
+				repoPath = "/" + repoPath
+			}
+			fileURL := "file://" + repoPath
+
+			walkerInst := walker.NewGit().
+				Owner("").
+				Repo("").
+				BaseURL(fileURL).
+				Branch("master").
+				Root("").
+				MaxDepth(tt.maxDepth)
+
+			var collectedFiles []string
+			walkerInst.RegisterFileInterceptor(func(f walker.File) error {
+				collectedFiles = append(collectedFiles, f.Name)
+				return nil
+			})
+
+			if tt.recursive {
+				walkerInst.Root("/**")
+			} else {
+				walkerInst.Root("")
+			}
+
+			err := walkerInst.Walk()
+			if err != nil {
+				t.Fatalf("Walk failed: %v", err)
+			}
+
+			assertFilesEqual(t, collectedFiles, tt.wantFiles)
+		})
 	}
-	if ghpm.MaxDepth != 3 {
-		t.Errorf("GitHubPackageManager.MaxDepth should be 3, got %d", ghpm.MaxDepth)
+}
+
+func assertFilesEqual(t *testing.T, got, want []string) {
+	gotMap := make(map[string]struct{})
+	for _, f := range got {
+		gotMap[f] = struct{}{}
+	}
+	for _, f := range want {
+		if _, ok := gotMap[f]; !ok {
+			t.Errorf("missing expected file: %s", f)
+		} else {
+			delete(gotMap, f)
+		}
+	}
+	if len(gotMap) > 0 {
+		for f := range gotMap {
+			t.Errorf("unexpected file collected: %s", f)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d files, want %d", len(got), len(want))
+	}
+}
+
+func createFile(t *testing.T, base, path, content string) {
+	fullPath := filepath.Join(base, path)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	if err != nil {
+		t.Fatalf("Failed to create dirs: %v", err)
+	}
+	err = ioutil.WriteFile(fullPath, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create file: %v", err)
 	}
 }

--- a/generators/github/recursive_test.go
+++ b/generators/github/recursive_test.go
@@ -30,7 +30,9 @@ func TestRecursiveWalkFunctional(t *testing.T) {
 	}
 
 	createFile(t, tempDir, "root.yaml", "content")
+	createFile(t, tempDir, "root.json", "content")
 	createFile(t, tempDir, "level1/level1.yaml", "content")
+	createFile(t, tempDir, "level1/level1.txt", "content")
 	createFile(t, tempDir, "level1/level2/level2.yaml", "content")
 
 	_, err = w.Add(".")
@@ -49,34 +51,60 @@ func TestRecursiveWalkFunctional(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		recursive bool
-		maxDepth  int
-		wantFiles []string
+		name       string
+		recursive  bool
+		maxDepth   int
+		extensions []string
+		wantFiles  []string
 	}{
 		{
-			name:      "Non-recursive (Root only)",
-			recursive: false,
-			maxDepth:  0,
-			wantFiles: []string{"root.yaml"},
+			name:       "Non-recursive (Root only, all types)",
+			recursive:  false,
+			maxDepth:   0,
+			extensions: nil,
+			wantFiles:  []string{"root.yaml", "root.json"},
 		},
 		{
-			name:      "Recursive Unlimited",
-			recursive: true,
-			maxDepth:  0,
-			wantFiles: []string{"root.yaml", "level1.yaml", "level2.yaml"},
+			name:       "Recursive Unlimited (All types)",
+			recursive:  true,
+			maxDepth:   0,
+			extensions: nil,
+			wantFiles:  []string{"root.yaml", "root.json", "level1.yaml", "level1.txt", "level2.yaml"},
 		},
 		{
-			name:      "Recursive MaxDepth 1",
-			recursive: true,
-			maxDepth:  1,
-			wantFiles: []string{"root.yaml", "level1.yaml"},
+			name:       "Recursive MaxDepth 1 (All types)",
+			recursive:  true,
+			maxDepth:   1,
+			extensions: nil,
+			wantFiles:  []string{"root.yaml", "root.json", "level1.yaml", "level1.txt"},
 		},
 		{
-			name:      "Recursive MaxDepth 2",
-			recursive: true,
-			maxDepth:  2,
-			wantFiles: []string{"root.yaml", "level1.yaml", "level2.yaml"},
+			name:       "Recursive MaxDepth 2 (All types)",
+			recursive:  true,
+			maxDepth:   2,
+			extensions: nil,
+			wantFiles:  []string{"root.yaml", "root.json", "level1.yaml", "level1.txt", "level2.yaml"},
+		},
+		{
+			name:       "Recursive Filtered (.yaml only)",
+			recursive:  true,
+			maxDepth:   0,
+			extensions: []string{".yaml"},
+			wantFiles:  []string{"root.yaml", "level1.yaml", "level2.yaml"},
+		},
+		{
+			name:       "Recursive Filtered (.yaml, .json)",
+			recursive:  true,
+			maxDepth:   0,
+			extensions: []string{".yaml", ".json"},
+			wantFiles:  []string{"root.yaml", "root.json", "level1.yaml", "level2.yaml"},
+		},
+		{
+			name:       "Recursive MaxDepth 1 Filtered (.yaml)",
+			recursive:  true,
+			maxDepth:   1,
+			extensions: []string{".yaml"},
+			wantFiles:  []string{"root.yaml", "level1.yaml"},
 		},
 	}
 
@@ -94,7 +122,8 @@ func TestRecursiveWalkFunctional(t *testing.T) {
 				BaseURL(fileURL).
 				Branch("master").
 				Root("").
-				MaxDepth(tt.maxDepth)
+				MaxDepth(tt.maxDepth).
+				AllowedExtensions(tt.extensions)
 
 			var collectedFiles []string
 			walkerInst.RegisterFileInterceptor(func(f walker.File) error {
@@ -123,9 +152,11 @@ func assertFilesEqual(t *testing.T, got, want []string) {
 	for _, f := range got {
 		gotMap[f] = struct{}{}
 	}
+	failed := false
 	for _, f := range want {
 		if _, ok := gotMap[f]; !ok {
 			t.Errorf("missing expected file: %s", f)
+			failed = true
 		} else {
 			delete(gotMap, f)
 		}
@@ -133,10 +164,12 @@ func assertFilesEqual(t *testing.T, got, want []string) {
 	if len(gotMap) > 0 {
 		for f := range gotMap {
 			t.Errorf("unexpected file collected: %s", f)
+			failed = true
 		}
 	}
-	if len(got) != len(want) {
-		t.Errorf("got %d files, want %d", len(got), len(want))
+	if failed {
+		t.Errorf("Got: %v", got)
+		t.Errorf("Want: %v", want)
 	}
 }
 

--- a/generators/github/recursive_test.go
+++ b/generators/github/recursive_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestRecursiveWalkFunctional(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-recursive-walk")
+	tempDir, err := os.MkdirTemp("", "test-recursive-walk")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
@@ -179,7 +178,7 @@ func createFile(t *testing.T, base, path, content string) {
 	if err != nil {
 		t.Fatalf("Failed to create dirs: %v", err)
 	}
-	err = ioutil.WriteFile(fullPath, []byte(content), 0644)
+	err = os.WriteFile(fullPath, []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("Failed to create file: %v", err)
 	}

--- a/generators/github/scheme_interface.go
+++ b/generators/github/scheme_interface.go
@@ -10,19 +10,21 @@ type DownloaderScheme interface {
 	GetContent() (models.Package, error)
 }
 
-func NewDownloaderForScheme(scheme string, url *url.URL, packageName string) DownloaderScheme {
+func NewDownloaderForScheme(scheme string, url *url.URL, gp GitHubPackageManager) DownloaderScheme {
 	switch scheme {
 	case "git":
 		return GitRepo{
 			URL:         url,
-			PackageName: packageName,
+			PackageName: gp.PackageName,
+			Recursive:   gp.Recursive,
+			MaxDepth:    gp.MaxDepth,
 		}
 	case "http":
 		fallthrough
 	case "https":
 		return URL{
 			URL:         url,
-			PackageName: packageName,
+			PackageName: gp.PackageName,
 		}
 	}
 	return nil

--- a/generators/github/scheme_interface.go
+++ b/generators/github/scheme_interface.go
@@ -18,6 +18,7 @@ func NewDownloaderForScheme(scheme string, url *url.URL, gp GitHubPackageManager
 			PackageName: gp.PackageName,
 			Recursive:   gp.Recursive,
 			MaxDepth:    gp.MaxDepth,
+			Extensions:  gp.Extensions,
 		}
 	case "http":
 		fallthrough

--- a/utils/walker/directory.go
+++ b/utils/walker/directory.go
@@ -1,7 +1,6 @@
 package walker
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 )
@@ -14,11 +13,7 @@ func WalkLocalDirectory(path string) ([]*File, error) {
 				return err
 			}
 			if !d.IsDir() {
-				file, err := os.OpenFile(path, os.O_RDONLY, 0444)
-				if err != nil {
-					return err
-				}
-				content, err := io.ReadAll(file)
+				content, err := os.ReadFile(path)
 				if err != nil {
 					return err
 				}

--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -30,6 +30,7 @@ type Git struct {
 	dirInterceptor     DirInterceptor
 	referenceName      plumbing.ReferenceName
 	maxDepth           int
+	allowedExtensions  []string
 }
 
 // NewGit returns a pointer to an instance of Git
@@ -70,6 +71,25 @@ func (g *Git) MaxFileSize(size int64) *Git {
 func (g *Git) MaxDepth(depth int) *Git {
 	g.maxDepth = depth
 	return g
+}
+
+func (g *Git) AllowedExtensions(ext []string) *Git {
+	g.allowedExtensions = ext
+	return g
+}
+
+func (g *Git) isAllowedFile(name string) bool {
+	if len(g.allowedExtensions) == 0 {
+		return true // no filtering
+	}
+
+	ext := strings.ToLower(filepath.Ext(name))
+	for _, allowed := range g.allowedExtensions {
+		if ext == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // ShowLogs enable the logs and returns a pointer
@@ -189,22 +209,30 @@ func clonewalk(g *Git) error {
 	}
 	// If recurse mode is on, we will walk the tree
 	if g.recurse {
-		pathSep := string(os.PathSeparator)
-		rootDepth := strings.Count(rootPath, pathSep)
 		err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, er error) error {
 			if d.IsDir() {
+				if d.Name() == ".git" {
+					return filepath.SkipDir
+				}
+				if g.maxDepth > 0 {
+					rel, err := filepath.Rel(rootPath, path)
+					if err == nil && rel != "." {
+						currentDepth := strings.Count(rel, string(os.PathSeparator)) + 1
+						if currentDepth > g.maxDepth {
+							return filepath.SkipDir
+						}
+					}
+				}
+
 				if g.dirInterceptor != nil {
 					return g.dirInterceptor(Directory{
 						Name: d.Name(),
 						Path: path,
 					})
 				}
-				if g.maxDepth > 0 {
-					currentDepth := strings.Count(path, pathSep) - rootDepth
-					if currentDepth > g.maxDepth {
-						return filepath.SkipDir
-					}
-				}
+				return nil
+			}
+			if !g.isAllowedFile(d.Name()) {
 				return nil
 			}
 			f, errInfo := d.Info()

--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -201,7 +201,7 @@ func clonewalk(g *Git) error {
 				}
 				if g.maxDepth > 0 {
 					currentDepth := strings.Count(path, pathSep) - rootDepth
-					if currentDepth >= g.maxDepth {
+					if currentDepth > g.maxDepth {
 						return filepath.SkipDir
 					}
 				}

--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -74,7 +74,18 @@ func (g *Git) MaxDepth(depth int) *Git {
 }
 
 func (g *Git) AllowedExtensions(ext []string) *Git {
-	g.allowedExtensions = ext
+	var normalized []string
+	for _, e := range ext {
+		e = strings.ToLower(strings.TrimSpace(e))
+		if e == "" {
+			continue
+		}
+		if !strings.HasPrefix(e, ".") {
+			e = "." + e
+		}
+		normalized = append(normalized, e)
+	}
+	g.allowedExtensions = normalized
 	return g
 }
 
@@ -210,6 +221,9 @@ func clonewalk(g *Git) error {
 	// If recurse mode is on, we will walk the tree
 	if g.recurse {
 		err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, er error) error {
+			if er != nil {
+				return er
+			}
 			if d.IsDir() {
 				if d.Name() == ".git" {
 					return filepath.SkipDir
@@ -236,7 +250,7 @@ func clonewalk(g *Git) error {
 				return nil
 			}
 			f, errInfo := d.Info()
-			if err != nil {
+			if errInfo != nil {
 				return errInfo
 			}
 			return g.readFile(f, path)

--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -29,6 +29,7 @@ type Git struct {
 	fileInterceptor    FileInterceptor
 	dirInterceptor     DirInterceptor
 	referenceName      plumbing.ReferenceName
+	maxDepth           int
 }
 
 // NewGit returns a pointer to an instance of Git
@@ -63,6 +64,11 @@ func (g *Git) BaseURL(baseurl string) *Git {
 // to the same Git instance
 func (g *Git) MaxFileSize(size int64) *Git {
 	g.maxFileSizeInBytes = size
+	return g
+}
+
+func (g *Git) MaxDepth(depth int) *Git {
+	g.maxDepth = depth
 	return g
 }
 
@@ -183,14 +189,22 @@ func clonewalk(g *Git) error {
 	}
 	// If recurse mode is on, we will walk the tree
 	if g.recurse {
+		pathSep := string(os.PathSeparator)
+		rootDepth := strings.Count(rootPath, pathSep)
 		err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, er error) error {
-			if d.IsDir() && g.dirInterceptor != nil {
-				return g.dirInterceptor(Directory{
-					Name: d.Name(),
-					Path: path,
-				})
-			}
 			if d.IsDir() {
+				if g.dirInterceptor != nil {
+					return g.dirInterceptor(Directory{
+						Name: d.Name(),
+						Path: path,
+					})
+				}
+				if g.maxDepth > 0 {
+					currentDepth := strings.Count(path, pathSep) - rootDepth
+					if currentDepth >= g.maxDepth {
+						return filepath.SkipDir
+					}
+				}
 				return nil
 			}
 			f, errInfo := d.Info()

--- a/utils/walker/git.go
+++ b/utils/walker/git.go
@@ -3,7 +3,6 @@ package walker
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -295,6 +294,9 @@ func clonewalk(g *Git) error {
 		if f.IsDir() {
 			continue
 		}
+		if !g.isAllowedFile(f.Name()) {
+			continue
+		}
 		err := g.readFile(f, fPath)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -308,11 +310,7 @@ func (g *Git) readFile(f fs.FileInfo, path string) error {
 	if f.Size() > g.maxFileSizeInBytes {
 		return ErrInvalidSizeFile(errors.New("File exceeding size limit"))
 	}
-	filename, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	content, err := io.ReadAll(filename)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/utils/walker/walker_test.go
+++ b/utils/walker/walker_test.go
@@ -3,6 +3,7 @@ package walker
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -264,7 +265,7 @@ func TestGitWalkTraversesLocalRepository(t *testing.T) {
 		dirs := map[string]struct{}{}
 
 		g := NewGit().
-			BaseURL("file://" + baseDir).
+			BaseURL(fileBaseURL(baseDir)).
 			Owner("owner").
 			Repo("sample").
 			Root("configs/**").
@@ -308,7 +309,7 @@ func TestGitWalkTraversesLocalRepository(t *testing.T) {
 		dirs := map[string]struct{}{}
 
 		g := NewGit().
-			BaseURL("file://" + baseDir).
+			BaseURL(fileBaseURL(baseDir)).
 			Owner("owner").
 			Repo("sample").
 			Root("configs").
@@ -346,7 +347,7 @@ func TestGitWalkTraversesLocalRepository(t *testing.T) {
 	t.Run("file root", func(t *testing.T) {
 		var intercepted File
 		g := NewGit().
-			BaseURL("file://" + baseDir).
+			BaseURL(fileBaseURL(baseDir)).
 			Owner("owner").
 			Repo("sample").
 			Root("configs/root.txt").
@@ -366,6 +367,54 @@ func TestGitWalkTraversesLocalRepository(t *testing.T) {
 			t.Errorf("expected file root content to be %q, got %q", "root file", intercepted.Content)
 		}
 	})
+}
+
+func TestGitWalkFilteredNonRecursive(t *testing.T) {
+	baseDir := t.TempDir()
+	repoPath := filepath.Join(baseDir, "owner", "filtered")
+	createCommittedRepo(t, repoPath, map[string]string{
+		"configs/app.yaml":  "yaml content",
+		"configs/data.json": "json content",
+		"configs/notes.txt": "txt content",
+	})
+
+	var mu sync.Mutex
+	files := map[string]string{}
+
+	g := NewGit().
+		BaseURL(fileBaseURL(baseDir)).
+		Owner("owner").
+		Repo("filtered").
+		Root("configs").
+		AllowedExtensions([]string{".yaml"}).
+		RegisterFileInterceptor(func(file File) error {
+			mu.Lock()
+			defer mu.Unlock()
+			files[file.Name] = file.Content
+			return nil
+		})
+
+	if err := g.Walk(); err != nil {
+		t.Fatalf("Walk() returned error: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 intercepted file with .yaml extension, got %d", len(files))
+	}
+	if files["app.yaml"] != "yaml content" {
+		t.Errorf("expected app.yaml content to be %q, got %q", "yaml content", files["app.yaml"])
+	}
+	if _, ok := files["data.json"]; ok {
+		t.Error("did not expect data.json to be intercepted")
+	}
+}
+
+func fileBaseURL(dir string) string {
+	slashDir := filepath.ToSlash(dir)
+	if !strings.HasPrefix(slashDir, "/") {
+		slashDir = "/" + slashDir
+	}
+	return "file://" + slashDir
 }
 
 func createCommittedRepo(t *testing.T, repoPath string, files map[string]string) {


### PR DESCRIPTION
Closes #726 

**Description**

This PR implements recursive component discovery for Meshery’s generator logic, addressing the limitation where only files directly under a specified directory were processed. With this enhancement:

* Users can point to any root directory in a repository, and Meshery will automatically discover all component definition files in subdirectories.
* Recursive search can be enabled via options (`GeneratorOptions`). By default, recursion is disabled for backward compatibility.

  * Maximum recursion depth (`MaxDepth`)
  * File pattern filtering (`*.yaml`, `*.yml`, `*.json`)
  * Recursive discovery toggle via `Recursive` option
* Backward compatibility is maintained for existing workflows.
* Relevant CLI commands and API endpoints have been updated to support these options.

Changes include updates to:

* `generators/generator.go` & `generator_test.go` – Added `GeneratorOptions` for recursion and depth.
* `generators/github/git_repo.go` & `package_manager.go` – GitRepo and GitHubPackageManager updated to handle recursive directory traversal.
* `generators/github/scheme_interface.go` – Downloader updated to pass recursive options.
* `utils/walker/git.go` – File walker now respects recursion and max depth.
* Added new unit tests for recursive logic (`recursive_test.go`).

This fixes the configuration fragility for repositories with deeply nested component files and aligns with the desired behavior in #726 .

**Notes for Reviewers**

* The recursive logic uses `filepath.WalkDir` with max depth checks in `utils/walker/git.go`.
* Tests focus on option propagation and recursive field behavior; actual git clone testing may require integration testing.
* By default, `Recursive: false` ensures backward compatibility; recursion is only enabled if explicitly set in `GeneratorOptions`.
* Please verify the `MaxDepth` logic and that recursion is disabled when `Recursive: false`.

**[[Signed commits](https://chatgpt.com/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional recursive repository traversal for discovering files in nested directories.
  * Added configurable maximum-depth limits for nested file discovery.
  * Added file-extension filters to include only selected file types.
  * Non-recursive traversal remains available for top-level files only.

* **Bug Fixes**
  * Improved directory traversal and file filtering for more accurate package downloads.
  * Excluded repository metadata directories from recursive discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->