### PR TITLE
feat: clear $ref fields across entire OpenAPI document

### DIFF
--- a/utils/component/openapi_generator.go
+++ b/utils/component/openapi_generator.go
@@ -204,41 +204,55 @@ func getResolvedManifest(manifest string) (string, error) {
 	return string(resolved), nil
 }
 
-// clearDocRefs clears $ref strings across the entire OpenAPI document,
-// including paths, components/parameters, components/headers,
-// components/requestBodies, components/responses, and components/callbacks.
+// clearDocRefs clears $ref strings across the entire OpenAPI document.
 func clearDocRefs(doc *openapi3.T) {
 	stack := make(map[*openapi3.Schema]bool)
+	visited := make(map[*openapi3.PathItem]bool)
 
 	if doc.Components != nil {
 		for _, sr := range doc.Components.Schemas {
 			clearSchemaRefs(sr, stack)
 		}
 		for _, pr := range doc.Components.Parameters {
-			clearParameterRefs(pr, stack)
+			clearParameterRefs(pr, stack, visited)
 		}
 		for _, hr := range doc.Components.Headers {
-			clearHeaderRefs(hr, stack)
+			clearHeaderRefs(hr, stack, visited)
 		}
 		for _, rb := range doc.Components.RequestBodies {
-			clearRequestBodyRefs(rb, stack)
+			clearRequestBodyRefs(rb, stack, visited)
 		}
 		for _, rr := range doc.Components.Responses {
-			clearResponseRefs(rr, stack)
+			clearResponseRefs(rr, stack, visited)
 		}
 		for _, cr := range doc.Components.Callbacks {
-			clearCallbackRefs(cr, stack)
+			clearCallbackRefs(cr, stack, visited)
+		}
+		for _, er := range doc.Components.Examples {
+			if er != nil {
+				er.Ref = ""
+			}
+		}
+		for _, lr := range doc.Components.Links {
+			if lr != nil {
+				lr.Ref = ""
+			}
+		}
+		for _, ssr := range doc.Components.SecuritySchemes {
+			if ssr != nil {
+				ssr.Ref = ""
+			}
 		}
 	}
 
 	if doc.Paths != nil {
 		for _, pathItem := range doc.Paths.Map() {
-			clearPathItemRefs(pathItem, stack)
+			clearPathItemRefs(pathItem, stack, visited)
 		}
 	}
 }
 
-func clearContentRefs(content openapi3.Content, stack map[*openapi3.Schema]bool) {
+func clearContentRefs(content openapi3.Content, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	for _, mt := range content {
 		if mt != nil {
 			clearSchemaRefs(mt.Schema, stack)
@@ -246,90 +260,91 @@ func clearContentRefs(content openapi3.Content, stack map[*openapi3.Schema]bool)
 	}
 }
 
-func clearParameterRefs(pr *openapi3.ParameterRef, stack map[*openapi3.Schema]bool) {
+func clearParameterRefs(pr *openapi3.ParameterRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if pr == nil {
 		return
 	}
 	pr.Ref = ""
 	if pr.Value != nil {
 		clearSchemaRefs(pr.Value.Schema, stack)
-		clearContentRefs(pr.Value.Content, stack)
+		clearContentRefs(pr.Value.Content, stack, visited)
 	}
 }
 
-func clearHeaderRefs(hr *openapi3.HeaderRef, stack map[*openapi3.Schema]bool) {
+func clearHeaderRefs(hr *openapi3.HeaderRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if hr == nil {
 		return
 	}
 	hr.Ref = ""
 	if hr.Value != nil {
 		clearSchemaRefs(hr.Value.Schema, stack)
-		clearContentRefs(hr.Value.Content, stack)
+		clearContentRefs(hr.Value.Content, stack, visited)
 	}
 }
 
-func clearRequestBodyRefs(rb *openapi3.RequestBodyRef, stack map[*openapi3.Schema]bool) {
+func clearRequestBodyRefs(rb *openapi3.RequestBodyRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if rb == nil {
 		return
 	}
 	rb.Ref = ""
 	if rb.Value != nil {
-		clearContentRefs(rb.Value.Content, stack)
+		clearContentRefs(rb.Value.Content, stack, visited)
 	}
 }
 
-func clearResponseRefs(rr *openapi3.ResponseRef, stack map[*openapi3.Schema]bool) {
+func clearResponseRefs(rr *openapi3.ResponseRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if rr == nil {
 		return
 	}
 	rr.Ref = ""
 	if rr.Value != nil {
-		clearContentRefs(rr.Value.Content, stack)
+		clearContentRefs(rr.Value.Content, stack, visited)
 		for _, hr := range rr.Value.Headers {
-			clearHeaderRefs(hr, stack)
+			clearHeaderRefs(hr, stack, visited)
 		}
 	}
 }
 
-func clearCallbackRefs(cr *openapi3.CallbackRef, stack map[*openapi3.Schema]bool) {
+func clearCallbackRefs(cr *openapi3.CallbackRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if cr == nil {
 		return
 	}
 	cr.Ref = ""
 	if cr.Value != nil {
 		for _, pathItem := range cr.Value.Map() {
-			clearPathItemRefs(pathItem, stack)
+			clearPathItemRefs(pathItem, stack, visited)
 		}
 	}
 }
 
-func clearPathItemRefs(pathItem *openapi3.PathItem, stack map[*openapi3.Schema]bool) {
-	if pathItem == nil {
+func clearPathItemRefs(pathItem *openapi3.PathItem, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
+	if pathItem == nil || visited[pathItem] {
 		return
 	}
+	visited[pathItem] = true
 	for _, pr := range pathItem.Parameters {
-		clearParameterRefs(pr, stack)
+		clearParameterRefs(pr, stack, visited)
 	}
 	for _, op := range pathItem.Operations() {
-		clearOperationRefs(op, stack)
+		clearOperationRefs(op, stack, visited)
 	}
 }
 
-func clearOperationRefs(op *openapi3.Operation, stack map[*openapi3.Schema]bool) {
+func clearOperationRefs(op *openapi3.Operation, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
 	if op == nil {
 		return
 	}
 	for _, pr := range op.Parameters {
-		clearParameterRefs(pr, stack)
+		clearParameterRefs(pr, stack, visited)
 	}
-	clearRequestBodyRefs(op.RequestBody, stack)
+	clearRequestBodyRefs(op.RequestBody, stack, visited)
 	if op.Responses != nil {
 		for _, rr := range op.Responses.Map() {
-			clearResponseRefs(rr, stack)
+			clearResponseRefs(rr, stack, visited)
 		}
 	}
 	for _, cr := range op.Callbacks {
-		clearCallbackRefs(cr, stack)
+		clearCallbackRefs(cr, stack, visited)
 	}
 }
 

--- a/utils/component/openapi_generator.go
+++ b/utils/component/openapi_generator.go
@@ -196,15 +196,141 @@ func getResolvedManifest(manifest string) (string, error) {
 	if doc.Components == nil || len(doc.Components.Schemas) == 0 {
 		return "", ErrNoSchemasFound
 	}
-	stack := make(map[*openapi3.Schema]bool)
-	for _, schemaRef := range doc.Components.Schemas {
-		clearSchemaRefs(schemaRef, stack)
-	}
+	clearDocRefs(doc)
 	resolved, err := json.Marshal(doc)
 	if err != nil {
 		return "", err
 	}
 	return string(resolved), nil
+}
+
+// clearDocRefs clears $ref strings across the entire OpenAPI document,
+// including paths, components/parameters, components/headers,
+// components/requestBodies, components/responses, and components/callbacks.
+func clearDocRefs(doc *openapi3.T) {
+	stack := make(map[*openapi3.Schema]bool)
+
+	if doc.Components != nil {
+		for _, sr := range doc.Components.Schemas {
+			clearSchemaRefs(sr, stack)
+		}
+		for _, pr := range doc.Components.Parameters {
+			clearParameterRefs(pr, stack)
+		}
+		for _, hr := range doc.Components.Headers {
+			clearHeaderRefs(hr, stack)
+		}
+		for _, rb := range doc.Components.RequestBodies {
+			clearRequestBodyRefs(rb, stack)
+		}
+		for _, rr := range doc.Components.Responses {
+			clearResponseRefs(rr, stack)
+		}
+		for _, cr := range doc.Components.Callbacks {
+			clearCallbackRefs(cr, stack)
+		}
+	}
+
+	if doc.Paths != nil {
+		for _, pathItem := range doc.Paths.Map() {
+			clearPathItemRefs(pathItem, stack)
+		}
+	}
+}
+
+func clearContentRefs(content openapi3.Content, stack map[*openapi3.Schema]bool) {
+	for _, mt := range content {
+		if mt != nil {
+			clearSchemaRefs(mt.Schema, stack)
+		}
+	}
+}
+
+func clearParameterRefs(pr *openapi3.ParameterRef, stack map[*openapi3.Schema]bool) {
+	if pr == nil {
+		return
+	}
+	pr.Ref = ""
+	if pr.Value != nil {
+		clearSchemaRefs(pr.Value.Schema, stack)
+		clearContentRefs(pr.Value.Content, stack)
+	}
+}
+
+func clearHeaderRefs(hr *openapi3.HeaderRef, stack map[*openapi3.Schema]bool) {
+	if hr == nil {
+		return
+	}
+	hr.Ref = ""
+	if hr.Value != nil {
+		clearSchemaRefs(hr.Value.Schema, stack)
+		clearContentRefs(hr.Value.Content, stack)
+	}
+}
+
+func clearRequestBodyRefs(rb *openapi3.RequestBodyRef, stack map[*openapi3.Schema]bool) {
+	if rb == nil {
+		return
+	}
+	rb.Ref = ""
+	if rb.Value != nil {
+		clearContentRefs(rb.Value.Content, stack)
+	}
+}
+
+func clearResponseRefs(rr *openapi3.ResponseRef, stack map[*openapi3.Schema]bool) {
+	if rr == nil {
+		return
+	}
+	rr.Ref = ""
+	if rr.Value != nil {
+		clearContentRefs(rr.Value.Content, stack)
+		for _, hr := range rr.Value.Headers {
+			clearHeaderRefs(hr, stack)
+		}
+	}
+}
+
+func clearCallbackRefs(cr *openapi3.CallbackRef, stack map[*openapi3.Schema]bool) {
+	if cr == nil {
+		return
+	}
+	cr.Ref = ""
+	if cr.Value != nil {
+		for _, pathItem := range cr.Value.Map() {
+			clearPathItemRefs(pathItem, stack)
+		}
+	}
+}
+
+func clearPathItemRefs(pathItem *openapi3.PathItem, stack map[*openapi3.Schema]bool) {
+	if pathItem == nil {
+		return
+	}
+	for _, pr := range pathItem.Parameters {
+		clearParameterRefs(pr, stack)
+	}
+	for _, op := range pathItem.Operations() {
+		clearOperationRefs(op, stack)
+	}
+}
+
+func clearOperationRefs(op *openapi3.Operation, stack map[*openapi3.Schema]bool) {
+	if op == nil {
+		return
+	}
+	for _, pr := range op.Parameters {
+		clearParameterRefs(pr, stack)
+	}
+	clearRequestBodyRefs(op.RequestBody, stack)
+	if op.Responses != nil {
+		for _, rr := range op.Responses.Map() {
+			clearResponseRefs(rr, stack)
+		}
+	}
+	for _, cr := range op.Callbacks {
+		clearCallbackRefs(cr, stack)
+	}
 }
 
 // clearSchemaRefs recursively clears $ref strings on all nested SchemaRefs

--- a/utils/component/openapi_generator.go
+++ b/utils/component/openapi_generator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"cuelang.org/go/cue"
@@ -204,188 +205,92 @@ func getResolvedManifest(manifest string) (string, error) {
 	return string(resolved), nil
 }
 
-// clearDocRefs clears $ref strings across the entire OpenAPI document.
+// clearDocRefs uses reflection to walk the entire OpenAPI document and clear
+// all $ref strings so that json.Marshal outputs fully inlined schemas.
+// It uses two tracking mechanisms:
+//   - visited: permanent set for general pointers to avoid re-processing
+//   - schemaStack: path-based set for *Schema pointers to detect circular
+//     schema references (add on enter, remove on exit), allowing the same
+//     schema to appear in multiple non-circular positions
 func clearDocRefs(doc *openapi3.T) {
-	stack := make(map[*openapi3.Schema]bool)
-	visited := make(map[*openapi3.PathItem]bool)
+	visited := make(map[uintptr]bool)
+	schemaStack := make(map[uintptr]bool)
+	walkAndClearRefs(reflect.ValueOf(doc), visited, schemaStack)
+}
 
-	if doc.Components != nil {
-		for _, sr := range doc.Components.Schemas {
-			clearSchemaRefs(sr, stack)
+var schemaRefType = reflect.TypeOf((*openapi3.SchemaRef)(nil))
+
+func walkAndClearRefs(v reflect.Value, visited map[uintptr]bool, schemaStack map[uintptr]bool) {
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
 		}
-		for _, pr := range doc.Components.Parameters {
-			clearParameterRefs(pr, stack, visited)
+
+		// SchemaRef needs path-based cycle detection so shared (non-circular)
+		// schemas are fully expanded while true cycles are broken.
+		if v.Type() == schemaRefType {
+			sr := v.Interface().(*openapi3.SchemaRef)
+			sr.Ref = ""
+			if sr.Value == nil {
+				return
+			}
+			schemaPtr := reflect.ValueOf(sr.Value).Pointer()
+			if schemaStack[schemaPtr] {
+				sr.Value = &openapi3.Schema{}
+				return
+			}
+			schemaStack[schemaPtr] = true
+			walkAndClearRefs(reflect.ValueOf(sr.Value), visited, schemaStack)
+			delete(schemaStack, schemaPtr)
+			return
 		}
-		for _, hr := range doc.Components.Headers {
-			clearHeaderRefs(hr, stack, visited)
+
+		ptr := v.Pointer()
+		if visited[ptr] {
+			return
 		}
-		for _, rb := range doc.Components.RequestBodies {
-			clearRequestBodyRefs(rb, stack, visited)
-		}
-		for _, rr := range doc.Components.Responses {
-			clearResponseRefs(rr, stack, visited)
-		}
-		for _, cr := range doc.Components.Callbacks {
-			clearCallbackRefs(cr, stack, visited)
-		}
-		for _, er := range doc.Components.Examples {
-			if er != nil {
-				er.Ref = ""
+		visited[ptr] = true
+
+		elem := v.Elem()
+		if elem.Kind() == reflect.Struct {
+			if refField := elem.FieldByName("Ref"); refField.IsValid() && refField.Kind() == reflect.String {
+				refField.SetString("")
 			}
 		}
-		for _, lr := range doc.Components.Links {
-			if lr != nil {
-				lr.Ref = ""
+		walkAndClearRefs(elem, visited, schemaStack)
+
+	case reflect.Struct:
+		// Handle types with unexported map fields (Paths, Callback, Responses)
+		// accessed via a Map() method.
+		if v.CanAddr() {
+			if mapMethod := v.Addr().MethodByName("Map"); mapMethod.IsValid() {
+				results := mapMethod.Call(nil)
+				if len(results) == 1 && results[0].Kind() == reflect.Map {
+					walkAndClearRefs(results[0], visited, schemaStack)
+				}
 			}
 		}
-		for _, ssr := range doc.Components.SecuritySchemes {
-			if ssr != nil {
-				ssr.Ref = ""
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			if field.CanInterface() {
+				walkAndClearRefs(field, visited, schemaStack)
 			}
 		}
-	}
 
-	if doc.Paths != nil {
-		for _, pathItem := range doc.Paths.Map() {
-			clearPathItemRefs(pathItem, stack, visited)
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			walkAndClearRefs(v.MapIndex(key), visited, schemaStack)
+		}
+
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			walkAndClearRefs(v.Index(i), visited, schemaStack)
+		}
+
+	case reflect.Interface:
+		if !v.IsNil() {
+			walkAndClearRefs(v.Elem(), visited, schemaStack)
 		}
 	}
-}
-
-func clearContentRefs(content openapi3.Content, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	for _, mt := range content {
-		if mt != nil {
-			clearSchemaRefs(mt.Schema, stack)
-		}
-	}
-}
-
-func clearParameterRefs(pr *openapi3.ParameterRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if pr == nil {
-		return
-	}
-	pr.Ref = ""
-	if pr.Value != nil {
-		clearSchemaRefs(pr.Value.Schema, stack)
-		clearContentRefs(pr.Value.Content, stack, visited)
-	}
-}
-
-func clearHeaderRefs(hr *openapi3.HeaderRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if hr == nil {
-		return
-	}
-	hr.Ref = ""
-	if hr.Value != nil {
-		clearSchemaRefs(hr.Value.Schema, stack)
-		clearContentRefs(hr.Value.Content, stack, visited)
-	}
-}
-
-func clearRequestBodyRefs(rb *openapi3.RequestBodyRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if rb == nil {
-		return
-	}
-	rb.Ref = ""
-	if rb.Value != nil {
-		clearContentRefs(rb.Value.Content, stack, visited)
-	}
-}
-
-func clearResponseRefs(rr *openapi3.ResponseRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if rr == nil {
-		return
-	}
-	rr.Ref = ""
-	if rr.Value != nil {
-		clearContentRefs(rr.Value.Content, stack, visited)
-		for _, hr := range rr.Value.Headers {
-			clearHeaderRefs(hr, stack, visited)
-		}
-	}
-}
-
-func clearCallbackRefs(cr *openapi3.CallbackRef, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if cr == nil {
-		return
-	}
-	cr.Ref = ""
-	if cr.Value != nil {
-		for _, pathItem := range cr.Value.Map() {
-			clearPathItemRefs(pathItem, stack, visited)
-		}
-	}
-}
-
-func clearPathItemRefs(pathItem *openapi3.PathItem, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if pathItem == nil || visited[pathItem] {
-		return
-	}
-	visited[pathItem] = true
-	for _, pr := range pathItem.Parameters {
-		clearParameterRefs(pr, stack, visited)
-	}
-	for _, op := range pathItem.Operations() {
-		clearOperationRefs(op, stack, visited)
-	}
-}
-
-func clearOperationRefs(op *openapi3.Operation, stack map[*openapi3.Schema]bool, visited map[*openapi3.PathItem]bool) {
-	if op == nil {
-		return
-	}
-	for _, pr := range op.Parameters {
-		clearParameterRefs(pr, stack, visited)
-	}
-	clearRequestBodyRefs(op.RequestBody, stack, visited)
-	if op.Responses != nil {
-		for _, rr := range op.Responses.Map() {
-			clearResponseRefs(rr, stack, visited)
-		}
-	}
-	for _, cr := range op.Callbacks {
-		clearCallbackRefs(cr, stack, visited)
-	}
-}
-
-// clearSchemaRefs recursively clears $ref strings on all nested SchemaRefs
-// so that json.Marshal outputs fully inlined schemas. The stack set tracks
-// Schema values (not SchemaRef pointers) on the current recursion path to
-// detect circular references. kin-openapi resolves $refs by creating
-// different SchemaRef objects that share the same underlying Schema pointer,
-// so tracking by *Schema is necessary to catch all cycles.
-func clearSchemaRefs(sr *openapi3.SchemaRef, stack map[*openapi3.Schema]bool) {
-	if sr == nil {
-		return
-	}
-	sr.Ref = ""
-	s := sr.Value
-	if s == nil {
-		return
-	}
-	if stack[s] {
-		sr.Value = &openapi3.Schema{}
-		return
-	}
-	stack[s] = true
-	for _, child := range s.AllOf {
-		clearSchemaRefs(child, stack)
-	}
-	for _, child := range s.AnyOf {
-		clearSchemaRefs(child, stack)
-	}
-	for _, child := range s.OneOf {
-		clearSchemaRefs(child, stack)
-	}
-	clearSchemaRefs(s.Not, stack)
-	if s.Items != nil {
-		clearSchemaRefs(s.Items, stack)
-	}
-	for _, prop := range s.Properties {
-		clearSchemaRefs(prop, stack)
-	}
-	if s.AdditionalProperties.Schema != nil {
-		clearSchemaRefs(s.AdditionalProperties.Schema, stack)
-	}
-	delete(stack, s)
 }

--- a/utils/component/openapi_generator_test.go
+++ b/utils/component/openapi_generator_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -307,7 +308,7 @@ func TestGetResolvedManifest_AllOf(t *testing.T) {
 	}
 }
 
-func TestClearSchemaRefs(t *testing.T) {
+func TestWalkAndClearRefs(t *testing.T) {
 	tests := []struct {
 		name string
 		sr   *openapi3.SchemaRef
@@ -324,8 +325,9 @@ func TestClearSchemaRefs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			visited := make(map[*openapi3.Schema]bool)
-			clearSchemaRefs(tt.sr, visited)
+			visited := make(map[uintptr]bool)
+			schemaStack := make(map[uintptr]bool)
+			walkAndClearRefs(reflect.ValueOf(tt.sr), visited, schemaStack)
 			if tt.sr != nil && tt.sr.Ref != "" {
 				t.Errorf("Ref = %q, want empty", tt.sr.Ref)
 			}
@@ -333,15 +335,16 @@ func TestClearSchemaRefs(t *testing.T) {
 	}
 }
 
-func TestClearSchemaRefs_Circular(t *testing.T) {
+func TestWalkAndClearRefs_Circular(t *testing.T) {
 	// Build a circular reference: A -> B -> A
 	a := &openapi3.SchemaRef{Ref: "#/components/schemas/A", Value: &openapi3.Schema{}}
 	b := &openapi3.SchemaRef{Ref: "#/components/schemas/B", Value: &openapi3.Schema{}}
 	a.Value.Properties = openapi3.Schemas{"b": b}
 	b.Value.Properties = openapi3.Schemas{"a": a}
 
-	stack := make(map[*openapi3.Schema]bool)
-	clearSchemaRefs(a, stack) // must not hang or panic
+	visited := make(map[uintptr]bool)
+	schemaStack := make(map[uintptr]bool)
+	walkAndClearRefs(reflect.ValueOf(a), visited, schemaStack) // must not hang or panic
 
 	if a.Ref != "" {
 		t.Errorf("a.Ref = %q, want empty", a.Ref)
@@ -356,15 +359,16 @@ func TestClearSchemaRefs_Circular(t *testing.T) {
 	}
 }
 
-func TestClearSchemaRefs_SelfReference(t *testing.T) {
+func TestWalkAndClearRefs_SelfReference(t *testing.T) {
 	// Schema that references itself (like JSONSchemaProps).
 	self := &openapi3.SchemaRef{Value: &openapi3.Schema{
 		Type: &openapi3.Types{"object"},
 	}}
 	self.Value.Properties = openapi3.Schemas{"nested": self}
 
-	stack := make(map[*openapi3.Schema]bool)
-	clearSchemaRefs(self, stack)
+	visited := make(map[uintptr]bool)
+	schemaStack := make(map[uintptr]bool)
+	walkAndClearRefs(reflect.ValueOf(self), visited, schemaStack)
 
 	// The self-referencing property should be replaced, breaking the cycle.
 	if _, err := json.Marshal(self); err != nil {

--- a/utils/component/openapi_generator_test.go
+++ b/utils/component/openapi_generator_test.go
@@ -372,6 +372,185 @@ func TestClearSchemaRefs_SelfReference(t *testing.T) {
 	}
 }
 
+func TestGetResolvedManifest_PathsAndComponents(t *testing.T) {
+	input := `{
+		"openapi": "3.0.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/pets": {
+				"get": {
+					"parameters": [
+						{"$ref": "#/components/parameters/LimitParam"}
+					],
+					"responses": {
+						"200": {
+							"$ref": "#/components/responses/PetList"
+						}
+					}
+				},
+				"post": {
+					"requestBody": {
+						"$ref": "#/components/requestBodies/PetBody"
+					},
+					"responses": {
+						"201": {
+							"description": "created"
+						}
+					}
+				}
+			}
+		},
+		"components": {
+			"schemas": {
+				"Pet": {
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"}
+					}
+				}
+			},
+			"parameters": {
+				"LimitParam": {
+					"name": "limit",
+					"in": "query",
+					"schema": {"type": "integer"}
+				}
+			},
+			"requestBodies": {
+				"PetBody": {
+					"content": {
+						"application/json": {
+							"schema": {"$ref": "#/components/schemas/Pet"}
+						}
+					}
+				}
+			},
+			"responses": {
+				"PetList": {
+					"description": "A list of pets",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {"$ref": "#/components/schemas/Pet"}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	out, err := getResolvedManifest(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	// Verify parameter ref in path is resolved.
+	param := navigatePath(t, parsed, "paths./pets.get.parameters")
+	params, ok := param.([]any)
+	if !ok || len(params) == 0 {
+		t.Fatal("expected parameters array")
+	}
+	pm := params[0].(map[string]any)
+	if _, hasRef := pm["$ref"]; hasRef {
+		t.Error("parameter $ref still present in path")
+	}
+	if pm["name"] != "limit" {
+		t.Errorf("parameter name = %v, want limit", pm["name"])
+	}
+
+	// Verify response ref in path is resolved.
+	resp := navigatePath(t, parsed, "paths./pets.get.responses.200").(map[string]any)
+	if _, hasRef := resp["$ref"]; hasRef {
+		t.Error("response $ref still present in path")
+	}
+	if resp["description"] != "A list of pets" {
+		t.Errorf("response description = %v, want 'A list of pets'", resp["description"])
+	}
+
+	// Verify schema ref inside response content is resolved.
+	items := navigatePath(t, parsed, "paths./pets.get.responses.200.content.application/json.schema.items").(map[string]any)
+	if _, hasRef := items["$ref"]; hasRef {
+		t.Error("schema $ref in response items still present")
+	}
+	if items["type"] != "object" {
+		t.Errorf("items type = %v, want object", items["type"])
+	}
+
+	// Verify requestBody ref in path is resolved.
+	rb := navigatePath(t, parsed, "paths./pets.post.requestBody").(map[string]any)
+	if _, hasRef := rb["$ref"]; hasRef {
+		t.Error("requestBody $ref still present in path")
+	}
+
+	// Verify schema ref inside requestBody content is resolved.
+	rbSchema := navigatePath(t, parsed, "paths./pets.post.requestBody.content.application/json.schema").(map[string]any)
+	if _, hasRef := rbSchema["$ref"]; hasRef {
+		t.Error("schema $ref in requestBody content still present")
+	}
+	if rbSchema["type"] != "object" {
+		t.Errorf("requestBody schema type = %v, want object", rbSchema["type"])
+	}
+}
+
+func TestGetResolvedManifest_HeaderRefs(t *testing.T) {
+	input := `{
+		"openapi": "3.0.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/items": {
+				"get": {
+					"responses": {
+						"200": {
+							"description": "OK",
+							"headers": {
+								"X-Rate-Limit": {
+									"$ref": "#/components/headers/RateLimit"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"components": {
+			"schemas": {
+				"Placeholder": {"type": "string"}
+			},
+			"headers": {
+				"RateLimit": {
+					"schema": {"type": "integer"}
+				}
+			}
+		}
+	}`
+
+	out, err := getResolvedManifest(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	header := navigatePath(t, parsed, "paths./items.get.responses.200.headers.X-Rate-Limit").(map[string]any)
+	if _, hasRef := header["$ref"]; hasRef {
+		t.Error("header $ref still present")
+	}
+	schema := header["schema"].(map[string]any)
+	if schema["type"] != "integer" {
+		t.Errorf("header schema type = %v, want integer", schema["type"])
+	}
+}
+
 // navigatePath walks a dot-separated path through nested maps.
 func navigatePath(t *testing.T, data map[string]any, path string) any {
 	t.Helper()


### PR DESCRIPTION
**Description**

This PR fixes #926

**Notes for Reviewers**

## Why                                                                                                 
  
The `getResolvedManifest` function only cleared `$ref` fields from `components/schemas`, leaving refs in paths, parameters, responses, request bodies, headers, and callbacks unresolved.
                                                                                                       
## How                                                          

- Extract ref-clearing into `clearDocRefs` that traverses paths, all component types, and nested
callbacks
- Add helpers for clearing refs in parameters, headers, request bodies, responses, operations, and
content
- Add tests verifying ref resolution in paths, request bodies, responses, and headers


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
