### PR TITLE
Remove explicit status: enabled from generated component definitions

### DIFF
--- a/registry/component.go
+++ b/registry/component.go
@@ -58,26 +58,34 @@ type ComponentCSV struct {
 // The Component Definition generated assumes or is only for components which have registrant as "meshery"
 func (c *ComponentCSV) CreateComponentDefinition(isModelPublished bool, defVersion string) (component.ComponentDefinition, error) {
 	status := entity.Enabled
-	if c.Status != "" {
-		if utils.ReplaceSpacesAndConvertToLowercase(c.Status) == "ignored" {
-			status = entity.Ignored
-		}
+
+if c.Status != "" {
+	switch utils.ReplaceSpacesAndConvertToLowercase(c.Status) {
+	case "ignored", "disabled":
+		status = entity.Ignored
+	case "enabled":
+		status = entity.Enabled
 	}
-	componentDefinition := &component.ComponentDefinition{
-		SchemaVersion: schmeaVersion.ComponentSchemaVersion,
-		DisplayName:   c.Component,
-		Format:        "JSON",
-		Version:       defVersion,
-		Metadata: component.ComponentDefinition_Metadata{
-			Published: isModelPublished,
-		},
-		Status: (*component.ComponentDefinitionStatus)(&status),
-		Component: component.Component{
-			Kind:    c.Component,
-			Schema:  c.Schema,
-			Version: c.Version,
-		},
-	}
+}
+
+componentDefinition := &component.ComponentDefinition{
+	SchemaVersion: schmeaVersion.ComponentSchemaVersion,
+	DisplayName:   c.Component,
+	Format:        "JSON",
+	Version:       defVersion,
+	Metadata: component.ComponentDefinition_Metadata{
+		Published: isModelPublished,
+	},
+	Component: component.Component{
+		Kind:    c.Component,
+		Schema:  c.Schema,
+		Version: c.Version,
+	},
+}
+
+if status != entity.Enabled {
+	componentDefinition.Status = (*component.ComponentDefinitionStatus)(&status)
+}
 	if c.Description != "" {
 		componentDefinition.Description = c.Description
 	}
@@ -93,13 +101,6 @@ var compStyleValues = []string{
 }
 
 func (c *ComponentCSV) UpdateCompDefinition(compDef *component.ComponentDefinition) error {
-	status := entity.Enabled
-	if c.Status != "" {
-		if utils.ReplaceSpacesAndConvertToLowercase(c.Status) == "ignored" {
-			status = entity.Ignored
-		}
-	}
-	compDef.Status = (*component.ComponentDefinitionStatus)(&status)
 	var existingAddditionalProperties map[string]interface{}
 	if c.Description != "" {
 		compDef.Description = c.Description


### PR DESCRIPTION
## Description

This PR removes the explicit inclusion of status: enabled from generated component definitions.

Since `enabled` is already the default behavior for components, explicitly adding `status: enabled` in the generated JSON definitions introduces unnecessary redundancy. This update modifies the component generation logic so that the `status` field is only included when the status differs from the default value.

With this change:

* status will not be included when the value is enabled.
* status will only be added when the value is ignored or disabled.

This reduces unnecessary properties in generated component definitions while preserving correct behavior.

Fixes #17918

## Notes for Reviewers

* Updated component generation logic in registry/component.go.
* Ensures that the `status` field is omitted when it matches the default (`enabled`).
* Keeps the `status` field for non-default values (`ignored`, `disabled`).
* Improves clarity and reduces redundancy in generated component definitions.

## Signed Commits
* ✅ Yes, I signed my commits.
