### PR TITLE
Fix schemas v0.8.129 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/schemas v0.8.127
+	github.com/meshery/schemas v0.8.129
 	github.com/nats-io/nats.go v1.47.0
 	github.com/open-policy-agent/opa v1.11.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -299,7 +299,7 @@ require (
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251213004720-97cd9d5aeac2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251213004720-97cd9d5aeac2 // indirect
-	google.golang.org/grpc v1.77.0 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/schemas v0.8.127 h1:MHR0sotqeZFjGsFYd+uQHP+fhOWcpAKyN9gaNWeuP6o=
-github.com/meshery/schemas v0.8.127/go.mod h1:5sD1I33x+J/oSIwYIdccH4VTVRQ71QCN7dUPvpqmESw=
+github.com/meshery/schemas v0.8.129 h1:N2ZaQFeKH4U3t3TAHKUXjx/VrWYiU+EiDde8WsO6m4o=
+github.com/meshery/schemas v0.8.129/go.mod h1:+N/+Q3ZJzBrGGWVGTNWA4m8PviHhM2cnrsVv8p27ieQ=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -757,8 +757,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20251213004720-97cd9d5aeac2 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20251213004720-97cd9d5aeac2/go.mod h1:+rXWjjaukWZun3mLfjmVnQi18E1AsFbDN9QdJ5YXLto=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251213004720-97cd9d5aeac2 h1:2I6GHUeJ/4shcDpoUlLs/2WPnhg7yJwvXtqcMJt9liA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251213004720-97cd9d5aeac2/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
-google.golang.org/grpc v1.77.0 h1:wVVY6/8cGA6vvffn+wWK5ToddbgdU3d8MNENr4evgXM=
-google.golang.org/grpc v1.77.0/go.mod h1:z0BY1iVj0q8E1uSQCjL9cppRj+gnZjzDnzV0dHhrNig=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/models/meshmodel/core/policies/rego_policy_relationship.go
+++ b/models/meshmodel/core/policies/rego_policy_relationship.go
@@ -20,10 +20,10 @@ import (
 var SyncRelationship sync.Mutex
 
 type Rego struct {
-	store       storagepkg.Store
-	txn         storagepkg.Transaction
-	ctx         context.Context
-	policyDir   string
+	store     storagepkg.Store
+	txn       storagepkg.Transaction
+	ctx       context.Context
+	policyDir string
 }
 
 // NewRegoInstance creates a new Rego evaluator with relationships loaded
@@ -52,7 +52,7 @@ func NewRegoInstance(policyDir string, regManager *registry.RegistryManager) (*R
 }
 
 // CustomPrint implements the print.Hook interface to capture print statements
-type CustomPrint struct{
+type CustomPrint struct {
 	Messages []string
 }
 
@@ -136,7 +136,7 @@ func (r *Rego) RegoPolicyHandler(
 	for _, comp := range resp.Design.Components {
 		var patches []patching.Patch
 		for _, up := range updates {
-			if up.Id == comp.Id.String() {
+			if up.Id == comp.ID.String() {
 				patches = append(patches, patching.Patch{Path: up.Path[1:], Value: up.Value})
 			}
 		}

--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -152,7 +152,7 @@ func (rm *RegistryManager) UpdateEntityStatus(ID string, status string, entityTy
 	}
 	switch entityType {
 	case "models":
-		model := model.ModelDefinition{Id: entityID}
+		model := model.ModelDefinition{ID: entityID}
 		err := model.UpdateStatus(rm.db, entity.EntityStatus(status))
 		if err != nil {
 			return err

--- a/models/meshmodel/registry/v1beta1/model_filter.go
+++ b/models/meshmodel/registry/v1beta1/model_filter.go
@@ -66,7 +66,7 @@ func (mf *ModelFilter) GetById(db *database.Handler) (entity.Entity, error) {
 		var components []component.ComponentDefinition
 		componentFinder := db.Model(&component.ComponentDefinition{}).
 			Select("component_definition_dbs.id, component_definition_dbs.component, component_definition_dbs.display_name, component_definition_dbs.metadata, component_definition_dbs.schema_version, component_definition_dbs.version").
-			Where("component_definition_dbs.model_id = ?", m.Id)
+			Where("component_definition_dbs.model_id = ?", m.ID)
 		if err := componentFinder.Scan(&components).Error; err != nil {
 			return nil, err
 		}
@@ -78,7 +78,7 @@ func (mf *ModelFilter) GetById(db *database.Handler) (entity.Entity, error) {
 		var relationships []relationship.RelationshipDefinition
 		relationshipFinder := db.Model(&relationship.RelationshipDefinition{}).
 			Select("relationship_definition_dbs.*").
-			Where("relationship_definition_dbs.model_id = ?", m.Id)
+			Where("relationship_definition_dbs.model_id = ?", m.ID)
 		if err := relationshipFinder.Scan(&relationships).Error; err != nil {
 			return nil, err
 		}
@@ -178,16 +178,16 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 		// resolve for loop scope
 		_modelDB := modelDB
 		var componentCount int64
-		db.Model(&component.ComponentDefinition{}).Where("component_definition_dbs.model_id = ?", _modelDB.Id).Count(&componentCount)
+		db.Model(&component.ComponentDefinition{}).Where("component_definition_dbs.model_id = ?", _modelDB.ID).Count(&componentCount)
 		var relationshipCount int64
-		db.Model(&relationship.RelationshipDefinition{}).Where("relationship_definition_dbs.model_id = ?", _modelDB.Id).Count(&relationshipCount)
+		db.Model(&relationship.RelationshipDefinition{}).Where("relationship_definition_dbs.model_id = ?", _modelDB.ID).Count(&relationshipCount)
 		_modelDB.ComponentsCount = int(componentCount)
 		_modelDB.RelationshipsCount = int(relationshipCount)
 
 		// If Trim is true, only include the id, name, counts and metadata
 		if mf.Trim {
 			trimmedModel := &model.ModelDefinition{
-				Id:                 _modelDB.Id,
+				ID:                 _modelDB.ID,
 				Name:               _modelDB.Name,
 				DisplayName:        _modelDB.DisplayName,
 				Metadata:           _modelDB.Metadata,
@@ -201,7 +201,7 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 				var components []component.ComponentDefinition
 				finder := db.Model(&component.ComponentDefinition{}).
 					Select("component_definition_dbs.*").
-					Where("component_definition_dbs.model_id = ?", _modelDB.Id)
+					Where("component_definition_dbs.model_id = ?", _modelDB.ID)
 				if err := finder.Scan(&components).Error; err != nil {
 					return nil, 0, 0, err
 				}
@@ -211,7 +211,7 @@ func (mf *ModelFilter) Get(db *database.Handler) ([]entity.Entity, int64, int, e
 				var relationships []relationship.RelationshipDefinition
 				finder := db.Model(&relationship.RelationshipDefinition{}).
 					Select("relationship_definition_dbs.*").
-					Where("relationship_definition_dbs.model_id = ?", _modelDB.Id)
+					Where("relationship_definition_dbs.model_id = ?", _modelDB.ID)
 				if err := finder.Scan(&relationships).Error; err != nil {
 					return nil, 0, 0, err
 				}

--- a/models/registration/register.go
+++ b/models/registration/register.go
@@ -138,11 +138,12 @@ func (rh *RegistrationHelper) register(pkg PackagingUnit) {
 	// 3. Register relationships
 	for _, rel := range pkg.Relationships {
 		rel.Model = model.ToReference()
-		rel.ModelId = model.Id
+		modelID := model.ID
+		rel.ModelId = &modelID
 		_, _, err := rh.regManager.RegisterEntity(model.Registrant, &rel)
 		if err != nil {
 			err = ErrRegisterEntity(err, string(rel.Type()), string(rel.Kind))
-			rh.regErrStore.InsertEntityRegError(hostname, model.DisplayName, entity.RelationshipDefinition, rel.Id.String(), err)
+			rh.regErrStore.InsertEntityRegError(hostname, model.DisplayName, entity.RelationshipDefinition, rel.ID.String(), err)
 		} else {
 			// Successful registration, add to successfulRelationships
 			registeredRelationships = append(registeredRelationships, rel)

--- a/orchestration/design.go
+++ b/orchestration/design.go
@@ -45,7 +45,7 @@ func EnrichComponentWithMesheryMetadata(comp *component.ComponentDefinition, des
 	// Assign the new label
 	labels[ResourceSourceDesignIdLabelKey] = designId
 	annotations[ResourceSourceDesignVersionLabelKey] = designVersion
-	annotations[ResourceSourceComponentIdLabelKey] = comp.Id.String()
+	annotations[ResourceSourceComponentIdLabelKey] = comp.ID.String()
 
 	return nil
 }

--- a/registry/component.go
+++ b/registry/component.go
@@ -1,12 +1,12 @@
 package registry
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"encoding/json"
 
 	"github.com/meshery/meshkit/encoding"
 	"github.com/meshery/meshkit/files"
@@ -14,10 +14,11 @@ import (
 	"github.com/meshery/meshkit/utils"
 	"github.com/meshery/meshkit/utils/csv"
 	"github.com/meshery/meshkit/utils/manifests"
+	"github.com/meshery/schemas"
 	"github.com/meshery/schemas/models/v1alpha1/capability"
+	core "github.com/meshery/schemas/models/v1alpha1/core"
 	schmeaVersion "github.com/meshery/schemas/models/v1beta1"
 	"github.com/meshery/schemas/models/v1beta1/component"
-	"github.com/meshery/schemas"
 )
 
 const (
@@ -175,8 +176,8 @@ func (c *ComponentCSV) UpdateCompDefinition(compDef *component.ComponentDefiniti
 	//styling properties from csv
 	for _, key := range compStyleValues {
 		if c.Shape != "" {
-			shape := c.Shape
-			compDefStyles.Shape = (*component.ComponentDefinitionStylesShape)(&shape)
+			shape := core.Shape(c.Shape)
+			compDefStyles.Shape = &shape
 		}
 		if c.PrimaryColor != "" {
 
@@ -209,8 +210,6 @@ func (c *ComponentCSV) UpdateCompDefinition(compDef *component.ComponentDefiniti
 	compDef.Metadata.AdditionalProperties = metadata
 	return nil
 }
-
-
 
 type ComponentCSVHelper struct {
 	SpreadsheetID  int64
@@ -465,43 +464,42 @@ func getSVGForComponent(model ModelCSV, component ComponentCSV) (colorSVG string
 	return
 }
 
-
 func getMinimalUICapabilitiesFromSchema() ([]capability.Capability, error) {
-    schema, err := schemas.Schemas.ReadFile("schemas/constructs/v1beta1/component/component.json")
-    if err != nil {
-        return nil, fmt.Errorf("failed to read component schema: %v", err)
-    }
+	schema, err := schemas.Schemas.ReadFile("schemas/constructs/v1beta1/component/component.json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read component schema: %v", err)
+	}
 
-    capabilitiesJSON, err := extractCapabilitiesJSONFromSchema(schema)
-    if err != nil {
-        return nil, fmt.Errorf("failed to extract capabilities from schema: %v", err)
-    }
+	capabilitiesJSON, err := extractCapabilitiesJSONFromSchema(schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract capabilities from schema: %v", err)
+	}
 
-    var allCapabilities []capability.Capability
-    if err := json.Unmarshal(capabilitiesJSON, &allCapabilities); err != nil {
-        return nil, fmt.Errorf("failed to unmarshal capabilities: %v", err)
-    }
+	var allCapabilities []capability.Capability
+	if err := json.Unmarshal(capabilitiesJSON, &allCapabilities); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal capabilities: %v", err)
+	}
 
-    if len(allCapabilities) >= 3 {
-        return allCapabilities[len(allCapabilities)-3:], nil
-    }
+	if len(allCapabilities) >= 3 {
+		return allCapabilities[len(allCapabilities)-3:], nil
+	}
 
-    return nil, fmt.Errorf("insufficient default capabilities in schema, found %d", len(allCapabilities))
+	return nil, fmt.Errorf("insufficient default capabilities in schema, found %d", len(allCapabilities))
 }
 
 func extractCapabilitiesJSONFromSchema(schema []byte) ([]byte, error) {
-    var schemaMap map[string]interface{}
-    if err := json.Unmarshal(schema, &schemaMap); err != nil {
-        return nil, err
-    }
+	var schemaMap map[string]interface{}
+	if err := json.Unmarshal(schema, &schemaMap); err != nil {
+		return nil, err
+	}
 
-    if properties, ok := schemaMap["properties"].(map[string]interface{}); ok {
-        if capabilitiesSchema, ok := properties["capabilities"].(map[string]interface{}); ok {
-            if defaultValue, ok := capabilitiesSchema["default"]; ok {
-                return json.Marshal(defaultValue)
-            }
-        }
-    }
+	if properties, ok := schemaMap["properties"].(map[string]interface{}); ok {
+		if capabilitiesSchema, ok := properties["capabilities"].(map[string]interface{}); ok {
+			if defaultValue, ok := capabilitiesSchema["default"]; ok {
+				return json.Marshal(defaultValue)
+			}
+		}
+	}
 
-    return nil, fmt.Errorf("default capabilities not found in schema")
+	return nil, fmt.Errorf("default capabilities not found in schema")
 }


### PR DESCRIPTION
## Summary

Update `meshkit` to build cleanly against `github.com/meshery/schemas v0.8.129`.

This change fixes the generated-model API shifts that broke downstream consumers:
- switch `Id` references to `ID` for generated model, component, and relationship types
- update component style shape assignment to the generated core `Shape` type
- bump the direct `schemas` dependency to `v0.8.129`

## Validation

- `go build ./...`
- `go test ./models/meshmodel/... ./orchestration/... ./models/registration/...`

## Notes

- `go test ./registry/...` still hits a pre-existing nil-pointer panic in `TestUpdateCompDefinitionWithDefaultCapabilities` on both this branch and clean `origin/master`; I did not change that behavior in this PR.
- This PR is intended to replace the downstream workaround in `layer5io/meshery-cloud`.