### PR TITLE
chore: upgrade meshery/schemas to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/schemas v1.0.0
+	github.com/meshery/schemas v1.0.1
 	github.com/nats-io/nats.go v1.47.0
 	github.com/open-policy-agent/opa v1.11.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/schemas v1.0.0 h1:tJUE+mK/f1eGuXdh1atQm4oW8aLPFxFaXRi/hJnFhjQ=
-github.com/meshery/schemas v1.0.0/go.mod h1:/eO94KQC21suWzT5sIAJB6LKZx+oyAOr98vpomsD0TQ=
+github.com/meshery/schemas v1.0.1 h1:voyeQxpMlWJd+gI/5pl1xQmAWCd59HeieTcMevmNJ6o=
+github.com/meshery/schemas v1.0.1/go.mod h1:/eO94KQC21suWzT5sIAJB6LKZx+oyAOr98vpomsD0TQ=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=


### PR DESCRIPTION
## Summary
- Upgrades `meshery/schemas` from v1.0.0 to v1.0.1, which packages the complete set of v1beta1 and v1beta2 constructs
- All existing v1beta1/v1alpha3 imports verified compatible with v1.0.1
- Full build, `go vet`, and test suite pass cleanly

## v1beta2 Migration Analysis
The v1.0.1 release introduces v1beta2 packages for: `component`, `connection`, `design` (formerly pattern), `relationship`, `academy`, `plan`, `subscription`, `token`, `event`, and `invitation`.

**Current state**: meshkit continues to use v1beta1/v1alpha3 types because they include:
- **Entity interface** implementations (`TableName`, `Create`, `Type`, `GetID`, `GenerateID`, `GetEntityDetail`) required by the registry system
- **GORM integration** (table name mappings, association handling)
- **Conversion methods** (`ConvertTo`/`ConvertFrom` on PatternFile)
- **Evaluation models** (`Trace`, `EvaluationResponse`, `EvaluationRequest`)
- **Schema version constants** (`ComponentSchemaVersion`, `ModelSchemaVersion`, etc.)

The v1beta2 types are clean generated API types without these integrations. A full v1beta2 migration requires either:
1. Adding helper methods to v1beta2 packages in meshery/schemas, or
2. Creating wrapper/adapter types in meshkit (Go prohibits adding methods to external types)

No locally-defined types were found duplicating schemas constructs. No deprecated aliases are in use.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all tests pass