### PR TITLE
docs: cross-reference the identifier-naming contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Learn more about the <a href="https://meshery.io/community#meshmates">MeshMates<
 # Contributing
 
 Please do! We're a warm and welcoming community of open source contributors. Please join. All types of contributions are welcome. Be sure to read the [Contributor Guides](https://docs.meshery.io/project/contributing) for a tour of resources available to you and how to get started.
+
+## Naming conventions
+
+MeshKit utilities that expose wire-facing identifiers (error constants, structured log keys, event envelopes consumed by Meshery Server or Layer5 Cloud) follow the ecosystem-wide camelCase-on-the-wire contract. See the [identifier-naming contributor guide](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) in `meshery/schemas` for the reader-friendly 26-row naming directory with before/after and do/don't examples.


### PR DESCRIPTION
## Summary

Adds a "Naming conventions" subsection under "Contributing" in `README.md` pointing at the ecosystem-wide canonical reference at <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>.

MeshKit utilities that expose wire-facing identifiers (error constants, structured log keys, event envelopes consumed by Meshery Server or Layer5 Cloud) follow the ecosystem-wide camelCase-on-the-wire contract. The new pointer sits inside "Contributing" so anyone adding a new MeshKit helper that surfaces on the wire can find the directory before committing. No inline rules are duplicated here.

Paired cross-reference PRs are being opened in `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`, and `layer5io/sistent`.

## Test plan

- [x] `git diff --stat` shows 1 doc-only file, +4 lines / -0 lines, no code modified.
- [x] Branch opened off `origin/master`, signed off per DCO.