### PR TITLE
Create consumer-smoke.sh

### DIFF
--- a/.github/scripts/consumer-smoke.sh
+++ b/.github/scripts/consumer-smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+cat >"$WORKDIR/go.mod" <<MODULE
+module meshkit-smoke
+
+go 1.25.5
+
+require github.com/meshery/meshkit v0.0.0
+
+replace github.com/meshery/meshkit => ${GITHUB_WORKSPACE:-/workspace/meshkit}
+MODULE
+
+cat >"$WORKDIR/smoke_test.go" <<'TEST'
+package smoke
+
+import (
+    "testing"
+
+    mkerrors "github.com/meshery/meshkit/errors"
+)
+
+func TestMeshkitAsDependency(t *testing.T) {
+    err := mkerrors.New(
+        "11001",
+        mkerrors.Alert,
+        []string{"Dependency smoke test"},
+        []string{"MeshKit consumer build works"},
+        []string{"None"},
+        []string{"None"},
+    )
+
+    if mkerrors.GetCode(err) != "11001" {
+        t.Fatalf("expected error code 11001")
+    }
+}
+TEST
+
+cd "$WORKDIR"
+go test ./... -v

--- a/.github/scripts/consumer-smoke.sh
+++ b/.github/scripts/consumer-smoke.sh
@@ -14,7 +14,7 @@ go 1.25.5
 
 require github.com/meshery/meshkit v0.0.0
 
-replace github.com/meshery/meshkit => ${GITHUB_WORKSPACE:-/workspace/meshkit}
+replace github.com/meshery/meshkit => ${GITHUB_WORKSPACE:-$PWD}
 MODULE
 
 cat >"$WORKDIR/smoke_test.go" <<'TEST'
@@ -43,4 +43,5 @@ func TestMeshkitAsDependency(t *testing.T) {
 TEST
 
 cd "$WORKDIR"
+go mod tidy
 go test ./... -v


### PR DESCRIPTION
Added a consumer-oriented smoke script that creates a temporary external Go module, pins MeshKit via replace, and runs tests to confirm MeshKit can still be consumed as a downstream dependency after dependency updates.

Signed-off-by: raymondoyondi <raymondoyondi@gmail.com>

Closes #434