### PR TITLE
Create meshkit_smoke_test.go

### DIFF
--- a/integration/meshkit_smoke_test.go
+++ b/integration/meshkit_smoke_test.go
@@ -1,0 +1,28 @@
+package integration_test
+
+import (
+	"strings"
+	"testing"
+
+	mkerrors "github.com/meshery/meshkit/errors"
+)
+
+func TestMeshKitFunctionalFlow(t *testing.T) {
+	err := mkerrors.New(
+		"11000",
+		mkerrors.Alert,
+		[]string{"MeshKit smoke check"},
+		[]string{"Functional pipeline validation"},
+		[]string{"Unknown"},
+		[]string{"Review CI logs"},
+	)
+
+	if code := mkerrors.GetCode(err); code != "11000" {
+		t.Fatalf("expected error code 11000, got %q", code)
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "Functional pipeline validation") {
+		t.Fatalf("expected rendered message to include long description, got %q", message)
+	}
+}


### PR DESCRIPTION
Added an integration smoke test (integration/meshkit_smoke_test.go) that exercises MeshKit error creation, metadata extraction, and rendered error output as a functional flow check in CI.

Signed-off-by: raymondoyondi <raymondoyondi@gmail.com>

Closes #434