### PR TITLE
fix(wire-format): flip meshkit JSON tags to canonical camelCase (Phase 7c)

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -27,9 +27,9 @@ type Options struct {
 
 type Model struct {
 	ID        string `json:"id,omitempty" gorm:"primarykey"`
-	CreatedAt string `json:"created_at,omitempty" gorm:"index"`
-	UpdatedAt string `json:"updated_at,omitempty" gorm:"index"`
-	DeletedAt string `json:"deleted_at,omitempty" gorm:"index"`
+	CreatedAt string `json:"createdAt,omitempty" gorm:"index"`
+	UpdatedAt string `json:"updatedAt,omitempty" gorm:"index"`
+	DeletedAt string `json:"deletedAt,omitempty" gorm:"index"`
 }
 
 type Handler struct {

--- a/docs/event-streaming.md
+++ b/docs/event-streaming.md
@@ -113,9 +113,9 @@ locally.
 // models/events/events.go (excerpt)
 type Event struct {
     ID          ID                     `db:"id" json:"id"`
-    UserID      *UserID                `db:"user_id"      json:"user_id,omitempty"`
-    SystemID    SystemID               `db:"system_id"    json:"system_id"`
-    OperationID OperationID            `db:"operation_id" json:"operation_id"`
+    UserID      *UserID                `db:"user_id"      json:"userId,omitempty"`
+    SystemID    SystemID               `db:"system_id"    json:"systemId"`
+    OperationID OperationID            `db:"operation_id" json:"operationId"`
 
     Category    string                 `db:"category"     json:"category"`
     Action      string                 `db:"action"       json:"action"`
@@ -123,12 +123,12 @@ type Event struct {
     Severity    EventSeverity          `db:"severity"     json:"severity"`
     Status      EventStatus            `db:"status"       json:"status"`
 
-    ActedUpon   core.Uuid              `db:"acted_upon"   json:"acted_upon"`
+    ActedUpon   core.Uuid              `db:"acted_upon"   json:"actedUpon"`
     Metadata    map[string]interface{} `db:"metadata"     json:"metadata" gorm:"type:bytes;serializer:json"`
 
-    CreatedAt   CreatedAt              `db:"created_at" json:"created_at"`
-    UpdatedAt   UpdatedAt              `db:"updated_at" json:"updated_at"`
-    DeletedAt   *DeletedAt             `db:"deleted_at" json:"deleted_at,omitempty"`
+    CreatedAt   CreatedAt              `db:"created_at" json:"createdAt"`
+    UpdatedAt   UpdatedAt              `db:"updated_at" json:"updatedAt"`
+    DeletedAt   *DeletedAt             `db:"deleted_at" json:"deletedAt,omitempty"`
 }
 
 type EventSeverity string // alert | critical | debug | emergency | error | informational | warning | success

--- a/generators/github/package.go
+++ b/generators/github/package.go
@@ -21,7 +21,7 @@ type GitHubPackage struct {
 	branch     string
 	repository string
 	version    string
-	SourceURL  string `yaml:"source_url" json:"source_url"`
+	SourceURL  string `yaml:"source_url" json:"sourceUrl"`
 }
 
 func (gp GitHubPackage) GetVersion() string {

--- a/models/catalog/v1alpha1/catalog.go
+++ b/models/catalog/v1alpha1/catalog.go
@@ -9,18 +9,18 @@ import (
 
 // CatalogData defines model for catalog_data.
 type CatalogData struct {
-	ContentClass ContentClass `json:"content_class,omitempty"`
+	ContentClass ContentClass `json:"contentClass,omitempty"`
 	//Tracks the specific content version that has been made available in the Catalog
-	PublishedVersion string `json:"published_version"`
+	PublishedVersion string `json:"publishedVersion"`
 
 	// Compatibility A list of technologies included in or implicated by this design; a list of relevant technology tags.
 	Compatibility []CatalogDataCompatibility `json:"compatibility"`
 
 	// PatternCaveats Specific stipulations to consider and known behaviors to be aware of when using this design.
-	PatternCaveats string `json:"pattern_caveats"`
+	PatternCaveats string `json:"patternCaveats"`
 
 	// PatternInfo Purpose of the design along with its intended and unintended uses.
-	PatternInfo string `json:"pattern_info"`
+	PatternInfo string `json:"patternInfo"`
 
 	// Contains reference to the dark and light mode snapshots of the catalog.
 	SnapshotURL []string `json:"imageURL,omitempty"` // this will require updating exisitng catalog data as well. updated the json tag to match previous key name, so changes will not be required in exisitng catgalogs

--- a/models/events/events.go
+++ b/models/events/events.go
@@ -34,7 +34,7 @@ type DeletedAt = time.Time
 // Event Defines model for event_trackers
 type Event struct {
 	// ActedUpon UUID of the entity on which the event was performed.
-	ActedUpon core.Uuid `db:"acted_upon" json:"acted_upon"`
+	ActedUpon core.Uuid `db:"acted_upon" json:"actedUpon"`
 
 	// Action Action taken on the resource.
 	Action string `db:"action" json:"action"`
@@ -43,10 +43,10 @@ type Event struct {
 	Category string `db:"category" json:"category"`
 
 	// CreatedAt Timestamp when the resource was created.
-	CreatedAt CreatedAt `db:"created_at" json:"created_at"`
+	CreatedAt CreatedAt `db:"created_at" json:"createdAt"`
 
 	// DeletedAt Timestamp when the resource was deleted.
-	DeletedAt *DeletedAt `db:"deleted_at" json:"deleted_at,omitempty"`
+	DeletedAt *DeletedAt `db:"deleted_at" json:"deletedAt,omitempty"`
 
 	// Description A summary/receipt of event that occurred.
 	Description string `db:"description" json:"description"`
@@ -55,18 +55,18 @@ type Event struct {
 	// Metadata Contains meaningful information, specific to the type of event.
 	// Structure of metadata can be different for different events.
 	Metadata    map[string]interface{} `db:"metadata" json:"metadata" gorm:"type:bytes;serializer:json"`
-	OperationID OperationID            `db:"operation_id" json:"operation_id"`
+	OperationID OperationID            `db:"operation_id" json:"operationId"`
 
 	// Severity A set of seven standard event levels.
 	Severity EventSeverity `db:"severity" json:"severity"`
 
 	// Status Status for the event.
 	Status   EventStatus `db:"status" json:"status"`
-	SystemID SystemID    `db:"system_id" json:"system_id"`
+	SystemID SystemID    `db:"system_id" json:"systemId"`
 
 	// UpdatedAt Timestamp when the resource was updated.
-	UpdatedAt UpdatedAt `db:"updated_at" json:"updated_at"`
-	UserID    *UserID   `db:"user_id" json:"user_id,omitempty"`
+	UpdatedAt UpdatedAt `db:"updated_at" json:"updatedAt"`
+	UserID    *UserID   `db:"user_id" json:"userId,omitempty"`
 }
 
 // EventSeverity A set of seven standard event levels.
@@ -89,16 +89,16 @@ type EventsFilter struct {
 	Status   EventStatus `json:"status"`
 	Severity []string    `json:"severity"`
 	// SortOn Field on which records are sorted
-	SortOn string `json:"sort_on"`
+	SortOn string `json:"sortOn"`
 
 	// ActedUpon UUID of the entity on which the event was performed.
-	ActedUpon []string `json:"acted_upon"`
+	ActedUpon []string `json:"actedUpon"`
 
 	// UserID UUIDs of users to filter events by.
-	UserID []string `json:"user_id"`
+	UserID []string `json:"userId"`
 
 	// SystemID UUIDs of systems to filter events by.
-	SystemID []string `json:"system_id"`
+	SystemID []string `json:"systemId"`
 }
 
 // ID defines model for id.

--- a/models/smi_conformance.go
+++ b/models/smi_conformance.go
@@ -15,7 +15,7 @@ type Specification struct {
 
 // SmiResult - represents the results from Meshery smi conformance test run
 type SmiResult struct {
-	ID                 uuid.UUID       `json:"meshery_id,omitempty" db:"id"`
+	ID                 uuid.UUID       `json:"mesheryId,omitempty" db:"id"`
 	Date               string          `json:"datetime,omitempty" dc:"datetime"`
 	ServiceMesh        string          `json:"servicemesh,omitempty" db:"servicemesh"`
 	ServiceMeshVersion string          `json:"servicemeshversion,omitempty" db:"servicemeshversion"`

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -16,9 +16,9 @@ import (
 // Config holds the configuration parameters for tracing
 type Config struct {
 	// ServiceName is the name of the service being traced
-	ServiceName string `yaml:"service_name" json:"service_name"`
+	ServiceName string `yaml:"service_name" json:"serviceName"`
 	// ServiceVersion is the version of the service
-	ServiceVersion string `yaml:"service_version" json:"service_version"`
+	ServiceVersion string `yaml:"service_version" json:"serviceVersion"`
 	// Environment is the deployment environment (e.g., "production", "staging", "development")
 	Environment string `yaml:"environment" json:"environment"`
 	// Endpoint is the OTLP collector endpoint (e.g., "localhost:4317")

--- a/utils/kubernetes/kubernetes.go
+++ b/utils/kubernetes/kubernetes.go
@@ -9,7 +9,7 @@ import (
 type Client struct {
 	RestConfig        rest.Config           `json:"restconfig,omitempty"`
 	KubeClient        *kubernetes.Clientset `json:"kubeclient,omitempty"`
-	DynamicKubeClient dynamic.Interface     `json:"dynamic_kubeclient,omitempty"`
+	DynamicKubeClient dynamic.Interface     `json:"dynamicKubeClient,omitempty"`
 }
 
 func New(kubeconfig []byte) (*Client, error) {


### PR DESCRIPTION
## Summary

Phase 7c of the multi-repo identifier-naming overhaul: flip meshkit's snake_case `json:` wire tags to canonical camelCase, per the ecosystem contract (camelCase on the wire, snake_case in the database, ORM is the boundary — see [`meshery/schemas/AGENTS.md`](https://github.com/meshery/schemas/blob/master/AGENTS.md)).

The headline change is `models/events/events.go`: the `Event` type is embedded by meshery-cloud's `EventResult` and emitted by meshery server's events stream, so its snake_case keys (`acted_upon`, `user_id`, `system_id`, `created_at`, ...) were leaking out of every downstream API even after Phase 4 flipped the local cloud types. After this change, every meshkit-emitted event field is camelCase end-to-end.

`db:` tags are preserved as snake_case (database is snake-case-canonical). `yaml:` tags on config structs (e.g. `tracing.Config`) are preserved as their existing snake_case — yaml files are user-facing config, not a Meshery API wire contract.

## Tags flipped

`models/events/events.go` (11 tags):
- `Event.ActedUpon`: `acted_upon` -> `actedUpon`
- `Event.CreatedAt`: `created_at` -> `createdAt`
- `Event.DeletedAt`: `deleted_at,omitempty` -> `deletedAt,omitempty`
- `Event.OperationID`: `operation_id` -> `operationId`
- `Event.SystemID`: `system_id` -> `systemId`
- `Event.UpdatedAt`: `updated_at` -> `updatedAt`
- `Event.UserID`: `user_id,omitempty` -> `userId,omitempty`
- `EventsFilter.SortOn`: `sort_on` -> `sortOn`
- `EventsFilter.ActedUpon`: `acted_upon` -> `actedUpon`
- `EventsFilter.UserID`: `user_id` -> `userId`
- `EventsFilter.SystemID`: `system_id` -> `systemId`

`models/catalog/v1alpha1/catalog.go` (4 tags):
- `CatalogData.ContentClass`: `content_class,omitempty` -> `contentClass,omitempty`
- `CatalogData.PublishedVersion`: `published_version` -> `publishedVersion`
- `CatalogData.PatternCaveats`: `pattern_caveats` -> `patternCaveats`
- `CatalogData.PatternInfo`: `pattern_info` -> `patternInfo`

`database/database.go` (3 tags on the shared `Model`):
- `Model.CreatedAt`: `created_at,omitempty` -> `createdAt,omitempty`
- `Model.UpdatedAt`: `updated_at,omitempty` -> `updatedAt,omitempty`
- `Model.DeletedAt`: `deleted_at,omitempty` -> `deletedAt,omitempty`

`tracing/tracing.go` (2 `json:` tags; `yaml:` left alone):
- `Config.ServiceName`: `service_name` -> `serviceName`
- `Config.ServiceVersion`: `service_version` -> `serviceVersion`

`utils/kubernetes/kubernetes.go` (1 tag):
- `Client.DynamicKubeClient`: `dynamic_kubeclient,omitempty` -> `dynamicKubeClient,omitempty`

`models/smi_conformance.go` (1 tag):
- `SmiResult.ID`: `meshery_id,omitempty` -> `mesheryId,omitempty`

`generators/github/package.go` (1 `json:` tag; `yaml:` left alone):
- `GitHubPackage.SourceURL`: `source_url` -> `sourceUrl`

## Docs

- `docs/event-streaming.md` — updated the canonical `Event` struct excerpt to reflect camelCase JSON tags. The surrounding doc text already documented the camelCase-on-wire contract; this brings the example into agreement with the code.

## Out of scope (explicitly NOT flipped)

- `cmd/errorutil/internal/component/component.go` and `cmd/errorutil/internal/error/{summary,info,export}.go` — these define the **internal output schema for the `errorutil` tool** (the on-disk `component_info.json` and `${app}_analyze_summary.json` files consumed by CI / `make error`). They are not a wire contract; flipping would break tooling consumers.
- `utils/walker/github.go` — fields mirror the GitHub REST API response shape (`html_url`, `git_url`, `download_url`); 3rd-party wire contract.
- `utils/csv/csv_test.go` — `person_age` is a CSV column header in a test fixture exercising column-mapping behavior, not a JSON wire contract.

## Cross-repo follow-ups required

Once meshkit cuts a release tag with this change, downstream consumers must bump their meshkit dep and update any UI / handler code that reads the snake-case keys:

- **meshery** (`meshery/meshery`)
  - `go.mod`: bump `github.com/meshery/meshkit` to the new tag.
  - UI consumers of `/api/system/events` and the events SSE stream: read `actedUpon`, `userId`, `systemId`, `operationId`, `createdAt`, `updatedAt`, `deletedAt` (was snake-case).
  - GraphQL `events` subscription resolver / Relay schema: same.
  - `EventsFilter` query-string consumers: read `sortOn`, `actedUpon`, `userId`, `systemId`.
- **meshery-cloud** (`layer5io/meshery-cloud`)
  - `go.mod`: bump `github.com/meshery/meshkit` to the new tag.
  - The embedded meshkit `Event` inside `EventResult` now emits camelCase. Any cloud UI events table or search filter that reads the previously snake-cased keys must be updated.
- **meshery-extensions** (`layer5io/meshery-extensions`)
  - `go.mod`: bump `github.com/meshery/meshkit` to the new tag.
  - Verify catalog (`CatalogData`) and event surfaces — `contentClass`, `publishedVersion`, `patternCaveats`, `patternInfo` change wire keys.

These bumps will be tracked as follow-up PRs in their respective repos.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -count=1 ./...` — all packages pass (events, catalog, database, tracing, kubernetes, generators/github included)
- [x] Manual verification: no remaining snake_case `json:` tags outside the explicit exclusion set (`grep -rn 'json:\"[a-z]*_[a-z][^\"]*\"' --include='*.go'`)