### PR TITLE
chore(deps): bump github.com/meshery/schemas to v1.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/schemas v1.2.2
+	github.com/meshery/schemas v1.2.6
 	github.com/nats-io/nats.go v1.47.0
 	github.com/open-policy-agent/opa v1.11.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/schemas v1.2.2 h1:L07RaoqjzRRQxheAxTE5HCIqqcjfihKO5i5IBxCHic0=
-github.com/meshery/schemas v1.2.2/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
+github.com/meshery/schemas v1.2.6 h1:EKW4lQe/MUurmFxhW6Ulxe9u+b9828Ftmnc1bpEpzWQ=
+github.com/meshery/schemas v1.2.6/go.mod h1:QUDp59chV2L7KMHbywjumSJE1dkUK5P5vNNOU/2Z8as=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/meshery/schemas` from v1.2.2 to v1.2.6 (4 patch releases behind master).
- Surfaced by Phase 8a post-canonical-naming integration validation: meshery-cloud, meshery, and meshkit were all pinned at v1.2.2 even though the published Go module and the docs OpenAPI baseline already advanced to v1.2.6. Cloud's `TestPublishedDocsOpenAPIVersionNotAhead` was the canary failure.
- Companion PRs: meshery/meshery#18994 and layer5io/meshery-cloud#5145 (each lands the same v1.2.6 pin in its own go.mod). All three pin the same already-tagged release independently — no cross-PR ordering required.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./...` — all packages pass (artifacthub, github, logger, converter, events, meshmodel/registry, registration, registry, schema, schemas, tracing, utils, utils/component, utils/csv, utils/events, utils/kubernetes, utils/kubernetes/kompose, utils/manifests, utils/store, utils/walker, validator).

No code changes — pure dependency bump.