### PR TITLE
Update Go version to 1.26.4

### DIFF
--- a/.github/agents/meshkit-code-contributor.md
+++ b/.github/agents/meshkit-code-contributor.md
@@ -24,7 +24,7 @@ You are an expert-level software engineering agent specialized in contributing t
 
 ### Backend (MeshKit Core)
 
-- **Language**: Go 1.25.5 (always check `go.mod` for consistency)
+- **Language**: Go 1.26.4 (always check `go.mod` for consistency)
 - **Key Responsibilities**: Error definitions, helpers, and shared utilities consumed by Meshery services.
 - **Testing**: Go standard testing library with `--short`, `-race`, and coverage enabled via Makefile targets.
 - **Build System**: Make-based workflow defined in MeshKit’s Makefile.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Build, test, and lint
 
-- Use Go 1.25.x (`go.mod` pins `go 1.25.5`; CI uses Go 1.25).
+- Use Go 1.26.x (`go.mod` pins `go 1.26.4`; CI uses Go 1.26).
 - Prefer the repo `make` targets for final verification:
   - `make test` - runs `go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic`
   - `make check` - runs `golangci-lint run -c .golangci.yml -v ./...`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@master
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
           skip-cache: true
       - name: Run golangci-lint
         run: make check
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@master
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
           cache-dependency-path: go.sum
       - name: go mod tidy
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@master
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
           cache-dependency-path: go.sum
       - name: Run tests

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Run utility
         run: |

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -18,7 +18,7 @@
 GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 
-GOVERSION = 1.25.5
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/meshkit
 
-go 1.25.5
+go 1.26.4
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.9.3

--- a/registry/model.go
+++ b/registry/model.go
@@ -587,7 +587,7 @@ func AssignDefaultsForCompDefs(componentDef *component.ComponentDefinition, mode
 				return strings.EqualFold(k, name)
 			}); field.IsValid() && field.CanSet() {
 				switch field.Kind() {
-				case reflect.Ptr:
+				case reflect.Pointer:
 					ptrType := field.Type().Elem()
 					val := reflect.New(ptrType).Elem()
 


### PR DESCRIPTION
## Summary

- Updates the module Go version to 1.26.4
- Updates CI setup-go jobs to use the 1.26 release line
- Updates golangci-lint to a release built with Go 1.26
- Refreshes repository contributor guidance to match the new Go version
- Replaces the deprecated reflect.Ptr alias with reflect.Pointer for Go 1.26 vet compatibility

## Validation

- go mod tidy
- make tidy
- make build-errorutil
- make check
- make test