### PR TITLE
feat(entity): add ConnectionDefinition registry entity type

### DIFF
--- a/models/meshmodel/entity/types.go
+++ b/models/meshmodel/entity/types.go
@@ -13,6 +13,11 @@ const (
 	RelationshipDefinition EntityType = "relationship"
 	Model                  EntityType = "model"
 	Category               EntityType = "category"
+	// ConnectionDefinition is the registry entity type for connection
+	// definitions: uninitialized, per-model connection templates registered
+	// alongside components and relationships. The schemas connection helper
+	// (github.com/meshery/schemas/models/v1beta3/connection) reports this type.
+	ConnectionDefinition EntityType = "connection"
 )
 
 // Each entity will have it's own Filter implementation via which it exposes the nobs and dials to fetch entities


### PR DESCRIPTION
## Description

Adds a `ConnectionDefinition` value to the `EntityType` enum in `models/meshmodel/entity/types.go`.

Connection definitions - uninitialized, per-model connection templates - are registered into the registry alongside components and relationships. The schemas connection helper (`github.com/meshery/schemas/models/v1beta3/connection/connection_definition_helper.go`) implements the meshkit `entity.Entity` interface and reports this `EntityType` from its `Type()` method.

Because MeshKit owns the `EntityType` enum, the constant must live here. Without it, `github.com/meshery/schemas/models/v1beta3/connection` fails to compile:

```
models/v1beta3/connection/connection_definition_helper.go:21:16: undefined: entity.ConnectionDefinition
```

## Why this PR

Unblocks [meshery/schemas#932](https://github.com/meshery/schemas/pull/932), which adds the connection-definition construct and helper. That PR cannot compile (and post-merge artifact generation / downstream consumers would break) until this constant exists in a released MeshKit.

The value `"connection"` follows the established short-noun convention (`ComponentDefinition = "component"`, `RelationshipDefinition = "relationship"`).

## Scope / follow-on

This PR is intentionally limited to the enum constant, which is the precise and self-contained fix for the compile blocker. Wiring connection definitions through the full registration pipeline (the `schemaVersion` -> entity mapping in `utils/getEntityType` and the packaging-unit handling in `models/registration/dir.go`) is a larger feature that also requires a packaging-unit field and meshery-side consumption; it should land as a cohesive unit and is tracked as follow-on.

## Test

- `go build ./...` - passes
- `go vet ./models/meshmodel/entity/... ./models/registration/...` - passes
- `go test ./models/meshmodel/entity/... ./models/registration/...` - passes

## Notes

Coordinated cross-repo change. After merge, a `v1.0.11` release is needed so meshery/schemas#932 can bump its MeshKit dependency.