### PR TITLE
Consolidate owner terminology in events model

### DIFF
--- a/models/events/build.go
+++ b/models/events/build.go
@@ -58,7 +58,7 @@ func (e *EventBuilder) WithStatus(status EventStatus) *EventBuilder {
 }
 
 func (e *EventBuilder) FromUser(id core.Uuid) *EventBuilder {
-	e.event.UserID = &id
+	e.event.Owner = &id
 	return e
 }
 

--- a/models/events/build.go
+++ b/models/events/build.go
@@ -57,7 +57,7 @@ func (e *EventBuilder) WithStatus(status EventStatus) *EventBuilder {
 	return e
 }
 
-func (e *EventBuilder) FromUser(id core.Uuid) *EventBuilder {
+func (e *EventBuilder) FromOwner(id core.Uuid) *EventBuilder {
 	e.event.Owner = &id
 	return e
 }

--- a/models/events/constants.go
+++ b/models/events/constants.go
@@ -8,13 +8,13 @@ import (
 
 func DesignDownloadEvent(designID core.Uuid, designName string, userID core.Uuid, systemID core.Uuid) *Event {
 
-	event := NewEvent().ActedUpon(designID).FromSystem(systemID).FromUser(userID).WithCategory("pattern").WithAction("download").
+	event := NewEvent().ActedUpon(designID).FromSystem(systemID).FromOwner(userID).WithCategory("pattern").WithAction("download").
 		WithSeverity(Informational).WithDescription(fmt.Sprintf("Downloaded \"%s\" design", designName)).Build()
 	return event
 }
 
 func DesignViewEvent(designID core.Uuid, designName string, userID core.Uuid, systemID core.Uuid) *Event {
 
-	event := NewEvent().ActedUpon(designID).FromSystem(systemID).FromUser(userID).WithCategory("pattern").WithAction("view").WithSeverity(Informational).WithDescription(fmt.Sprintf("Accessed \"%s\" pattern.", designName)).Build()
+	event := NewEvent().ActedUpon(designID).FromSystem(systemID).FromOwner(userID).WithCategory("pattern").WithAction("view").WithSeverity(Informational).WithDescription(fmt.Sprintf("Accessed \"%s\" pattern.", designName)).Build()
 	return event
 }

--- a/models/events/events.go
+++ b/models/events/events.go
@@ -66,7 +66,7 @@ type Event struct {
 
 	// UpdatedAt Timestamp when the resource was updated.
 	UpdatedAt UpdatedAt `db:"updated_at" json:"updatedAt"`
-	UserID    *UserID   `db:"user_id" json:"userId,omitempty"`
+	Owner     *Owner    `db:"owner" json:"owner,omitempty"`
 }
 
 // EventSeverity A set of seven standard event levels.
@@ -94,8 +94,8 @@ type EventsFilter struct {
 	// ActedUpon UUID of the entity on which the event was performed.
 	ActedUpon []string `json:"actedUpon"`
 
-	// UserID UUIDs of users to filter events by.
-	UserID []string `json:"userId"`
+	// Owner UUIDs of owners to filter events by.
+	Owner []string `json:"owner"`
 
 	// SystemID UUIDs of systems to filter events by.
 	SystemID []string `json:"systemId"`
@@ -116,5 +116,5 @@ type Time = time.Time
 // UpdatedAt Timestamp when the resource was updated.
 type UpdatedAt = time.Time
 
-// UserID defines model for user_uuid.
-type UserID = core.Uuid
+// Owner defines model for owner uuid.
+type Owner = core.Uuid

--- a/models/events/events_test.go
+++ b/models/events/events_test.go
@@ -67,8 +67,8 @@ func TestEventBuilder_FullChain(t *testing.T) {
 	if event.Status != Read {
 		t.Errorf("expected status Read, got %s", event.Status)
 	}
-	if event.UserID == nil || *event.UserID != userID {
-		t.Error("UserID mismatch")
+	if event.Owner == nil || *event.Owner != userID {
+		t.Error("Owner mismatch")
 	}
 	if event.SystemID != systemID {
 		t.Error("SystemID mismatch")

--- a/models/events/events_test.go
+++ b/models/events/events_test.go
@@ -42,7 +42,7 @@ func TestEventBuilder_FullChain(t *testing.T) {
 		WithMetadata(metadata).
 		WithSeverity(Informational).
 		WithStatus(Read).
-		FromUser(userID).
+		FromOwner(userID).
 		FromSystem(systemID).
 		Build()
 


### PR DESCRIPTION
## Summary
Migrate Event model to use unified 'owner' field across all contexts, replacing inconsistent UserID terminology. This aligns meshery/meshkit with meshery/schemas contracts for owner consolidation.

## Changes
- Rename `Event.UserID` field to `Event.Owner`
- Update `EventBuilder.FromUser()` to set `Owner` field
- Replace `EventsFilter.UserID` with `EventsFilter.Owner`
- Update all related test assertions

## Rationale
The event model previously used `UserID` while other Meshery constructs standardize on `owner` for identifying resource ownership. This consolidation reduces terminology inconsistency and aligns with the schema migration in meshery/schemas.

## Test Plan
- All existing event tests updated and passing
- EventBuilder chain correctly sets owner field
- EventsFilter correctly references owner UUID