### PR TITLE
chore: migrate UUID from gofrs/uuid to google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/schemas v1.3.9
+	github.com/meshery/schemas v1.3.12
 	github.com/nats-io/nats.go v1.47.0
 	github.com/open-policy-agent/opa v1.11.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/go-logr/logr v1.4.3
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
@@ -163,6 +162,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/schemas v1.3.9 h1:vfj5RTOpdBAA2hSxgIpoFnBKr5Aus6BMbRHC8JN1k8M=
-github.com/meshery/schemas v1.3.9/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
+github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=
+github.com/meshery/schemas v1.3.12/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/models/events/build.go
+++ b/models/events/build.go
@@ -3,7 +3,7 @@ package events
 import (
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	core "github.com/meshery/schemas/models/core"
 )
 
@@ -12,7 +12,7 @@ type EventBuilder struct {
 }
 
 func NewEvent() *EventBuilder {
-	operationId, _ := uuid.NewV4()
+	operationId := uuid.New()
 	return &EventBuilder{
 		event: Event{
 			CreatedAt:   time.Now(),

--- a/models/events/database.go
+++ b/models/events/database.go
@@ -3,12 +3,12 @@ package events
 import (
 	"fmt"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
 func (e *Event) BeforeCreate(tx *gorm.DB) (err error) {
-	e.ID, _ = uuid.NewV4()
+	e.ID = uuid.New()
 	err = isEventStatusSupported(e)
 	return
 }

--- a/models/events/events_test.go
+++ b/models/events/events_test.go
@@ -3,7 +3,7 @@ package events
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 func TestNewEvent(t *testing.T) {
@@ -20,15 +20,15 @@ func TestNewEvent(t *testing.T) {
 }
 
 func TestEventBuilder_FullChain(t *testing.T) {
-	resourceID, err := uuid.FromString("11111111-1111-1111-1111-111111111111")
+	resourceID, err := uuid.Parse("11111111-1111-1111-1111-111111111111")
 	if err != nil {
 		t.Fatalf("failed to parse resourceID UUID: %v", err)
 	}
-	userID, err := uuid.FromString("22222222-2222-2222-2222-222222222222")
+	userID, err := uuid.Parse("22222222-2222-2222-2222-222222222222")
 	if err != nil {
 		t.Fatalf("failed to parse userID UUID: %v", err)
 	}
-	systemID, err := uuid.FromString("33333333-3333-3333-3333-333333333333")
+	systemID, err := uuid.Parse("33333333-3333-3333-3333-333333333333")
 	if err != nil {
 		t.Fatalf("failed to parse systemID UUID: %v", err)
 	}

--- a/models/meshmodel/core/v1beta1/policy.go
+++ b/models/meshmodel/core/v1beta1/policy.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/utils"
 	core "github.com/meshery/schemas/models/core"
@@ -33,7 +33,7 @@ func (p PolicyDefinition) GetID() core.Uuid {
 }
 
 func (p *PolicyDefinition) GenerateID() (core.Uuid, error) {
-	return uuid.NewV4()
+	return uuid.New(), nil
 }
 
 func (p PolicyDefinition) Type() entity.EntityType {

--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
@@ -130,7 +130,7 @@ func (rm *RegistryManager) RegisterEntity(h connection.Connection, en entity.Ent
 	if err != nil {
 		return false, true, err
 	}
-	id, _ := uuid.NewV4()
+	id := uuid.New()
 	entry := Registry{
 		ID:           id,
 		RegistrantID: registrantID,
@@ -150,7 +150,7 @@ func (rm *RegistryManager) RegisterEntity(h connection.Connection, en entity.Ent
 // By default during models generation ignore is set to false
 func (rm *RegistryManager) UpdateEntityStatus(ID string, status string, entityType string) error {
 	// Convert string UUID to google UUID
-	entityID, err := uuid.FromString(ID)
+	entityID, err := uuid.Parse(ID)
 	if err != nil {
 		return err
 	}

--- a/models/meshmodel/registry/registry_test.go
+++ b/models/meshmodel/registry/registry_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/schemas/models/v1beta1"
@@ -27,8 +27,7 @@ func TestUpdateEntityStatusUpdatesModel(t *testing.T) {
 		assert.NoError(t, db.DBClose())
 	})
 
-	hostID, err := uuid.NewV4()
-	require.NoError(t, err)
+	hostID := uuid.New()
 
 	modelDef := model.ModelDefinition{
 		SchemaVersion: v1beta1.ModelSchemaVersion,


### PR DESCRIPTION
## Summary

Implements meshery/meshkit#1029.

Migrates all hand-written Go code in the meshmodel entity/registry layer and events package from `github.com/gofrs/uuid` to `github.com/google/uuid`, aligning meshkit with the uuid consolidation in [meshery/schemas#727](https://github.com/meshery/schemas/pull/727).

**Changes:**
- `models/events/build.go`: `uuid.NewV4()` → `uuid.New()`
- `models/events/database.go`: `uuid.NewV4()` → `uuid.New()`
- `models/events/events_test.go`: `uuid.FromString()` → `uuid.Parse()`
- `models/meshmodel/core/v1beta1/policy.go`: `GenerateID()` returns `uuid.New(), nil`
- `models/meshmodel/registry/registry.go`: `uuid.NewV4()` → `uuid.New()`, `uuid.FromString()` → `uuid.Parse()`
- `models/meshmodel/registry/registry_test.go`: `uuid.NewV4()` → `uuid.New()`
- `go.mod`: demote `gofrs/uuid` from direct to indirect (still a transitive dep via `meshery/schemas@v1.3.9`)

## Compilation status

This PR **does not compile cleanly** against `meshery/schemas@v1.3.9` because `core.Uuid` is still a type alias for `gofrs/uuid.UUID` in that version. The type-mismatch errors in `models/events` and `models/meshmodel/core/v1beta1/policy.go` are expected and will resolve automatically once meshery/schemas#727 is merged, `core.Uuid` becomes `google/uuid.UUID`, and the dep is bumped here.

## Test plan

- [x] `go build ./...` — expected type-mismatch errors only (events and policy packages, all attributable to `core.Uuid` still being `gofrs/uuid.UUID` in schemas@v1.3.9)
- [x] `go test ./utils/...` — passes (pre-existing file-permission failures are unrelated)
- [x] No hand-written file retains a `github.com/gofrs/uuid` import
- [ ] Full test suite passes after meshery/schemas#727 is merged and dep bumped