### PR TITLE
fix: propagate uuid.NewRandom() errors in error-returning functions

### DIFF
--- a/models/events/database.go
+++ b/models/events/database.go
@@ -8,7 +8,10 @@ import (
 )
 
 func (e *Event) BeforeCreate(tx *gorm.DB) (err error) {
-	e.ID = uuid.New()
+	e.ID, err = uuid.NewRandom()
+	if err != nil {
+		return
+	}
 	err = isEventStatusSupported(e)
 	return
 }

--- a/models/meshmodel/core/v1beta1/policy.go
+++ b/models/meshmodel/core/v1beta1/policy.go
@@ -45,7 +45,11 @@ func (p *PolicyDefinition) GetEntityDetail() string {
 }
 
 func (p *PolicyDefinition) Create(db *database.Handler, hostID core.Uuid) (core.Uuid, error) {
-	p.ID, _ = p.GenerateID()
+	var err error
+	p.ID, err = p.GenerateID()
+	if err != nil {
+		return core.Uuid{}, err
+	}
 
 	mid, err := p.Model.Create(db, hostID)
 	if err != nil {

--- a/models/meshmodel/core/v1beta1/policy.go
+++ b/models/meshmodel/core/v1beta1/policy.go
@@ -33,7 +33,7 @@ func (p PolicyDefinition) GetID() core.Uuid {
 }
 
 func (p *PolicyDefinition) GenerateID() (core.Uuid, error) {
-	return uuid.New(), nil
+	return uuid.NewRandom()
 }
 
 func (p PolicyDefinition) Type() entity.EntityType {

--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -130,7 +130,10 @@ func (rm *RegistryManager) RegisterEntity(h connection.Connection, en entity.Ent
 	if err != nil {
 		return false, true, err
 	}
-	id := uuid.New()
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return false, false, err
+	}
 	entry := Registry{
 		ID:           id,
 		RegistrantID: registrantID,


### PR DESCRIPTION
## Summary

Follow-up to #1030 addressing review feedback: three functions that already return errors were using `uuid.New()` (which panics on entropy failure via `Must(NewRandom())`) instead of propagating the error explicitly.

- `PolicyDefinition.GenerateID()` — returns `(core.Uuid, error)`; now uses `uuid.NewRandom()` directly
- `Event.BeforeCreate()` — GORM hook propagates errors to abort the transaction; now captures the UUID error before calling `isEventStatusSupported`
- `RegistryManager.RegisterEntity()` — returns `(bool, bool, error)`; now returns `false, false, err` if UUID generation fails

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./models/...` — all pass