### PR TITLE
[uuid] Restore gofrs/uuid; pin schemas v1.3.13

### DIFF
--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
@@ -46,7 +46,7 @@ func NewChannelBrokerHandler(optsSetters ...OptionsSetter) *ChannelBrokerHandler
 	return &ChannelBrokerHandler{
 		name: fmt.Sprintf(
 			"channel-broker-handler--%s",
-			uuid.New().String(),
+			uuid.Must(uuid.NewV4()).String(),
 		),
 		Options: options,
 		storage: make(map[string]map[string]chan *broker.Message),

--- a/converter/helm.go
+++ b/converter/helm.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/models/patterns"
 	"github.com/meshery/meshkit/utils/helm"
 	"helm.sh/helm/v3/pkg/action"
@@ -70,7 +70,7 @@ func createHelmChartContent(manifestContent, chartName, chartVersion string) (st
 		return "", ErrCreateHelmChart(err, "creating temp directory")
 	}
 
-	buildID := uuid.New().String()
+	buildID := uuid.Must(uuid.NewV4()).String()
 	buildDir := filepath.Join(tempDir, buildID)
 	chartSourcePath := filepath.Join(buildDir, chartName)
 

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ replace (
 	// github.com/docker/libcompose => github.com/docker/libcompose v0.4.1-0.20190808084053-143e0f3f1ab9
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.5.5
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-
-//github.com/meshery/schemas => ../schemas
 )
 
 require (
@@ -23,11 +21,11 @@ require (
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/go-logr/logr v1.4.3
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
+	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-containerregistry v0.20.3
-	github.com/google/uuid v1.6.0
 	github.com/kubernetes/kompose v1.37.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/schemas v1.3.12
+	github.com/meshery/schemas v1.3.13
 	github.com/nats-io/nats.go v1.47.0
 	github.com/open-policy-agent/opa v1.11.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -162,7 +160,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -172,6 +169,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=
-github.com/meshery/schemas v1.3.12/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
+github.com/meshery/schemas v1.3.13 h1:q72IGBSYYbT3Zz7hZpprNFKTB3wQvKvjorFuHfK20s4=
+github.com/meshery/schemas v1.3.13/go.mod h1:o9g0uAmcyH7w/ZZbyHilVhZlEFoBGy8RE+OSJYqIfa0=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/models/events/build.go
+++ b/models/events/build.go
@@ -3,7 +3,7 @@ package events
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	core "github.com/meshery/schemas/models/core"
 )
 
@@ -12,7 +12,7 @@ type EventBuilder struct {
 }
 
 func NewEvent() *EventBuilder {
-	operationId := uuid.New()
+	operationId, _ := uuid.NewV4()
 	return &EventBuilder{
 		event: Event{
 			CreatedAt:   time.Now(),

--- a/models/events/build.go
+++ b/models/events/build.go
@@ -12,7 +12,7 @@ type EventBuilder struct {
 }
 
 func NewEvent() *EventBuilder {
-	operationId, _ := uuid.NewV4()
+	operationId := uuid.Must(uuid.NewV4())
 	return &EventBuilder{
 		event: Event{
 			CreatedAt:   time.Now(),

--- a/models/events/database.go
+++ b/models/events/database.go
@@ -3,12 +3,12 @@ package events
 import (
 	"fmt"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 )
 
 func (e *Event) BeforeCreate(tx *gorm.DB) (err error) {
-	e.ID, err = uuid.NewRandom()
+	e.ID, err = uuid.NewV4()
 	if err != nil {
 		return
 	}

--- a/models/events/events_test.go
+++ b/models/events/events_test.go
@@ -15,8 +15,8 @@ func TestNewEvent(t *testing.T) {
 	if event.Status != Unread {
 		t.Errorf("expected default status Unread, got %s", event.Status)
 	}
-	// OperationID is generated via uuid.NewV4() in NewEvent which ignores errors.
-	// We only verify default status here; OperationID may be Nil if entropy is unavailable.
+	// OperationID is generated via uuid.Must(uuid.NewV4()) in NewEvent, which
+	// panics only if entropy is unavailable, so it is always a valid non-Nil UUID.
 }
 
 func TestEventBuilder_FullChain(t *testing.T) {

--- a/models/events/events_test.go
+++ b/models/events/events_test.go
@@ -3,7 +3,7 @@ package events
 import (
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 func TestNewEvent(t *testing.T) {
@@ -20,15 +20,15 @@ func TestNewEvent(t *testing.T) {
 }
 
 func TestEventBuilder_FullChain(t *testing.T) {
-	resourceID, err := uuid.Parse("11111111-1111-1111-1111-111111111111")
+	resourceID, err := uuid.FromString("11111111-1111-1111-1111-111111111111")
 	if err != nil {
 		t.Fatalf("failed to parse resourceID UUID: %v", err)
 	}
-	userID, err := uuid.Parse("22222222-2222-2222-2222-222222222222")
+	userID, err := uuid.FromString("22222222-2222-2222-2222-222222222222")
 	if err != nil {
 		t.Fatalf("failed to parse userID UUID: %v", err)
 	}
-	systemID, err := uuid.Parse("33333333-3333-3333-3333-333333333333")
+	systemID, err := uuid.FromString("33333333-3333-3333-3333-333333333333")
 	if err != nil {
 		t.Fatalf("failed to parse systemID UUID: %v", err)
 	}

--- a/models/meshmodel/core/v1beta1/policy.go
+++ b/models/meshmodel/core/v1beta1/policy.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/utils"
 	core "github.com/meshery/schemas/models/core"
@@ -33,7 +33,7 @@ func (p PolicyDefinition) GetID() core.Uuid {
 }
 
 func (p *PolicyDefinition) GenerateID() (core.Uuid, error) {
-	return uuid.NewRandom()
+	return uuid.NewV4()
 }
 
 func (p PolicyDefinition) Type() entity.EntityType {

--- a/models/meshmodel/registry/registry.go
+++ b/models/meshmodel/registry/registry.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
@@ -130,7 +130,7 @@ func (rm *RegistryManager) RegisterEntity(h connection.Connection, en entity.Ent
 	if err != nil {
 		return false, true, err
 	}
-	id, err := uuid.NewRandom()
+	id, err := uuid.NewV4()
 	if err != nil {
 		return false, false, err
 	}
@@ -153,7 +153,7 @@ func (rm *RegistryManager) RegisterEntity(h connection.Connection, en entity.Ent
 // By default during models generation ignore is set to false
 func (rm *RegistryManager) UpdateEntityStatus(ID string, status string, entityType string) error {
 	// Convert string UUID to google UUID
-	entityID, err := uuid.Parse(ID)
+	entityID, err := uuid.FromString(ID)
 	if err != nil {
 		return err
 	}

--- a/models/meshmodel/registry/registry_test.go
+++ b/models/meshmodel/registry/registry_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/schemas/models/v1beta1"
@@ -27,7 +27,7 @@ func TestUpdateEntityStatusUpdatesModel(t *testing.T) {
 		assert.NoError(t, db.DBClose())
 	})
 
-	hostID := uuid.New()
+	hostID := uuid.Must(uuid.NewV4())
 
 	modelDef := model.ModelDefinition{
 		SchemaVersion: v1beta1.ModelSchemaVersion,

--- a/models/smi_conformance.go
+++ b/models/smi_conformance.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 type Specification struct {

--- a/utils/broadcast/broadcaster.go
+++ b/utils/broadcast/broadcaster.go
@@ -11,7 +11,7 @@ package broadcast
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 type BroadcastSource string

--- a/utils/uuid.go
+++ b/utils/uuid.go
@@ -1,13 +1,13 @@
 package utils
 
 import (
-	"fmt"
-
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 func NewUUID() (string, error) {
-	id := uuid.New()
-	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:])
-	return uuid, nil
+	id, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
 }


### PR DESCRIPTION
**Notes for Reviewers**

Reverses meshkit's gofrs->google/uuid migration (PR #1033 / commits `36b38e9`, `c9788db`, `b57fae9`) and pins the gofrs-restored `github.com/meshery/schemas v1.3.13`.

**Why.** `google/uuid`-typed UUID primary keys panic `gobuffalo/pop` v4.13.1 on every Create/Update (pop hardcodes a `gofrs/uuid.UUID` type assertion). The ecosystem standardizes on **gofrs v4** (not gofrs `/v5`, which re-triggers the panic). `core.Uuid` is `gofrs/uuid.UUID` again as of schemas v1.3.13, so meshkit's entity layer must produce gofrs UUIDs.

**What changed**
- meshmodel entity layer (`policy`, `registry`, `events/build`, `events/database`): `uuid.NewRandom()` -> `uuid.NewV4()`, `uuid.Parse()` -> `uuid.FromString()`, `uuid.New()` -> `uuid.Must(uuid.NewV4())`. gofrs `NewV4` shares `NewRandom`'s `(UUID, error)` signature, so **PR #1033's error-propagation fix is preserved** (no regression to error-ignoring).
- `broker/channel`, `converter/helm`, `utils/uuid`, `utils/broadcast`, `models/smi_conformance` (the last is pop-backed `db:"id"`): back to gofrs.
- `go.mod`: pin `github.com/meshery/schemas v1.3.13`; `google/uuid` demoted to indirect.

**Validation:** `go build ./...` + touched-package tests green against the released schemas v1.3.13.

Part of the ecosystem-wide gofrs standardization (schemas #945, already merged; meshery + meshery-cloud companion PRs follow).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.