### PR TITLE
[Fix] Add SanitizePattern to trim whitespace and fix YAML manifest exports

### DIFF
--- a/models/patterns/pattern.go
+++ b/models/patterns/pattern.go
@@ -2,6 +2,7 @@ package patterns
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -79,6 +80,54 @@ func DehydratePattern(pattern *pattern.PatternFile) {
 			comp.ModelReference = comp.Model.ToReference()
 		}
 		comp.Model = nil
+	}
+}
+
+// SanitizePattern trims leading and trailing whitespace from every string key
+// and string value inside each component's Configuration map, and from each
+// component's DisplayName. This prevents gopkg.in/yaml.v3 from quoting map
+// keys or values that contain incidental whitespace (e.g. 'storage ': 2Gi)
+// when the design is exported as a Kubernetes manifest or Helm chart.
+//
+// Call SanitizePattern at the design-save boundary, alongside DehydratePattern,
+// so that clean data is always persisted to the database.
+func SanitizePattern(p *pattern.PatternFile) {
+	for _, comp := range p.Components {
+		comp.DisplayName = strings.TrimSpace(comp.DisplayName)
+		comp.Configuration = sanitizeConfigMap(comp.Configuration)
+	}
+}
+
+// sanitizeConfigMap recursively trims string keys and string values in a
+// map[string]interface{} configuration tree. Non-string leaves (bool, number,
+// nil) are passed through unchanged so that schema-typed fields are not
+// corrupted.
+func sanitizeConfigMap(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		result[strings.TrimSpace(k)] = sanitizeConfigValue(v)
+	}
+	return result
+}
+
+func sanitizeConfigValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		return strings.TrimSpace(val)
+	case map[string]interface{}:
+		return sanitizeConfigMap(val)
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, item := range val {
+			result[i] = sanitizeConfigValue(item)
+		}
+		return result
+	default:
+		// bool, int64, float64, nil — pass through unchanged.
+		return v
 	}
 }
 

--- a/models/patterns/pattern.go
+++ b/models/patterns/pattern.go
@@ -92,7 +92,13 @@ func DehydratePattern(pattern *pattern.PatternFile) {
 // Call SanitizePattern at the design-save boundary, alongside DehydratePattern,
 // so that clean data is always persisted to the database.
 func SanitizePattern(p *pattern.PatternFile) {
+	if p == nil {
+		return
+	}
 	for _, comp := range p.Components {
+		if comp == nil {
+			continue
+		}
 		comp.DisplayName = strings.TrimSpace(comp.DisplayName)
 		comp.Configuration = sanitizeConfigMap(comp.Configuration)
 	}

--- a/models/patterns/pattern_sanitize_test.go
+++ b/models/patterns/pattern_sanitize_test.go
@@ -113,3 +113,16 @@ func TestSanitizePattern_EmptyPatternIsNoop(t *testing.T) {
 	// Must not panic on empty component list.
 	patterns.SanitizePattern(p)
 }
+
+func TestSanitizePattern_NilPatternFileIsNoop(t *testing.T) {
+	// Must not panic when called with a nil *PatternFile.
+	patterns.SanitizePattern(nil)
+}
+
+func TestSanitizePattern_NilComponentInSliceIsSkipped(t *testing.T) {
+	// Must not panic when the Components slice contains a nil pointer.
+	p := &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{nil},
+	}
+	patterns.SanitizePattern(p)
+}

--- a/models/patterns/pattern_sanitize_test.go
+++ b/models/patterns/pattern_sanitize_test.go
@@ -1,0 +1,115 @@
+package patterns_test
+
+import (
+	"testing"
+
+	"github.com/meshery/meshkit/models/patterns"
+	component "github.com/meshery/schemas/models/v1beta2/component"
+	pattern "github.com/meshery/schemas/models/v1beta3/design"
+)
+
+func makePatternFile(displayName string, config map[string]interface{}) *pattern.PatternFile {
+	return &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{
+			{
+				DisplayName:   displayName,
+				Configuration: config,
+			},
+		},
+	}
+}
+
+func TestSanitizePattern_TrimsDisplayName(t *testing.T) {
+	p := makePatternFile("  my-pvc  ", nil)
+	patterns.SanitizePattern(p)
+	got := p.Components[0].DisplayName
+	if got != "my-pvc" {
+		t.Errorf("expected DisplayName %q, got %q", "my-pvc", got)
+	}
+}
+
+func TestSanitizePattern_TrimsStringKeyWithTrailingSpace(t *testing.T) {
+	// Reproduces the 'storage ': 2Gi YAML quoting bug.
+	p := makePatternFile("pvc", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"resources": map[string]interface{}{
+				"limits": map[string]interface{}{
+					"storage ": "2Gi", // trailing space in key
+				},
+			},
+		},
+	})
+	patterns.SanitizePattern(p)
+
+	limits := p.Components[0].Configuration["spec"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})
+	if _, ok := limits["storage "]; ok {
+		t.Error("key 'storage ' with trailing space should have been trimmed")
+	}
+	if v, ok := limits["storage"]; !ok || v != "2Gi" {
+		t.Errorf("expected limits[\"storage\"] = \"2Gi\", got %v", v)
+	}
+}
+
+func TestSanitizePattern_TrimsStringValue(t *testing.T) {
+	// Reproduces the 'test-volume ': trailing-space string value quoting bug.
+	p := makePatternFile("deployment", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"volumes": []interface{}{
+						map[string]interface{}{
+							"name": "test-volume ", // trailing space in value
+						},
+					},
+				},
+			},
+		},
+	})
+	patterns.SanitizePattern(p)
+
+	volumes := p.Components[0].Configuration["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["volumes"].([]interface{})
+	vol := volumes[0].(map[string]interface{})
+	if got := vol["name"]; got != "test-volume" {
+		t.Errorf("expected volumes[0].name = \"test-volume\", got %q", got)
+	}
+}
+
+func TestSanitizePattern_PreservesNonStringLeaves(t *testing.T) {
+	// bool, int, float, nil must pass through unchanged.
+	p := makePatternFile("comp", map[string]interface{}{
+		"replicas":  3,
+		"enabled":   true,
+		"ratio":     1.5,
+		"optionNil": nil,
+	})
+	patterns.SanitizePattern(p)
+
+	cfg := p.Components[0].Configuration
+	if cfg["replicas"] != 3 {
+		t.Errorf("replicas changed: %v", cfg["replicas"])
+	}
+	if cfg["enabled"] != true {
+		t.Errorf("enabled changed: %v", cfg["enabled"])
+	}
+	if cfg["ratio"] != 1.5 {
+		t.Errorf("ratio changed: %v", cfg["ratio"])
+	}
+	if cfg["optionNil"] != nil {
+		t.Errorf("optionNil changed: %v", cfg["optionNil"])
+	}
+}
+
+func TestSanitizePattern_NilConfigurationIsNoop(t *testing.T) {
+	p := makePatternFile("comp", nil)
+	// Must not panic.
+	patterns.SanitizePattern(p)
+	if p.Components[0].Configuration != nil {
+		t.Errorf("expected nil Configuration to remain nil")
+	}
+}
+
+func TestSanitizePattern_EmptyPatternIsNoop(t *testing.T) {
+	p := &pattern.PatternFile{}
+	// Must not panic on empty component list.
+	patterns.SanitizePattern(p)
+}


### PR DESCRIPTION
### Description
This PR introduces a robust server-side sanitization utility designed to prevent YAML quoting artifacts in exported Kubernetes manifests. 

When users accidentally type trailing whitespace in the UI, `yaml.v3` strictly preserves it upon export by wrapping keys and values in single quotes (e.g., `'storage ': 1Gi`), which causes the manifest to fail Kubernetes validation. This PR adds a data-scrubbing step that can be called at the persistence boundary to prevent this dirty data from ever reaching the database.

**Changes Made:**
- Added `SanitizePattern` alongside helper functions (`sanitizeConfigMap`, `sanitizeConfigValue`) to recursively traverse a pattern's `Configuration` map.
- Automatically trims leading and trailing whitespace from all string keys and string values, as well as the component `DisplayName`.
- Explicitly passes `bool`, `int64`, `float64`, and `nil` through unchanged to guarantee type safety and prevent schema data corruption.
- Added 6 comprehensive unit tests covering edge cases (nil maps, empty components, type-preservation, and value-trimming).

**Related Issue:**
Fixes #1036 



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
