### PR TITLE
registry: track meshery server/meshmodel relocation to server/models

### DIFF
--- a/registry/relationship.go
+++ b/registry/relationship.go
@@ -112,7 +112,7 @@ func (mrh *RelationshipCSVHelper) ParseRelationshipsSheet(modelName string) erro
 
 func ProcessRelationships(relationshipCSVHelper *RelationshipCSVHelper, spreadsheetUpdateChan chan RelationshipCSV, path string) {
 	if path == "" {
-		path = "../../meshery/server/meshmodel"
+		path = "../../meshery/server/models"
 	}
 	for _, relationship := range relationshipCSVHelper.Relationships {
 		var versions []string


### PR DESCRIPTION
## Symptom
`registry.ProcessRelationships` has a hardcoded fallback default path of `../../meshery/server/meshmodel` (`registry/relationship.go:115`), used when the function is invoked without an explicit `path`. The meshery server's model data directory is being relocated and renamed from `server/meshmodel` to `server/models`, leaving this fallback pointing at a directory that will no longer exist.

## Root cause
The default targets the old on-disk model-definitions directory in the meshery repo. When `path == ""`, relationship version resolution (`os.ReadDir(filepath.Join(path, relationship.Model))`) would read from the stale location and fail.

## Fix
Update the fallback to `../../meshery/server/models` so relationship generation resolves model versions from the new location when no explicit path is supplied. The normal `mesheryctl registry generate` flow always passes an explicit `path`, so this only affects callers that rely on the default - but it should track the new canonical location.

## Scope note - this is the only MeshKit reference to the data directory
The many `github.com/meshery/meshkit/models/meshmodel/...` import paths are MeshKit's own Go package and are **unrelated** to the meshery server directory rename - they are unaffected. This fallback string is the sole filesystem reference in MeshKit to the relocated directory.

## Watch for - coordinated changes in sibling repos
This rename requires coordinated updates elsewhere (flagged for visibility, not included here):
- **meshery**: source constants (`server/models/seed_models.go` `ModelsPath`/`PoliciesPath`, `k8s_components_registration.go`, `server/cmd/main.go` `RelationshipsPath`), `server/policies/*_test.go`, `mesheryctl registry generate/update` flag defaults, `Makefile`, Dockerfiles, `.github/workflows/{model-generator,rego-lint-and-test}.yml`, `.github/labeler.yml`, issue templates, and docs.
- **meshery-extensions**: `.github/workflows/build-and-release.yml` sparse-checkout exclusion (`!/server/meshmodel`).
- **meshery-cloud / layer5 / meshery.io**: no references to meshery's `server/meshmodel`; unaffected. (meshery-cloud's own `meshmodels/` data dir is independent and not part of this rename.)