### PR TITLE
registry: correct meshmodel fallback to meshery/models

### DIFF
--- a/registry/relationship.go
+++ b/registry/relationship.go
@@ -112,7 +112,7 @@ func (mrh *RelationshipCSVHelper) ParseRelationshipsSheet(modelName string) erro
 
 func ProcessRelationships(relationshipCSVHelper *RelationshipCSVHelper, spreadsheetUpdateChan chan RelationshipCSV, path string) {
 	if path == "" {
-		path = "../../meshery/server/models"
+		path = "../../meshery/models"
 	}
 	for _, relationship := range relationshipCSVHelper.Relationships {
 		var versions []string


### PR DESCRIPTION
Follow-up correction to #1040.

The meshery model data directory is relocating to the **repo root** as `meshery/models` - not `meshery/server/models` as the prior PR assumed. This points the `ProcessRelationships` fallback (`registry/relationship.go:115`) at `../../meshery/models`.

This is the only filesystem reference to the relocated directory in MeshKit; the `…/meshkit/models/meshmodel/…` Go import paths are unrelated and unaffected.