### PR TITLE
fix: resolve docker/docker/api -> moby/moby/api module path mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.5
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.9.3
-	// github.com/docker/docker => github.com/moby/moby v23.0.3+incompatible
 	// github.com/docker/libcompose => github.com/docker/libcompose v0.4.1-0.20190808084053-143e0f3f1ab9
+	github.com/docker/docker/api => github.com/moby/moby/api v1.55.0
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.5.5
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 


### PR DESCRIPTION
## Description

Resolves #963 
### Problem

When running `go mod tidy`, the build fails with:

```
github.com/docker/docker/api@v1.54.0: parsing go.mod:
    module declares its path as: github.com/moby/moby/api
        but was required as: github.com/docker/docker/api
```

This happens because Docker recently modularized their repository into sub-modules with their own `go.mod` files. The sub-module at `github.com/docker/docker/api` is a vanity import path that redirects to `github.com/moby/moby` - but the `go.mod` inside declares `module github.com/moby/moby/api`, causing a path mismatch.

Transitive dependencies like `kubernetes/kompose`, `fsouza/go-dockerclient`, and `docker/cli` can trigger this when they reference types under `docker/docker/api/types/`.

### Fix

Added a `replace` directive in `go.mod` to redirect the Docker vanity path to the canonical Moby module:

```go
github.com/docker/docker/api => github.com/moby/moby/api v1.55.0
```

This is the standard approach for handling the Docker/Moby module path divergence, consistent with the existing `replace` patterns already in the project (e.g., `Sirupsen/logrus => sirupsen/logrus`).

### Why not the suggested fix from the issue?

The issue suggested `replace github.com/docker/docker/api => github.com/moby/moby/api v20.10.24+incompatible`, but `v20.10.24` is a version of the root `docker/docker` module - not the `api` sub-module. The `moby/moby/api` sub-module uses versions `v1.52.0` through `v1.55.0`. This PR uses `v1.55.0` (latest stable).

### Verification

- [x] `go mod tidy` - passes, idempotent
- [x] `go test ./...` - all packages pass
- [x] `go vet ./...` - clean
- [x] No unintended file changes (only `go.mod` modified, 1 line changed)