### PR TITLE
fix(syncmodutil): emit one canonical, deduplicated replace block

### DIFF
--- a/cmd/syncmodutil/internal/modsync/sync.go
+++ b/cmd/syncmodutil/internal/modsync/sync.go
@@ -72,83 +72,87 @@ func (g *GoMod) SyncRequire(f io.Reader, throwerr bool) (gomod string, err error
 		}
 	}
 
-	// Emit a replace block that pins every package in the source (host)
-	// module graph to its exact source-selected version. Pinning via
-	// `replace` — rather than relying on `require` alone — is required for
-	// Go plugin ABI compatibility. Without it, the `go mod tidy` step that
-	// callers run after this tool can upgrade transitive dependencies past
-	// what the host binary is linked against (for example, a direct
-	// dependency on github.com/99designs/gqlgen pulling in a newer
-	// github.com/vektah/gqlparser/v2 than the host uses), causing
-	// plugin.Open to fail at runtime with:
+	// Emit a single, canonical replace block that pins every package in the
+	// source (host) module graph to its exact source-selected version.
+	// Pinning via `replace` — rather than relying on `require` alone — is
+	// required for Go plugin ABI compatibility. Without it, the `go mod tidy`
+	// step that callers run after this tool can upgrade transitive
+	// dependencies past what the host binary is linked against (for example,
+	// a direct dependency on github.com/99designs/gqlgen pulling in a newer
+	// github.com/vektah/gqlparser/v2 than the host uses), causing plugin.Open
+	// to fail at runtime with:
 	//   "plugin was built with a different version of package <pkg>".
-	// Because replace directives override require resolution, this
-	// guarantees the destination module is compiled against the exact same
-	// versions as the source. Source-declared replaces take precedence over
-	// pinning and are emitted verbatim.
-	replacedMods := make(map[string]bool, len(g.ReplacedVersions))
-	for _, r := range g.ReplacedVersions {
-		if len(r) >= 1 {
-			replacedMods[r[0].Name] = true
+	//
+	// The block is assembled by merging three sources, highest precedence
+	// first, keeping exactly one directive per module:
+	//   1. Source-declared replaces (emitted verbatim). These override
+	//      require resolution, so the destination compiles against the exact
+	//      same versions as the source.
+	//   2. Source require pins (module => module version).
+	//   3. Destination-only replaces the source does not touch, so
+	//      extension-specific overrides (e.g. a local `=> ../../meshery`
+	//      path) survive.
+	//
+	// Every pre-existing replace in the destination is stripped first and the
+	// merged set is re-emitted as one block. Emitting exactly one directive
+	// per module is what makes the tool idempotent and guarantees the output
+	// can never carry a duplicate or conflicting replacement — even when the
+	// destination arrives already corrupted by a prior run (two conflicting
+	// replaces for the same module in separate blocks, which makes the
+	// caller's `go mod tidy` fail with "conflicting replacements for
+	// <module>" before this tool can run again to heal it).
+	final := make(map[string]string, len(g.RequiredVersions)+len(g.ReplacedVersions))
+	order := make([]string, 0, len(g.RequiredVersions)+len(g.ReplacedVersions))
+	addReplace := func(name, line string) {
+		if name == "" || line == "" {
+			return
 		}
+		if _, exists := final[name]; exists {
+			return
+		}
+		final[name] = line
+		order = append(order, name)
 	}
 
-	// Compute the set of modules we will emit a replace directive for, so
-	// that any pre-existing replace in the destination for the same module
-	// can be stripped first. Leaving both in place would cause `go mod tidy`
-	// to fail with "multiple replacements for <module>".
-	emitModules := make(map[string]bool, len(g.RequiredVersions)+len(g.ReplacedVersions))
-	for _, required := range g.RequiredVersions {
-		if !replacedMods[required.Name] {
-			emitModules[required.Name] = true
-		}
-	}
-	for _, r := range g.ReplacedVersions {
-		if len(r) >= 1 {
-			emitModules[r[0].Name] = true
-		}
-	}
-	data = stripConflictingReplaces(data, emitModules)
-
-	if len(g.RequiredVersions) > 0 || len(g.ReplacedVersions) > 0 {
-		data = append(data, "replace (")
-	}
-
-	pinned := make(map[string]bool, len(g.RequiredVersions))
-	for _, required := range g.RequiredVersions {
-		if pinned[required.Name] || replacedMods[required.Name] {
-			continue
-		}
-		pinned[required.Name] = true
-		data = append(data, fmt.Sprintf("\t%s => %s %s", required.Name, required.Name, required.Version))
-	}
-
-	// Add all the replaced versions from source to destination. Running go
-	// mod tidy after the utility will perform the cleanup in the destination
-	// go.mod and remove unused entries. Instead of trying to intelligently
-	// perform diffs, it is better to let `go mod tidy` do the cleanup.
+	// 1. Source-declared replaces take precedence and are emitted verbatim.
 	for _, replaced := range g.ReplacedVersions {
-		data = append(data, formatReplaceLine(replaced))
+		if len(replaced) >= 1 {
+			addReplace(replaced[0].Name, formatReplaceLine(replaced))
+		}
+	}
+	// 2. Pin every source require to its exact version.
+	for _, required := range g.RequiredVersions {
+		addReplace(required.Name, fmt.Sprintf("\t%s => %s %s", required.Name, required.Name, required.Version))
+	}
+	// 3. Preserve destination-only replaces (deduplicated; first wins).
+	for _, replaced := range getReplacedVersionsFromString(string(b)) {
+		if len(replaced) >= 1 {
+			addReplace(replaced[0].Name, formatReplaceLine(replaced))
+		}
 	}
 
-	if len(g.RequiredVersions) > 0 || len(g.ReplacedVersions) > 0 {
+	data = stripAllReplaces(data)
+
+	if len(order) > 0 {
+		data = append(data, "replace (")
+		for _, name := range order {
+			data = append(data, final[name])
+		}
 		data = append(data, ")")
 	}
 	gomod = strings.Join(data, "\n")
 	return
 }
 
-// stripConflictingReplaces removes any replace directive from the
-// destination go.mod lines whose "from" module is in the conflicts set.
-// Both forms are handled: single-line (`replace foo => bar v1`) and lines
-// inside an existing `replace (...)` block. Replaces for modules not in
-// conflicts are preserved — including destination-specific overrides that
-// the source does not touch. Empty replace blocks that may be left behind
-// are valid go.mod syntax; `go mod tidy` cleans them up.
-func stripConflictingReplaces(data []string, conflicts map[string]bool) []string {
-	if len(conflicts) == 0 {
-		return data
-	}
+// stripAllReplaces removes every replace directive from the destination
+// go.mod lines — both block form (`replace ( ... )`, including the wrapping
+// lines) and single-line form (`replace foo => bar v1`). The caller re-emits
+// a single canonical, deduplicated replace block. Removing all pre-existing
+// replaces (rather than only those being re-emitted) is what guarantees the
+// result can never carry a duplicate or conflicting replacement, even when
+// the destination arrived corrupted from a prior run. Any blank lines left
+// where blocks were removed are normalized by the caller's `go mod tidy`.
+func stripAllReplaces(data []string) []string {
 	out := make([]string, 0, len(data))
 	inReplaceBlock := false
 	for _, line := range data {
@@ -156,35 +160,22 @@ func stripConflictingReplaces(data []string, conflicts map[string]bool) []string
 
 		if !inReplaceBlock && (trim == "replace (" || trim == "replace(") {
 			inReplaceBlock = true
-			out = append(out, line)
-			continue
+			continue // drop the opening line
 		}
-		if inReplaceBlock && trim == ")" {
-			inReplaceBlock = false
-			out = append(out, line)
-			continue
+		if inReplaceBlock {
+			if trim == ")" {
+				inReplaceBlock = false
+			}
+			continue // drop block-interior lines and the closing ")"
 		}
 
+		// Single-line replace outside any block. go.mod allows arbitrary
+		// whitespace after the `replace` keyword, so tokenize rather than
+		// match a fixed prefix. Lines that merely contain "=>" elsewhere
+		// (e.g. an in-comment arrow) are left untouched.
 		if strings.Contains(trim, "=>") {
-			var rest string
-			switch {
-			case inReplaceBlock:
-				rest = trim
-			default:
-				// go.mod allows arbitrary whitespace after the `replace`
-				// keyword (e.g. `replace\tfoo => bar`), so tokenize rather
-				// than match a fixed "replace " prefix. Skip any other line
-				// containing "=>" (e.g. an in-comment arrow).
-				fields := strings.Fields(trim)
-				if len(fields) == 0 || fields[0] != "replace" {
-					out = append(out, line)
-					continue
-				}
-				rest = strings.TrimSpace(strings.TrimPrefix(trim, fields[0]))
-			}
-			parts := strings.SplitN(rest, "=>", 2)
-			from := strings.Fields(strings.TrimSpace(parts[0]))
-			if len(from) >= 1 && conflicts[from[0]] {
+			fields := strings.Fields(trim)
+			if len(fields) > 0 && fields[0] == "replace" {
 				continue
 			}
 		}

--- a/cmd/syncmodutil/internal/modsync/sync_test.go
+++ b/cmd/syncmodutil/internal/modsync/sync_test.go
@@ -1,0 +1,177 @@
+package modsync
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// replaceLine matches a single replace directive inside a block, capturing the
+// "from" module path and the "to" version (empty for local-path replacements).
+var replaceLine = regexp.MustCompile(`^\s+(\S+)(?:\s+\S+)?\s+=>\s+\S+(?:\s+(\S+))?\s*$`)
+
+// parseReplaces returns a map of "from" module -> list of "to" specs found in
+// every replace block of a go.mod string. A module mapping to more than one
+// distinct spec is exactly the "conflicting replacements" state Go rejects.
+func parseReplaces(t *testing.T, gomod string) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	inBlock := false
+	for _, line := range strings.Split(gomod, "\n") {
+		trim := strings.TrimSpace(line)
+		switch {
+		case !inBlock && (trim == "replace (" || trim == "replace("):
+			inBlock = true
+		case inBlock && trim == ")":
+			inBlock = false
+		case inBlock && strings.Contains(trim, "=>"):
+			m := replaceLine.FindStringSubmatch(line)
+			if m == nil {
+				t.Fatalf("unparseable replace line: %q", line)
+			}
+			out[m[1]] = append(out[m[1]], m[2])
+		}
+	}
+	return out
+}
+
+func sync(t *testing.T, src, dest string) string {
+	t.Helper()
+	g, err := New(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("New(src): %v", err)
+	}
+	got, err := g.SyncRequire(strings.NewReader(dest), false)
+	if err != nil {
+		t.Fatalf("SyncRequire: %v", err)
+	}
+	return got
+}
+
+// assertNoDuplicateReplaces fails if any module is replaced more than once,
+// which is what makes `go mod tidy` abort with "conflicting replacements".
+func assertNoDuplicateReplaces(t *testing.T, gomod string) {
+	t.Helper()
+	for mod, specs := range parseReplaces(t, gomod) {
+		if len(specs) > 1 {
+			t.Errorf("module %s replaced %d times: %v", mod, len(specs), specs)
+		}
+	}
+}
+
+// TestConflictingDestReplacesDeduped reproduces the release-pipeline failure:
+// the destination arrives with two conflicting replaces for a module the
+// source pins nowhere (github.com/vmihailenco/msgpack/v5 at v5.4.1 and v5.3.5,
+// in separate blocks). The tool must collapse them to a single directive.
+func TestConflictingDestReplacesDeduped(t *testing.T) {
+	src := "module github.com/meshery/meshery\n\ngo 1.26.4\n"
+	dest := `module github.com/meshery/extensions
+
+go 1.26.4
+
+replace (
+	github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.4
+	github.com/vmihailenco/msgpack/v5 => github.com/vmihailenco/msgpack/v5 v5.4.1
+)
+
+replace (
+	github.com/vmihailenco/msgpack/v5 => github.com/vmihailenco/msgpack/v5 v5.3.5
+)
+`
+	got := sync(t, src, dest)
+	assertNoDuplicateReplaces(t, got)
+
+	specs := parseReplaces(t, got)["github.com/vmihailenco/msgpack/v5"]
+	if len(specs) != 1 {
+		t.Fatalf("msgpack replaced %d times, want 1: %v", len(specs), specs)
+	}
+	if specs[0] != "v5.4.1" {
+		t.Errorf("msgpack pinned to %s, want v5.4.1 (first occurrence wins)", specs[0])
+	}
+}
+
+// TestSourceReplaceWins verifies a source-declared replace overrides a
+// destination replace for the same module.
+func TestSourceReplaceWins(t *testing.T) {
+	src := "module github.com/meshery/meshery\n\ngo 1.26.4\n\nreplace github.com/foo/bar => github.com/foo/bar v2.0.0\n"
+	dest := "module m\n\ngo 1.26.4\n\nreplace github.com/foo/bar => github.com/foo/bar v1.0.0\n"
+
+	got := sync(t, src, dest)
+	assertNoDuplicateReplaces(t, got)
+	if specs := parseReplaces(t, got)["github.com/foo/bar"]; len(specs) != 1 || specs[0] != "v2.0.0" {
+		t.Errorf("foo/bar = %v, want [v2.0.0]", specs)
+	}
+}
+
+// TestSourceRequirePinned verifies every source require is pinned via replace
+// so the plugin links against the host's exact versions.
+func TestSourceRequirePinned(t *testing.T) {
+	src := "module github.com/meshery/meshery\n\ngo 1.26.4\n\nrequire (\n\tgithub.com/foo/bar v3.1.0 // indirect\n)\n"
+	dest := "module m\n\ngo 1.26.4\n"
+
+	got := sync(t, src, dest)
+	assertNoDuplicateReplaces(t, got)
+	if specs := parseReplaces(t, got)["github.com/foo/bar"]; len(specs) != 1 || specs[0] != "v3.1.0" {
+		t.Errorf("foo/bar = %v, want [v3.1.0]", specs)
+	}
+}
+
+// TestDestOnlyReplacePreserved verifies an extension-specific replace the
+// source does not touch — including a local-path replace — survives.
+func TestDestOnlyReplacePreserved(t *testing.T) {
+	src := "module github.com/meshery/meshery\n\ngo 1.26.4\n"
+	dest := `module m
+
+go 1.26.4
+
+replace github.com/meshery/meshery v0.5.0-rc => ../../meshery
+
+replace github.com/only/dest => github.com/only/dest v1.2.3
+`
+	got := sync(t, src, dest)
+	assertNoDuplicateReplaces(t, got)
+
+	specs := parseReplaces(t, got)
+	if v := specs["github.com/only/dest"]; len(v) != 1 || v[0] != "v1.2.3" {
+		t.Errorf("only/dest = %v, want [v1.2.3]", v)
+	}
+	if !strings.Contains(got, "github.com/meshery/meshery v0.5.0-rc => ../../meshery") {
+		t.Errorf("local-path replace to ../../meshery was not preserved:\n%s", got)
+	}
+}
+
+// TestIdempotent verifies a second sync of already-synced output is a no-op,
+// proving the tool no longer grows the file with duplicate blocks on repeat
+// runs (the mechanism behind the original corruption).
+func TestIdempotent(t *testing.T) {
+	src := `module github.com/meshery/meshery
+
+go 1.26.4
+
+require (
+	github.com/foo/bar v3.1.0 // indirect
+)
+
+replace github.com/baz/qux => github.com/baz/qux v1.0.0
+`
+	dest := `module m
+
+go 1.26.4
+
+replace github.com/only/dest => github.com/only/dest v1.2.3
+
+replace (
+	github.com/vmihailenco/msgpack/v5 => github.com/vmihailenco/msgpack/v5 v5.4.1
+)
+
+replace (
+	github.com/vmihailenco/msgpack/v5 => github.com/vmihailenco/msgpack/v5 v5.3.5
+)
+`
+	first := sync(t, src, dest)
+	assertNoDuplicateReplaces(t, first)
+	second := sync(t, src, first)
+	if first != second {
+		t.Errorf("SyncRequire is not idempotent.\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}


### PR DESCRIPTION
## Symptom

The Kanvas release pipeline (`meshery-extensions/meshery-extensions-packages`) fails at **"Sync go.mod with Meshery"** with:

```
go: conflicting replacements for github.com/vmihailenco/msgpack/v5:
	github.com/vmihailenco/msgpack/v5@v5.4.1
	github.com/vmihailenco/msgpack/v5@v5.3.5
```

Go can't load the module graph, so the step's `go mod download` aborts.

## Root cause

`syncmodutil` **appended a fresh `replace (` block on every run** and only stripped pre-existing destination replaces for modules the **source** itself declared (`emitModules`). A module the source pins nowhere — e.g. `github.com/vmihailenco/msgpack/v5`, which `meshery/meshery` replaces nowhere — was never stripped. So when the destination arrived with two conflicting replaces for it (in separate blocks, from prior corrupted syncs / manual `update deps` commits), **both survived**. The caller's `go mod tidy` then aborts with `conflicting replacements` **before** syncmodutil can run again to heal it.

## Fix

Merge all replaces into a **single canonical block with exactly one directive per module**, precedence:

1. Source-declared replaces (verbatim)
2. Source require pins (`module => module version`)
3. Destination-only replaces (deduplicated, first wins) — preserves extension-specific overrides like the local `=> ../../meshery` path

Every pre-existing replace is stripped first (`stripAllReplaces` replaces the narrower `stripConflictingReplaces`), then the merged set is re-emitted. This makes the tool **idempotent** and makes a duplicate/conflicting replacement **structurally impossible** in the output — even when the destination arrives already corrupted.

## Tests

Added `sync_test.go` (the package had none):

- `TestConflictingDestReplacesDeduped` — the exact regression (msgpack v5.4.1 + v5.3.5 → single v5.4.1)
- `TestSourceReplaceWins` — source replace overrides dest
- `TestSourceRequirePinned` — require pinned via replace (plugin ABI)
- `TestDestOnlyReplacePreserved` — dest-only + local-path `../../meshery` survive
- `TestIdempotent` — second sync is a no-op

Verified end-to-end by running the rebuilt binary against a copy of the actual corrupted `graphql/go.mod`: the 2 conflicting msgpack replaces collapse to a single `v5.4.1`, everything consolidates into one block, zero duplicate replace LHS, local-path replace preserved. `go vet` and `gofmt` clean.

## Watch for

For this to reach the release pipeline, meshkit needs a new tag — the pipeline pulls `go mod download github.com/meshery/meshkit@latest`, and the extension's `graphql/go.mod` then bumps to it.