### PR TITLE
[Broker] Reliable, self-healing broker connectivity for ClusterIP-only / Helm-chart NATS

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -23,4 +23,5 @@ type Handler interface {
 	IsEmpty() bool
 	CloseConnection()
 	ConnectedEndpoints() []string //To get the IP addresses of connected endpoints
+	IsConnected() bool            //Whether the underlying connection is currently live
 }

--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -217,3 +217,10 @@ func (h *ChannelBrokerHandler) IsEmpty() bool {
 	defer h.mu.RUnlock()
 	return len(h.storage) <= 0
 }
+
+// IsConnected reports whether this in-process channel broker is usable. It has
+// no network connection to drop, so it is "connected" whenever the handler
+// exists.
+func (h *ChannelBrokerHandler) IsConnected() bool {
+	return h != nil
+}

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -26,6 +26,12 @@ type Options struct {
 	ReconnectWait  time.Duration
 	MaxReconnect   int
 	Logger         logger.Handler
+	// RetryOnFailedConnect keeps (re)connecting in the background when the
+	// initial connection fails, instead of returning an error. Combined with a
+	// negative MaxReconnect (infinite), this makes the handler self-healing: it
+	// connects as soon as the broker becomes reachable and reconnects if the
+	// broker (or a port-forward in front of it) drops — no restart needed.
+	RetryOnFailedConnect bool
 }
 
 // Nats will implement Nats subscribe and publish functionality
@@ -43,6 +49,7 @@ func New(opts Options) (broker.Handler, error) {
 		nats.Name(opts.ConnectionName),
 		nats.ReconnectWait(opts.ReconnectWait),
 		nats.MaxReconnects(opts.MaxReconnect),
+		nats.RetryOnFailedConnect(opts.RetryOnFailedConnect),
 		nats.UserInfo(opts.Username, opts.Password),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			if opts.Logger != nil {

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -126,6 +126,13 @@ func (n *Nats) Info() string {
 	return n.nc.Opts.Name
 }
 
+// IsConnected reports whether the underlying NATS connection is currently live
+// (established and not closed/reconnecting). Unlike ConnectedEndpoints (which
+// reports the known server pool), this reflects the real-time connection state.
+func (n *Nats) IsConnected() bool {
+	return n != nil && n.nc != nil && n.nc.IsConnected()
+}
+
 func (n *Nats) CloseConnection() {
 	if n == nil {
 		return

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -23,9 +23,12 @@ type Options struct {
 	ConnectionName string
 	Username       string
 	Password       string
-	ReconnectWait  time.Duration
-	MaxReconnect   int
-	Logger         logger.Handler
+	// Token authenticates to a NATS server configured with
+	// `authorization { token: ... }`. Leave empty for an unauthenticated server.
+	Token         string
+	ReconnectWait time.Duration
+	MaxReconnect  int
+	Logger        logger.Handler
 	// RetryOnFailedConnect keeps (re)connecting in the background when the
 	// initial connection fails, instead of returning an error. Combined with a
 	// negative MaxReconnect (infinite), this makes the handler self-healing: it
@@ -51,6 +54,7 @@ func New(opts Options) (broker.Handler, error) {
 		nats.MaxReconnects(opts.MaxReconnect),
 		nats.RetryOnFailedConnect(opts.RetryOnFailedConnect),
 		nats.UserInfo(opts.Username, opts.Password),
+		nats.Token(opts.Token),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			if opts.Logger != nil {
 				opts.Logger.Error(err)

--- a/models/controllers/helpers.go
+++ b/models/controllers/helpers.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -29,39 +28,70 @@ type connection struct {
 	Name string `json:"name"`
 }
 
+// parseHostPort splits a "host:port" string into a HostPort. It tolerates an
+// empty string and a bare host (returning ok=false) instead of panicking, which
+// the previous strings.Split(...)[1] indexing did when an endpoint was empty.
+func parseHostPort(hp string) (*utils.HostPort, bool) {
+	idx := strings.LastIndex(hp, ":")
+	if idx < 0 {
+		return nil, false
+	}
+	port, err := strconv.Atoi(hp[idx+1:])
+	if err != nil {
+		return nil, false
+	}
+	return &utils.HostPort{Address: hp[:idx], Port: int32(port)}, true
+}
+
+// GetBrokerEndpoint resolves the best reachable broker endpoint from the Broker
+// CRD status. Candidates are probed in the order Meshery is commonly deployed
+// relative to the cluster:
+//  1. internal             — Meshery running in-cluster (ClusterIP)
+//  2. external             — Meshery out-of-cluster, broker exposed (NodePort/LB)
+//  3. host.docker.internal — Meshery in Docker Desktop reaching the host
+//  4. API-server host      — reuse the kube API host with the broker port
+//     (e.g. a port-forwarded 127.0.0.1:<port>)
+//
+// Newer operators deploy NATS via the upstream Helm chart as a ClusterIP-only
+// Service, so Status.Endpoint.External is empty. The old implementation
+// unconditionally indexed strings.Split(External, ":")[1], panicking on that
+// empty value; it also fell back to the internal (unreachable) endpoint even
+// when a host.docker.internal / API-host path was reachable. This resolves both.
 func GetBrokerEndpoint(kclient *mesherykube.Client, broker *v1alpha1.Broker) string {
-	endpoint := broker.Status.Endpoint.Internal
-	if len(strings.Split(broker.Status.Endpoint.Internal, ":")) > 1 {
-		port, _ := strconv.Atoi(strings.Split(broker.Status.Endpoint.Internal, ":")[1])
-		if !utils.TcpCheck(&utils.HostPort{
-			Address: strings.Split(broker.Status.Endpoint.Internal, ":")[0],
-			Port:    int32(port),
-		}, nil) {
-			endpoint = broker.Status.Endpoint.External
-			port, _ = strconv.Atoi(strings.Split(broker.Status.Endpoint.External, ":")[1])
-			if !utils.TcpCheck(&utils.HostPort{
-				Address: strings.Split(broker.Status.Endpoint.External, ":")[0],
-				Port:    int32(port),
-			}, nil) {
-				if !utils.TcpCheck(&utils.HostPort{
-					Address: "host.docker.internal",
-					Port:    int32(port),
-				}, nil) {
-					u, _ := url.Parse(kclient.RestConfig.Host)
-					if utils.TcpCheck(&utils.HostPort{
-						Address: u.Hostname(),
-						Port:    int32(port),
-					}, nil) {
-						endpoint = fmt.Sprintf("%s:%d", u.Hostname(), int32(port))
-					}
-				} else {
-					endpoint = fmt.Sprintf("host.docker.internal:%d", int32(port))
-				}
-			}
+	internal := broker.Status.Endpoint.Internal
+	external := broker.Status.Endpoint.External
+
+	candidates := []*utils.HostPort{}
+	var port int32
+	if hp, ok := parseHostPort(internal); ok {
+		candidates = append(candidates, hp)
+		port = hp.Port
+	}
+	if hp, ok := parseHostPort(external); ok {
+		candidates = append(candidates, hp)
+		if port == 0 {
+			port = hp.Port
+		}
+	}
+	if port != 0 {
+		candidates = append(candidates, &utils.HostPort{Address: "host.docker.internal", Port: port})
+		if u, err := url.Parse(kclient.RestConfig.Host); err == nil && u.Hostname() != "" {
+			candidates = append(candidates, &utils.HostPort{Address: u.Hostname(), Port: port})
 		}
 	}
 
-	return endpoint
+	for _, hp := range candidates {
+		if hp != nil && hp.Address != "" && utils.TcpCheck(hp, nil) {
+			return hp.String()
+		}
+	}
+
+	// Nothing verified reachable; return the internal (else external) endpoint as
+	// a best-effort default, preserving prior in-cluster behavior.
+	if internal != "" {
+		return internal
+	}
+	return external
 }
 
 func applyOperatorHelmChart(chartRepo string, client mesherykube.Client, mesheryReleaseVersion string, delete bool, overrides map[string]interface{}) error {

--- a/models/controllers/helpers.go
+++ b/models/controllers/helpers.go
@@ -75,8 +75,12 @@ func GetBrokerEndpoint(kclient *mesherykube.Client, broker *v1alpha1.Broker) str
 	}
 	if port != 0 {
 		candidates = append(candidates, &utils.HostPort{Address: "host.docker.internal", Port: port})
-		if u, err := url.Parse(kclient.RestConfig.Host); err == nil && u.Hostname() != "" {
-			candidates = append(candidates, &utils.HostPort{Address: u.Hostname(), Port: port})
+		// kclient may be nil when this exported helper is called outside the
+		// controller (e.g. tests); only the API-host candidate needs it.
+		if kclient != nil {
+			if u, err := url.Parse(kclient.RestConfig.Host); err == nil && u.Hostname() != "" {
+				candidates = append(candidates, &utils.HostPort{Address: u.Hostname(), Port: port})
+			}
 		}
 	}
 
@@ -141,6 +145,12 @@ func ConnectivityTest(clientName, hostPort string) bool {
 	// Always close the body — otherwise every probe leaks a connection/FD, which
 	// accumulates quickly on the periodic status poll.
 	defer resp.Body.Close()
+
+	// A healthy NATS monitoring endpoint answers /connz with 200; anything else
+	// won't carry the connection list we parse below, so fail fast.
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/models/controllers/helpers.go
+++ b/models/controllers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"net/http"
 	"net/url"
@@ -16,6 +17,9 @@ import (
 )
 
 const BrokerPingEndpoint = "/connz"
+
+// connectivityTestTimeout bounds a single broker monitoring-endpoint probe.
+const connectivityTestTimeout = 5 * time.Second
 
 type Connections struct {
 	Connections []connection `json:"connections"`
@@ -96,10 +100,17 @@ func ConnectivityTest(clientName, hostPort string) bool {
 		return false
 	}
 
-	resp, err := http.Get(endpoint.String())
+	// Bound the probe: the default client has no timeout, so an endpoint that
+	// accepts the TCP connection but never responds would hang the caller
+	// (and, on the status-poll path, stall the whole status collection).
+	client := &http.Client{Timeout: connectivityTestTimeout}
+	resp, err := client.Get(endpoint.String())
 	if err != nil {
 		return false
 	}
+	// Always close the body — otherwise every probe leaks a connection/FD, which
+	// accumulates quickly on the periodic status poll.
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -47,6 +47,9 @@ func (mb *mesheryBroker) GetName() string {
 }
 
 func (mb *mesheryBroker) GetStatus() MesheryControllerStatus {
+	if mb.kclient == nil {
+		return Unknown
+	}
 	operatorClient, err := opClient.New(&mb.kclient.RestConfig)
 	if err != nil || operatorClient == nil {
 		return Unknown
@@ -147,6 +150,9 @@ func (mb *mesheryBroker) GetPublicEndpoint() (string, error) {
 }
 
 func (mb *mesheryBroker) GetVersion() (string, error) {
+	if mb.kclient == nil {
+		return "", fmt.Errorf("kubernetes client is not initialized")
+	}
 	var lastErr error
 	for _, name := range natsResourceNames {
 		statefulSet, err := mb.kclient.KubeClient.AppsV1().StatefulSets("meshery").Get(context.TODO(), name, metav1.GetOptions{})
@@ -172,6 +178,9 @@ const (
 // secret is absent — an unauthenticated broker — so callers stay backward
 // compatible with tokenless deployments.
 func (mb *mesheryBroker) GetToken() (string, error) {
+	if mb.kclient == nil {
+		return "", fmt.Errorf("kubernetes client is not initialized")
+	}
 	secret, err := mb.kclient.KubeClient.CoreV1().Secrets("meshery").Get(context.TODO(), natsAuthSecretName, metav1.GetOptions{})
 	if err != nil {
 		if kubeerror.IsNotFound(err) {
@@ -198,6 +207,9 @@ func (mb *mesheryBroker) GetPortForwarder(log logger.Handler) (*mesherykube.Port
 }
 
 func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
+	if mb.kclient == nil {
+		return "", ErrGetControllerEndpointForPort(fmt.Errorf("kubernetes client is not initialized"))
+	}
 	// Resolve the broker Service under each known NATS Service name. Older
 	// operators named it "meshery-broker"; operator >= 1.0.2 names it
 	// "meshery-nats". Looking up only "meshery-broker" made the monitoring-port

--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	opClient "github.com/meshery/meshery-operator/pkg/client"
@@ -134,9 +135,33 @@ func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
 		return "", ErrGetControllerEndpointForPort(err)
 	}
 
-	// Try endpoints in order of preference: external first, then internal
-	endpoints := []*utils.HostPort{endpoint.External, endpoint.Internal}
-	for _, ep := range endpoints {
+	// Probe the broker the same way the data connection does (see
+	// GetBrokerEndpoint), so a status check can't report "not connected" while
+	// the data path is actually up. Candidates, in order of how Meshery is
+	// commonly deployed relative to the cluster:
+	//   1. internal            — Meshery running in-cluster
+	//   2. external            — Meshery out-of-cluster, broker exposed (NodePort/LB)
+	//   3. host.docker.internal— Meshery in Docker Desktop reaching the host
+	//   4. API server host     — reuse the kube API host with the broker port
+	// The former "external first, internal only" ordering both preferred the
+	// wrong endpoint in-cluster and gave up before trying the Docker/API-host
+	// fallbacks, which is the main source of false "not connected" reports.
+	candidates := []*utils.HostPort{endpoint.Internal, endpoint.External}
+
+	var port int32
+	if endpoint.External != nil && endpoint.External.Port != 0 {
+		port = endpoint.External.Port
+	} else if endpoint.Internal != nil {
+		port = endpoint.Internal.Port
+	}
+	if port != 0 {
+		candidates = append(candidates, &utils.HostPort{Address: "host.docker.internal", Port: port})
+		if u, perr := url.Parse(mb.kclient.RestConfig.Host); perr == nil && u.Hostname() != "" {
+			candidates = append(candidates, &utils.HostPort{Address: u.Hostname(), Port: port})
+		}
+	}
+
+	for _, ep := range candidates {
 		if ep != nil && ep.Address != "" {
 			if utils.TcpCheck(ep, nil) {
 				return ep.String(), nil
@@ -145,7 +170,7 @@ func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
 	}
 
 	return "", ErrGetControllerEndpointForPort(
-		fmt.Errorf("neither external not internal endpoint is reachable for meshery-broker port %s", portName),
+		fmt.Errorf("no reachable endpoint (internal/external/host.docker.internal/api-host) for meshery-broker port %s", portName),
 	)
 }
 

--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -12,12 +12,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 )
 
 var (
 	brokerMonitoringPortName = "monitor"
+
+	// natsResourceNames lists the names the operator may use for the NATS
+	// broker's StatefulSet/Service, newest first. Older operators deployed a
+	// StatefulSet/Service literally named "meshery-broker"; operator >= 1.0.2
+	// deploys NATS via the upstream Helm chart, naming them "meshery-nats".
+	natsResourceNames = []string{MesheryBroker, "meshery-nats"}
 )
 
 type mesheryBroker struct {
@@ -63,11 +70,20 @@ func (mb *mesheryBroker) GetStatus() MesheryControllerStatus {
 			}
 			return mb.status
 		}
-		// when operatorClient is not able to get meshesry-broker, we try again with kubernetes client as a fallback
-		broker, err := mb.kclient.DynamicKubeClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}).Namespace("meshery").Get(context.TODO(), MesheryBroker, metav1.GetOptions{})
-		if err != nil {
+		// when operatorClient is not able to get meshery-broker, we try again with
+		// kubernetes client as a fallback, trying each known NATS StatefulSet name.
+		stsClient := mb.kclient.DynamicKubeClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}).Namespace("meshery")
+		var broker *unstructured.Unstructured
+		var stsErr error
+		for _, name := range natsResourceNames {
+			broker, stsErr = stsClient.Get(context.TODO(), name, metav1.GetOptions{})
+			if stsErr == nil {
+				break
+			}
+		}
+		if stsErr != nil {
 			// if the resource is not found, then it is NotDeployed
-			if kubeerror.IsNotFound(err) {
+			if kubeerror.IsNotFound(stsErr) {
 				mb.status = Undeployed
 				return mb.status
 			}
@@ -106,31 +122,59 @@ func (mb *mesheryBroker) GetPublicEndpoint() (string, error) {
 		return "", ErrGetControllerPublicEndpoint(err)
 	}
 	broker, err := operatorClient.CoreV1Alpha1().Brokers("meshery").Get(context.TODO(), MesheryBroker, metav1.GetOptions{})
-	if broker.Status.Endpoint.External == "" {
-		if err == nil {
-			err = fmt.Errorf("Could not get the External endpoint for meshery-broker")
-		}
-		// broker is not available
+	if err != nil {
 		return "", ErrGetControllerPublicEndpoint(err)
 	}
+	// Newer operators deploy NATS as a ClusterIP-only Service, so the Broker CRD
+	// publishes only an internal endpoint (External is empty). Requiring an
+	// external endpoint here made Meshery give up before even trying the
+	// internal / host.docker.internal / API-host fallbacks in GetBrokerEndpoint,
+	// so a host-run Meshery could never obtain a broker endpoint. Only fail when
+	// the broker has published no endpoint at all.
+	if broker.Status.Endpoint.Internal == "" && broker.Status.Endpoint.External == "" {
+		return "", ErrGetControllerPublicEndpoint(fmt.Errorf("broker has no published endpoint (neither internal nor external)"))
+	}
 
-	return GetBrokerEndpoint(mb.kclient, broker), nil
+	endpoint := GetBrokerEndpoint(mb.kclient, broker)
+	if endpoint == "" {
+		return "", ErrGetControllerPublicEndpoint(fmt.Errorf(
+			"no reachable endpoint for meshery-broker (published internal=%q external=%q)",
+			broker.Status.Endpoint.Internal, broker.Status.Endpoint.External,
+		))
+	}
+	return endpoint, nil
 }
 
 func (mb *mesheryBroker) GetVersion() (string, error) {
-	statefulSet, err := mb.kclient.KubeClient.AppsV1().StatefulSets("meshery").Get(context.TODO(), MesheryBroker, metav1.GetOptions{})
-	if kubeerror.IsNotFound(err) {
-		return "", err
+	var lastErr error
+	for _, name := range natsResourceNames {
+		statefulSet, err := mb.kclient.KubeClient.AppsV1().StatefulSets("meshery").Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return getImageVersionOfContainer(statefulSet.Spec.Template, "nats"), nil
 	}
-	return getImageVersionOfContainer(statefulSet.Spec.Template, "nats"), nil
+	return "", lastErr
 }
 
 func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {
-	endpoint, err := mesherykube.GetServiceEndpoint(context.TODO(), mb.kclient.KubeClient, &mesherykube.ServiceOptions{
-		Name:         "meshery-broker",
-		Namespace:    "meshery",
-		PortSelector: portName,
-	})
+	// Resolve the broker Service under each known NATS Service name. Older
+	// operators named it "meshery-broker"; operator >= 1.0.2 names it
+	// "meshery-nats". Looking up only "meshery-broker" made the monitoring-port
+	// (and thus the connectivity) lookup fail against newer deployments.
+	var endpoint *utils.Endpoint
+	var err error
+	for _, name := range natsResourceNames {
+		endpoint, err = mesherykube.GetServiceEndpoint(context.TODO(), mb.kclient.KubeClient, &mesherykube.ServiceOptions{
+			Name:         name,
+			Namespace:    "meshery",
+			PortSelector: portName,
+		})
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return "", ErrGetControllerEndpointForPort(err)
 	}

--- a/models/controllers/meshery_broker.go
+++ b/models/controllers/meshery_broker.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	opClient "github.com/meshery/meshery-operator/pkg/client"
+	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	v1 "k8s.io/api/core/v1"
@@ -156,6 +157,44 @@ func (mb *mesheryBroker) GetVersion() (string, error) {
 		return getImageVersionOfContainer(statefulSet.Spec.Template, "nats"), nil
 	}
 	return "", lastErr
+}
+
+// natsAuthSecretName / natsAuthTokenKey follow the operator's convention for the
+// NATS token secret (operator >= 1.0.2 provisions NATS with token auth:
+// `authorization { token: $NATS_TOKEN }`, token stored in this secret).
+const (
+	natsAuthSecretName = "meshery-nats-auth"
+	natsAuthTokenKey   = "token"
+)
+
+// GetToken returns the NATS authorization token the operator provisioned for the
+// broker (secret meshery-nats-auth, key token). It returns ("", nil) when the
+// secret is absent — an unauthenticated broker — so callers stay backward
+// compatible with tokenless deployments.
+func (mb *mesheryBroker) GetToken() (string, error) {
+	secret, err := mb.kclient.KubeClient.CoreV1().Secrets("meshery").Get(context.TODO(), natsAuthSecretName, metav1.GetOptions{})
+	if err != nil {
+		if kubeerror.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(secret.Data[natsAuthTokenKey]), nil
+}
+
+// natsClientPort is the NATS client port to port-forward to.
+const natsClientPort = 4222
+
+// GetPortForwarder returns a self-healing port-forwarder to the broker's NATS
+// pod, so an out-of-cluster Meshery can reach a ClusterIP-only broker without a
+// manual `kubectl port-forward`. The caller owns Start()/Stop(). The pod is
+// selected by the upstream NATS chart label and re-resolved on reconnect.
+func (mb *mesheryBroker) GetPortForwarder(log logger.Handler) (*mesherykube.PortForwarder, error) {
+	return mesherykube.NewPortForwarder(mb.kclient, mesherykube.PortForwardTarget{
+		Namespace:  "meshery",
+		PodLabels:  map[string]string{"app.kubernetes.io/name": "nats"},
+		RemotePort: natsClientPort,
+	}, log)
 }
 
 func (mb *mesheryBroker) GetEndpointForPort(portName string) (string, error) {

--- a/utils/kubernetes/portforward.go
+++ b/utils/kubernetes/portforward.go
@@ -151,11 +151,17 @@ func (pf *PortForwarder) forwardOnce() error {
 		return fmt.Errorf("new port-forward: %w", err)
 	}
 
+	// doneCh releases the logging goroutine when this attempt ends. Without it,
+	// a ForwardPorts() that errors before the tunnel is ready would leave the
+	// goroutine blocked on readyCh forever, leaking one goroutine per retry.
+	doneCh := make(chan struct{})
+	defer close(doneCh)
 	go func() {
 		select {
 		case <-readyCh:
 			pf.logf("port-forward ready: %s -> %s/%s:%d", pf.LocalAddr(), pf.target.Namespace, pod, pf.target.RemotePort)
 		case <-pf.stopCh:
+		case <-doneCh:
 		}
 	}()
 

--- a/utils/kubernetes/portforward.go
+++ b/utils/kubernetes/portforward.go
@@ -1,0 +1,206 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/meshery/meshkit/logger"
+)
+
+// PortForwardTarget identifies what to port-forward to. Provide either an
+// explicit PodName or a PodLabels selector (a Running pod matching it is chosen,
+// and re-resolved on every reconnect so the tunnel follows pod restarts).
+type PortForwardTarget struct {
+	Namespace  string
+	PodName    string
+	PodLabels  map[string]string
+	RemotePort int32
+}
+
+// PortForwarder maintains a self-healing port-forward from a stable local
+// address (127.0.0.1:<localPort>) to a pod in the cluster, tunneled through the
+// Kubernetes API server exactly like `kubectl port-forward`. The local port is
+// fixed for the lifetime of the forwarder so consumers can keep a stable URL; the
+// upstream tunnel is re-established on drop/pod-restart until Stop() is called.
+//
+// It is deliberately target-agnostic so it can back any server-internal TCP
+// tunnel (its first consumer is the Meshery Broker / NATS connection for an
+// out-of-cluster Meshery).
+type PortForwarder struct {
+	client *Client
+	target PortForwardTarget
+	log    logger.Handler
+
+	localPort int
+
+	mu       sync.Mutex
+	started  bool
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+// reconnectBackoff bounds how fast the forwarder retries after a tunnel drop or a
+// failed pod resolution.
+const portForwardReconnectBackoff = 2 * time.Second
+
+// NewPortForwarder allocates a stable local port and returns a forwarder for the
+// target. Call Start to begin forwarding and Stop to tear it down. The logger may
+// be nil.
+func NewPortForwarder(client *Client, target PortForwardTarget, log logger.Handler) (*PortForwarder, error) {
+	if client == nil || client.KubeClient == nil {
+		return nil, fmt.Errorf("port-forward: nil kubernetes client")
+	}
+	if target.RemotePort == 0 {
+		return nil, fmt.Errorf("port-forward: RemotePort is required")
+	}
+	if target.PodName == "" && len(target.PodLabels) == 0 {
+		return nil, fmt.Errorf("port-forward: a PodName or PodLabels selector is required")
+	}
+	localPort, err := freeLocalPort()
+	if err != nil {
+		return nil, fmt.Errorf("port-forward: could not allocate a local port: %w", err)
+	}
+	return &PortForwarder{
+		client:    client,
+		target:    target,
+		log:       log,
+		localPort: localPort,
+		stopCh:    make(chan struct{}),
+	}, nil
+}
+
+// LocalAddr is the stable local endpoint (127.0.0.1:<port>) consumers connect to.
+// It is valid immediately after NewPortForwarder, before the tunnel is up.
+func (pf *PortForwarder) LocalAddr() string {
+	return net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", pf.localPort))
+}
+
+// Start begins forwarding in the background (idempotent). It returns immediately;
+// the tunnel is (re)established asynchronously and consumers should tolerate the
+// local endpoint being briefly unavailable (the NATS client's retry handles this).
+func (pf *PortForwarder) Start() {
+	pf.mu.Lock()
+	defer pf.mu.Unlock()
+	if pf.started {
+		return
+	}
+	pf.started = true
+	go pf.run()
+}
+
+// Stop tears down the forwarder (idempotent).
+func (pf *PortForwarder) Stop() {
+	pf.stopOnce.Do(func() { close(pf.stopCh) })
+}
+
+func (pf *PortForwarder) run() {
+	for {
+		select {
+		case <-pf.stopCh:
+			return
+		default:
+		}
+		if err := pf.forwardOnce(); err != nil {
+			pf.logf("port-forward to %s/%s:%d dropped: %v", pf.target.Namespace, pf.targetDesc(), pf.target.RemotePort, err)
+		}
+		select {
+		case <-pf.stopCh:
+			return
+		case <-time.After(portForwardReconnectBackoff):
+		}
+	}
+}
+
+// forwardOnce resolves a pod and blocks in ForwardPorts until the tunnel drops
+// (returns an error) or Stop closes stopCh (returns nil).
+func (pf *PortForwarder) forwardOnce() error {
+	pod, err := pf.resolvePod()
+	if err != nil {
+		return err
+	}
+
+	req := pf.client.KubeClient.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(pf.target.Namespace).
+		Name(pod).
+		SubResource("portforward")
+
+	cfg := pf.client.RestConfig
+	roundTripper, upgrader, err := spdy.RoundTripperFor(&cfg)
+	if err != nil {
+		return fmt.Errorf("spdy round tripper: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
+
+	ports := []string{fmt.Sprintf("%d:%d", pf.localPort, pf.target.RemotePort)}
+	readyCh := make(chan struct{})
+	fw, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, ports, pf.stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return fmt.Errorf("new port-forward: %w", err)
+	}
+
+	go func() {
+		select {
+		case <-readyCh:
+			pf.logf("port-forward ready: %s -> %s/%s:%d", pf.LocalAddr(), pf.target.Namespace, pod, pf.target.RemotePort)
+		case <-pf.stopCh:
+		}
+	}()
+
+	return fw.ForwardPorts()
+}
+
+// resolvePod returns the explicit PodName, or a Running pod matching PodLabels.
+func (pf *PortForwarder) resolvePod() (string, error) {
+	if pf.target.PodName != "" {
+		return pf.target.PodName, nil
+	}
+	selector := labels.SelectorFromSet(pf.target.PodLabels).String()
+	pods, err := pf.client.KubeClient.CoreV1().Pods(pf.target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return "", fmt.Errorf("list pods (%s): %w", selector, err)
+	}
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+			return p.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no running pod for selector %q in namespace %q", selector, pf.target.Namespace)
+}
+
+func (pf *PortForwarder) targetDesc() string {
+	if pf.target.PodName != "" {
+		return pf.target.PodName
+	}
+	return labels.SelectorFromSet(pf.target.PodLabels).String()
+}
+
+func (pf *PortForwarder) logf(format string, args ...interface{}) {
+	if pf.log != nil {
+		pf.log.Info(fmt.Sprintf(format, args...))
+	}
+}
+
+// freeLocalPort asks the OS for a free TCP port on the loopback interface and
+// returns it. There is a small window before the forwarder binds it, which is
+// acceptable for this use.
+func freeLocalPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}


### PR DESCRIPTION
**Description**

This PR makes the Meshery Broker (NATS) connection work reliably across the deployment topologies newer operators produce, and hardens the status/connectivity path against panics, hangs, and resource leaks.

Operator `>= 1.0.2` deploys NATS via the upstream Helm chart as a **ClusterIP-only** Service named `meshery-nats` (token-authenticated), instead of an externally-exposed StatefulSet/Service named `meshery-broker`. The existing code assumed the old shape, so a host-run (out-of-cluster) Meshery could not resolve, authenticate to, or reach the broker — and often reported a false "not connected" while the data path was actually up.

Changes:

- **Broker resolution across operator versions** — every broker lookup (`GetStatus`, `GetVersion`, `GetPublicEndpoint`, `GetEndpointForPort`) now tries each known NATS resource name (`meshery-broker`, then `meshery-nats`). `GetPublicEndpoint` no longer requires an `External` endpoint; it succeeds on an internal-only broker and only fails when *no* endpoint is published.
- **Robust endpoint probing** — `GetBrokerEndpoint`/`GetEndpointForPort` probe candidates in deployment-order (internal → external → `host.docker.internal` → kube-API host), so Docker Desktop and port-forwarded (`127.0.0.1:<port>`) setups resolve. Replaces the old `strings.Split(endpoint, ":")[1]` indexing that **panicked** on an empty endpoint.
- **NATS token authentication** — new `Options.Token` on the broker handler; controller reads the operator-provisioned token from secret `meshery-nats-auth` (returns empty for unauthenticated brokers, preserving backward compatibility).
- **Self-healing connections** — new `Options.RetryOnFailedConnect`; combined with infinite reconnect the handler connects as soon as the broker is reachable and reconnects on drop, no restart needed. New `Handler.IsConnected()` reports the live connection state (implemented for both NATS and the in-process channel broker).
- **Self-healing port-forward** — new `utils/kubernetes/portforward.go` (`PortForwarder`) maintains a stable `127.0.0.1:<port>` tunnel through the API server (like `kubectl port-forward`), re-resolving the pod and reconnecting on drop, so an out-of-cluster Meshery can reach a ClusterIP-only broker with no manual `kubectl port-forward`.
- **Connectivity-check fixes** — `ConnectivityTest` now bounds the probe with a 5s timeout (was the default no-timeout client, which could hang the whole status poll) and closes the response body (fixing an FD/connection leak on the periodic poll).

**Notes for Reviewers**

- No changes to existing exported signatures; `Token`/`RetryOnFailedConnect` are additive `Options` fields, and `IsConnected()` is a new interface method implemented by both broker backends.
- The endpoint probe intentionally falls back to a best-effort default (internal, else external) when nothing verifies as reachable, preserving prior in-cluster behavior.
- `PortForwarder` is deliberately target-agnostic (its first consumer is the broker) and leaves `Start()`/`Stop()` lifecycle to the caller.
- Files touched: `broker/{broker,channel/channel,nats/nats}.go`, `models/controllers/{helpers,meshery_broker}.go`, `utils/kubernetes/portforward.go`.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
