### PR TITLE
docs: add AGENTS.md / CLAUDE.md agent instructions with ecosystem-shared directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# MeshKit - Agent Instructions
+
+MeshKit is the shared Go library of the Meshery ecosystem: structured errors, logging, database
+wrappers (GORM over SQLite/Postgres), MeshModel registration and registry, encoding, converters,
+broker clients, tracing, and general utilities. Nearly every ecosystem service (Meshery Server,
+Meshery Cloud, adapters, operators, CLIs) depends on it, so changes fan out downstream and must be coordinated with consumers.
+
+## Commands
+
+- `make test` - `go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic`
+- `make check` - `golangci-lint run -c .golangci.yml -v ./...`
+- `make tidy` - `go mod tidy`; fails if `go.mod` or `go.sum` change
+- `make errorutil` - update structured error codes and export artifacts
+- `make errorutil-analyze` - analyze structured errors without rewriting them
+- `make build-errorutil` - build the `cmd/errorutil` binary
+- Single test: `go test ./path/to/package -run TestName -count=1`
+
+## Critical Rules
+
+- **Structured errors**: concrete errors in each package's `error.go`; code symbols match
+  `^Err[A-Z].+Code$`; create with `errors.NewV2(...)`; keep description/cause/remediation text as string literals.
+  After adding or modifying errors, run `make errorutil` (reads `helpers/component_info.json`, emits artifacts under `helpers/`).
+- **Ecosystem ownership**: MeshKit owns shared errors, logging, and common utilities for the ecosystem -
+  downstream repos must not duplicate them. Shared data and API contracts belong in `meshery/schemas`, not here.
+- **Registration pipeline**: one model definition per imported package/directory; ingestion is
+  permissive (nested archives, YAML normalized to JSON) and mutates SVG fields to file paths.
+
+## Identifier Naming
+
+**Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.**
+
+- Authoritative source: `meshery/schemas/AGENTS.md § Casing rules at a glance`
+- Reader-friendly directory: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>
+- The contract is not optional; deviations block PRs via the schemas consumer-audit CI gate. On
+  any conflict, schemas wins - file discrepancies as issues against `meshery/schemas`, not locally.
+- `Id` (camelCase), never `ID`, in URL params, JSON tags, and TypeScript properties.
+- meshkit: Go-only surface. Struct fields follow Go idiom (UserID); json tags are camelCase;
+  db/gorm column mappings are snake_case. MeshKit is NOT the schema source of truth - types that
+  mirror schema constructs come from `github.com/meshery/schemas`; do not redeclare them locally.
+
+## Required on Every PR
+
+- **Tests accompany every behavioral change.** Run every locally-runnable test
+  before requesting review; never defer runnable coverage to reviewers or
+  follow-up PRs.
+- **Documentation accompanies every behavioral change, in both forms:**
+  - External, user-facing: docs.meshery.io (source: meshery/meshery docs; the error-code reference
+    at docs.meshery.io/reference/error-codes is generated from this repo's error registries) -
+    update whenever the change is user-visible.
+  - Internal, developer-facing: this repo's [`docs/`](docs/) - update whenever
+    architecture, workflows, or contracts change.
+- **Schema-aware changes**: run `cd ../schemas && make validate-schemas && make consumer-audit` before pushing.
+- **Sign off every commit** (`git commit -s`).
+- **No AI attribution** in commits, PR descriptions, comments, or code.
+
+## Detailed Docs
+
+- [architecture](docs/agent-instructions/architecture.md) - orientation: package map, the two core pipelines, cross-cutting packages.
+- [errors](docs/agent-instructions/errors.md) - read before adding or changing any error: conventions, errorutil workflow, code allocation.
+- [registration](docs/agent-instructions/registration.md) - read before touching `models/registration/` or `models/meshmodel/registry/`.
+- [testing](docs/agent-instructions/testing.md) - make targets, flags, single-test forms, lint and tidy discipline.
+- [naming-conventions](docs/agent-instructions/naming-conventions.md) - full identifier-naming contract and authority links.
+- [event-streaming](docs/event-streaming.md) - read when working on events, broadcasters, or the `Event`/`EventBuilder` types shared with Meshery Server.
+
+CLAUDE.md is a symlink to this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agent-instructions/architecture.md
+++ b/docs/agent-instructions/architecture.md
@@ -1,0 +1,63 @@
+# MeshKit Architecture
+
+MeshKit is primarily a shared Go library for the Meshery ecosystem, not a single
+application. Most top-level directories are reusable packages; the executable entrypoints
+live under `cmd/`, notably `cmd/errorutil` and `cmd/syncmodutil`.
+
+Go toolchain: `go.mod` pins `go 1.26.4`; CI builds with Go 1.26 (see
+`.github/workflows/ci.yml`, which also uses `go-version-file: go.mod`).
+
+## Core pipeline 1: structured errors
+
+The structured error pipeline spans several packages:
+
+- `errors/` defines the shared MeshKit error types (`Error`, `ErrorV2`) and the
+  `New(...)` / `NewV2(...)` constructors used across the entire Meshery code base.
+- Package-local `error.go` files define concrete errors for each package/component.
+- `logger/` enriches log output with MeshKit error metadata such as code, severity,
+  cause, and remediation.
+- `cmd/errorutil` scans the repository, analyzes those definitions, updates placeholder
+  codes using `helpers/component_info.json`, and writes export/analysis artifacts under
+  `helpers/`. The `error-codes-updater` GitHub workflow runs it on CI and publishes the
+  export into `meshery/meshery`'s docs data, which is how the error-code reference at
+  docs.meshery.io/reference/error-codes stays generated from this repo.
+
+Full conventions and workflow: [errors.md](errors.md).
+
+## Core pipeline 2: MeshModel registration
+
+- `models/registration/` ingests model packages from directories, YAML/JSON files,
+  nested archives (zip/tar), and OCI artifacts, then assembles a `PackagingUnit`
+  (one model definition plus its components, relationships, and connections).
+- `models/meshmodel/registry/` persists registrants, models, components, and
+  relationships through GORM-backed registry helpers (`RegistryManager`).
+- Schema definitions themselves come from `github.com/meshery/schemas`; in this repo,
+  focus on how MeshKit loads, normalizes, registers, and persists those entities rather
+  than treating MeshKit as the schema source of truth.
+
+Pipeline rules and caveats: [registration.md](registration.md).
+
+## Cross-cutting packages
+
+Intentionally reusable across Meshery services and tools:
+
+- `database/` wraps GORM setup for SQLite and Postgres.
+- `tracing/` provides OpenTelemetry initialization plus HTTP middleware and client
+  transport helpers (see `tracing/README.md`).
+- `logger/`, `utils/`, `encoding/`, and `converter/` provide shared support code used by
+  Meshery services and tools.
+- `broker/` provides messaging abstractions with NATS and in-process channel backends;
+  the event-streaming primitives shared with Meshery Server are documented in
+  [../event-streaming.md](../event-streaming.md).
+- `generators/` builds MeshModel models/components from upstream sources (Artifact Hub,
+  GitHub); `registry/` holds spreadsheet-driven registry tooling; `files/` handles file
+  identification, sanitization, and conversion; `config/`, `schema/`, `schemas/`,
+  `validator/`, `orchestration/`, and `encoding/` round out the shared surface.
+
+## Executable entrypoints (`cmd/`)
+
+- `cmd/errorutil` - the error-code utility described above.
+- `cmd/syncmodutil` - synchronizes a destination `go.mod` with a source `go.mod`
+  (rewrites shared `require` versions and appends a pinning `replace` block) so Go
+  plugin builds link against identical dependency versions. See `cmd/syncmodutil/README.md`
+  for behavior, the `--err` flag, and caveats.

--- a/docs/agent-instructions/errors.md
+++ b/docs/agent-instructions/errors.md
@@ -1,0 +1,58 @@
+# Structured Errors and the errorutil Workflow
+
+MeshKit-compatible structured errors are a repo-wide (and ecosystem-wide) convention.
+Uniform definitions allow error information to be extracted directly from the code and
+published automatically as the error-code reference at
+docs.meshery.io/reference/error-codes. The `cmd/errorutil` tool is part of that
+toolchain and only works if the conventions below are followed strictly.
+
+## Conventions (strict - errorutil parses these)
+
+- Define concrete errors in each package's `error.go`.
+- Define error-code symbols as string constants (preferably constants, variables are
+  tolerated) whose names match the regex `^Err[A-Z].+Code$`, e.g. `ErrApplyManifestCode`.
+- The initial value of a new code is a placeholder string (e.g. `"replace_me"`) set by
+  the developer. The final value is an integer string assigned by errorutil.
+- Create errors with `errors.NewV2(...)` when no existing error is a well-suited fit;
+  the `(*errors.Error).NewV2(...)` helper may also be used where applicable. The legacy
+  `errors.New(...)` constructor remains for existing call sites.
+- Keep static text in the short-description, long-description, probable-cause, and
+  remediation arrays as string literals, not composed constants or concatenations -
+  errorutil extracts this text statically.
+- Errors are namespaced to Meshery components (a component usually corresponds to one
+  git repository). Codes must be unique within a component. There are no predefined
+  code ranges, and codes carry no meaning (unlike HTTP status codes).
+
+See the package documentation in `errors/errors.go` and
+<https://docs.meshery.io/project/contributing/contributing-error> for background.
+
+## Workflow after adding or modifying errors
+
+1. Run `make errorutil` - rewrites placeholder codes to real integer codes and updates
+   exports. Usually also run `make errorutil-analyze` to verify without rewriting.
+2. Both targets run `cmd/errorutil` as
+   `go run github.com/meshery/meshkit/cmd/errorutil -d . <update|analyze> --skip-dirs meshery -i ./helpers -o ./helpers`.
+3. Commit the changed source files together with the regenerated artifacts.
+
+`make build-errorutil` builds a standalone `errorutil` binary from `cmd/errorutil/main.go`.
+
+## Artifacts and code allocation (`helpers/`)
+
+- `helpers/component_info.json` is the required input metadata. For this repo it holds
+  the component `name` (`meshkit`), `type` (`library`), and `next_error_code` - the
+  counter from which errorutil allocates integer codes to placeholder symbols. Do not
+  hand-pick codes; let errorutil allocate them from `next_error_code`.
+- errorutil emits `errorutil_analyze_errors.json` and `errorutil_analyze_summary.json`
+  (analysis results: duplicates, violations of the conventions above) plus
+  `errorutil_errors_export.json` (the full export consumed by the docs pipeline).
+- The `error-codes-updater` GitHub workflow (`.github/workflows/error-codes-updater.yaml`)
+  runs the update on CI and publishes `errorutil_errors_export.json` into
+  `meshery/meshery`'s `docs/data/errorref/` - that is how the public error-code
+  reference is generated from this repo's error registries.
+
+## Downstream ownership
+
+MeshKit owns shared errors, logging, and common utilities for the whole ecosystem.
+Downstream repos (Meshery Server, Meshery Cloud, adapters, operators) must consume them
+from MeshKit, not duplicate them locally. Conversely, shared data and API contracts
+belong in `meshery/schemas`, not in MeshKit.

--- a/docs/agent-instructions/naming-conventions.md
+++ b/docs/agent-instructions/naming-conventions.md
@@ -1,0 +1,45 @@
+# Identifier Naming Conventions
+
+This repo adheres to the canonical camelCase-wire identifier-naming contract of the
+Meshery ecosystem.
+
+**Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.**
+
+## Authority
+
+- Authoritative source: `meshery/schemas/AGENTS.md § Casing rules at a glance`.
+- Reader-friendly directory: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>
+  (the 26-row naming table with before/after and do/don't examples).
+- The contract is not optional; deviations block PRs via the schemas consumer-audit CI
+  gate. On any conflict, schemas wins - file discrepancies as issues against
+  `meshery/schemas`, not locally.
+
+## MeshKit-specific scope
+
+meshkit: Go-only surface. Struct fields follow Go idiom (UserID); json tags are
+camelCase; db/gorm column mappings are snake_case. MeshKit is NOT the schema source of
+truth - types that mirror schema constructs come from `github.com/meshery/schemas`; do
+not redeclare them locally.
+
+MeshKit utilities that expose wire-facing identifiers (error constants, structured log
+keys, event envelopes consumed by Meshery Server or Meshery Cloud) follow the
+ecosystem-wide camelCase-on-the-wire contract.
+
+## Per-layer forms relevant to MeshKit
+
+| Layer | Form | Example |
+|---|---|---|
+| Go struct field | PascalCase with Go-idiomatic initialisms | `UserID`, `OrgID`, `CreatedAt` |
+| `json:` tag | camelCase | `json:"userId"`, `json:"orgId"` |
+| DB column / gorm mapping | snake_case | `user_id`, `org_id`, `created_at` |
+
+## Hard rules
+
+- `Id` (camelCase), never `ID`, in URL params, JSON tags, and TypeScript properties.
+  (Go struct field names still use the Go-idiomatic `ID` initialism; only wire-facing
+  identifiers use `Id`.)
+- Never introduce a `json:` tag that matches the `db:`/gorm column name on a DB-backed
+  field: wire is camel, DB is snake, they differ by design.
+- Never mix casing conventions within a single resource.
+- Schema-aware changes require running
+  `cd ../schemas && make validate-schemas && make consumer-audit` before pushing.

--- a/docs/agent-instructions/registration.md
+++ b/docs/agent-instructions/registration.md
@@ -1,0 +1,49 @@
+# MeshModel Registration Pipeline
+
+Read this before touching `models/registration/` or `models/meshmodel/registry/`.
+
+## Shape of the pipeline
+
+- `models/registration/` ingests model packages and assembles a `PackagingUnit`: exactly
+  one `model.ModelDefinition` plus any number of components, relationships, and
+  connections associated with it.
+- A `RegistrationHelper` (constructed with an SVG base directory, a `RegistryManager`,
+  and a `RegistrationErrorStore`) drives `Register(entity)` for each
+  `RegisterableEntity` - currently directory (`dir.go`), tar (`tar.go`), and OCI
+  (`oci.go`) sources.
+- `models/meshmodel/registry/` persists registrants, models, components, and
+  relationships through GORM-backed helpers (`RegistryManager`), with versioned entity
+  handling under `registry/v1alpha3` and `registry/v1beta1`.
+
+## Rules
+
+- **One model definition per imported package/directory.** Registration assumes an
+  imported package/directory contains exactly one model definition and then any number
+  of components/relationships associated with it.
+- Entity types come from `github.com/meshery/schemas` (`model`, `component`,
+  `relationship`, `connection` definitions). MeshKit is NOT the schema source of truth;
+  never redeclare schema types locally - focus on how MeshKit loads, normalizes,
+  registers, and persists those entities.
+
+## Permissive-input behaviors (intentional, preserve them)
+
+Registration code is intentionally permissive on input shape:
+
+- Directory import recursively unwraps nested zip/tar/OCI content.
+- YAML is normalized to JSON before entity detection and unmarshal.
+- Registration accepts both legacy and canonical schema-version strings for models,
+  components, and relationships where compatibility is required. Regression coverage
+  exists, e.g.
+  `go test ./models/registration -run TestGetEntityAcceptsV1Beta2RelationshipSchemaVersion -count=1`.
+
+Do not tighten these behaviors without coordinating with every downstream importer
+(Meshery Server model import, mesheryctl, generators).
+
+## SVG mutation caveat
+
+Registration mutates asset references as part of ingestion: model and component SVG
+fields (color/white/complete SVGs) are written to the filesystem under the configured
+SVG base directory and the in-memory fields are replaced with file paths before
+persistence through `RegistryManager` (see `models/registration/svg_helper.go`). Code
+that inspects a `PackagingUnit` after registration sees file paths, not inline SVG
+content. Keep this in mind when adding fields that carry embedded assets.

--- a/docs/agent-instructions/testing.md
+++ b/docs/agent-instructions/testing.md
@@ -1,0 +1,37 @@
+# Testing, Linting, and Module Hygiene
+
+## Go toolchain
+
+Use the Go version pinned by `go.mod` (`go 1.26.4`); CI builds with Go 1.26 and
+`go-version-file: go.mod`.
+
+## Make targets (prefer these for final verification)
+
+- `make test` - runs `go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic`.
+  Note the flags: `--short` skips long-running tests (respect `testing.Short()` when
+  writing slow tests) and `-race` means all tests must be race-clean.
+- `make check` - runs `golangci-lint run -c .golangci.yml -v ./...`. Lint config lives
+  in `.golangci.yml`; fix findings rather than suppressing them.
+- `make tidy` - runs `go mod tidy` and then `git diff --exit-code go.mod go.sum`, so it
+  fails if `go.mod` or `go.sum` changed. Run it after any dependency change and commit
+  the result; never hand-edit `go.sum`.
+
+## Single-test iteration
+
+For a single test during iteration, run Go tests directly at package scope:
+
+- Example: `go test ./models/registration -run TestGetEntityAcceptsV1Beta2RelationshipSchemaVersion -count=1`
+- General form: `go test ./path/to/package -run TestName -count=1`
+
+Use direct `go test ./pkg -run TestName` only for focused iteration; prefer the
+Makefile targets for final verification before pushing.
+
+## PR discipline
+
+- Tests accompany every behavioral change; run every locally-runnable test before
+  requesting review. Never defer runnable coverage to reviewers or follow-up PRs.
+- After adding or modifying structured errors, `make errorutil` (and usually
+  `make errorutil-analyze`) must run and its artifacts must be committed - see
+  [errors.md](errors.md).
+- Schema-aware changes: run `cd ../schemas && make validate-schemas && make consumer-audit`
+  before pushing.


### PR DESCRIPTION
## Summary

Creates a progressive-disclosure agent instruction set for MeshKit. No AGENTS.md or CLAUDE.md existed before this PR; the root file is a minimal 65-line index (project one-liner, commands, critical rules, the ecosystem-shared identifier-naming and Required-on-Every-PR blocks, and a linked index of detail docs), with all detail moved into `docs/agent-instructions/`. `CLAUDE.md` is a symlink to `AGENTS.md`. The existing `.github/copilot-instructions.md` is left untouched.

Part of an ecosystem-wide alignment of agent instructions across meshery-extensions, meshery-cloud, meshkit, meshery-operator, and schemas.

## Files added

- `AGENTS.md` (65 lines) - root index
- `CLAUDE.md` - symlink to `AGENTS.md`
- `docs/agent-instructions/architecture.md` - package map, the structured-error and MeshModel registration pipelines, cross-cutting packages, `cmd/` entrypoints
- `docs/agent-instructions/errors.md` - structured-error conventions, errorutil workflow, `helpers/` artifacts, `component_info.json` code allocation
- `docs/agent-instructions/registration.md` - registration pipeline rules, permissive-input behaviors, SVG mutation caveat
- `docs/agent-instructions/testing.md` - make targets, race/short flags, single-test invocation forms, golangci-lint, `make tidy` discipline
- `docs/agent-instructions/naming-conventions.md` - identifier-naming contract, MeshKit-specific scope, authority links to meshery/schemas

## Moved-content map

This is a create-fresh task (no prior root file), so the map below traces where each source fact now lives. Source material: `.github/copilot-instructions.md` (kept as-is) and the shared ecosystem directive blocks.

- copilot "Build, test, and lint" section -> `AGENTS.md § Commands` (compressed) and `docs/agent-instructions/testing.md` (full)
- copilot "High-level architecture" section -> `docs/agent-instructions/architecture.md`
- copilot "Key conventions" (structured errors) -> `AGENTS.md § Critical Rules` (compressed) and `docs/agent-instructions/errors.md` (full)
- copilot "Key conventions" (registration pipeline, permissive inputs, SVG mutation) -> `AGENTS.md § Critical Rules` (one-liner) and `docs/agent-instructions/registration.md` (full)
- copilot naming-scheme pointer and `README.md § Naming conventions` -> `AGENTS.md § Identifier Naming` and `docs/agent-instructions/naming-conventions.md`
- `docs/event-streaming.md` -> unchanged; now linked from the root index with a when-to-read description
- `cmd/syncmodutil/README.md` -> unchanged; summarized and linked from `docs/agent-instructions/architecture.md`

## Flagged for deletion

None. No content was deleted; the pre-existing `.github/copilot-instructions.md`, `README.md`, `docs/event-streaming.md`, and `cmd/syncmodutil/README.md` are all preserved unmodified. The new files duplicate a small number of facts from `.github/copilot-instructions.md` by design, since that file serves a different agent surface and was explicitly kept untouched.

## Contradictions resolved

- `.github/copilot-instructions.md` says "Use Go 1.25.x ... CI uses Go 1.25", but `go.mod` pins `go 1.26.4` and `.github/workflows/ci.yml` uses `go-version: '1.26'` plus `go-version-file: go.mod`. The new docs state the current facts (Go 1.26 / go.mod-pinned); the copilot file was left as-is per scope.
- No naming-contract conflicts found; where source material and the schemas authority overlapped, wording follows the schemas-authority rule (schemas wins; discrepancies filed against meshery/schemas).

## Verification

- Root `AGENTS.md` is 65 lines (target 45-65).
- Every relative markdown link in the new files resolves from its file's directory (checked `AGENTS.md` and all five detail docs).
- Zero em-dash characters in all added files.
- Grep sweep: 20 distinctive strings from the source material (make targets, `^Err[A-Z].+Code$`, `errors.NewV2`, `component_info.json`, `errorutil_errors_export.json`, `--skip-dirs meshery`, `PackagingUnit`, `RegistryManager`, single-test invocation forms, naming-contract sentences, and more) all present in the new tree.
- Commit is signed off (`Signed-off-by: Lee Calcote <lee.calcote@layer5.io>`).
