### PR TITLE
fix: pin docker-compose schema URL to immutable compose-spec ref

### DIFF
--- a/utils/kubernetes/kompose/convert.go
+++ b/utils/kubernetes/kompose/convert.go
@@ -12,7 +12,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const DefaultDockerComposeSchemaURL = "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json"
+// Pinned to an immutable ref: validation semantics must not drift with the
+// upstream master branch (its 2026-07-03 schema update made empty manifests
+// pass validation). Bump deliberately, re-running the kompose package tests.
+const DefaultDockerComposeSchemaURL = "https://raw.githubusercontent.com/compose-spec/compose-spec/a08f8d51631b7127ddac3d2c65537db429d0f1d0/schema/compose-spec.json"
 
 // Checks whether the given manifest is a valid docker-compose file.
 // schemaURL is assigned a default url if not specified


### PR DESCRIPTION
## Symptom

`TestIsManifestADockerComposePanicRecovery` started failing on every branch on 2026-07-03 (including docs-only PRs such as #1053) with: `Expected an error when checking empty manifest, got nil`.

## Root cause

`DefaultDockerComposeSchemaURL` pointed at the compose-spec schema on the upstream **master branch**. Upstream commit compose-spec/compose-spec@4e2fe760 (2026-07-03 09:48 UTC, the first schema change since 2025-10-28) altered the schema such that an empty manifest now validates successfully. Because the schema is fetched live, this silently changed Meshery's runtime compose-file validation behavior and flipped CI on all branches with zero meshkit code change.

## Fix

Pin the default schema URL to the last reviewed schema revision (compose-spec/compose-spec@a08f8d51, 2025-10-28). Validation semantics now change only when the pin is bumped deliberately, with the kompose package tests re-run.

## Watch for

- `utils/catalog/package.go` also references a master-branch raw URL, but only for a logo image (cosmetic, left as is).
- Downstream consumers (meshery server) inherit the fix via their next meshkit bump; they pass an empty schemaURL and rely on this default.

## Verification

`go test ./utils/kubernetes/kompose/... -count=1` passes locally with the pin; it fails against upstream master schema.