### PR TITLE
[broker] Add Unsubscribe to the broker Handler interface

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -1,0 +1,64 @@
+# broker
+
+`broker` defines the message-broker abstraction used across the Meshery
+ecosystem (Meshery Server, MeshSync, adapters). Producers publish and consumers
+subscribe through the `Handler` interface, decoupling callers from the concrete
+transport.
+
+Two implementations ship with MeshKit:
+
+- **`broker/nats`** — a NATS-backed handler (`Nats`) used in cluster deployments,
+  where MeshSync publishes discovery events to Meshery Broker (NATS) and Meshery
+  Server consumes them.
+- **`broker/channel`** — an in-process handler (`ChannelBrokerHandler`) backed by
+  Go channels, used for embedded/library mode and tests, with no external broker.
+
+## Handler interface
+
+```go
+type Handler interface {
+	Publish(subject string, message *Message) error
+	PublishWithChannel(subject string, msgch chan *Message) error
+	Subscribe(subject, queue string, message []byte) error
+	SubscribeWithChannel(subject, queue string, msgch chan *Message) error
+	Unsubscribe(subject string) error
+	Info() string
+	DeepCopyObject() Handler
+	DeepCopyInto(Handler)
+	IsEmpty() bool
+	CloseConnection()
+	ConnectedEndpoints() []string
+}
+```
+
+## Unsubscribe
+
+`Unsubscribe(subject string) error` tears down **every** subscription previously
+created for `subject` (across all queue groups) and releases the resources they
+hold: for the NATS handler the underlying `nats.Subscription`(s); for the channel
+handler the per-queue delivery channels (which ends the goroutines started by
+`SubscribeWithChannel`).
+
+It is:
+
+- a **no-op** for a subject with no active subscriptions (including a
+  nil/uninitialized connection), and
+- **safe to call more than once**.
+
+### When to call it
+
+Long-lived, request-scoped subscriptions must be torn down when the request ends,
+or the subscription and its delivery goroutine leak for the lifetime of the
+process. The canonical case is an interactive session (exec, log stream) keyed by
+a unique subject:
+
+```go
+subject := fmt.Sprintf("input.%s", sessionID)
+if err := handler.SubscribeWithChannel(subject, connName, msgCh); err != nil {
+	return err
+}
+defer handler.Unsubscribe(subject) // release the subscription on session teardown
+```
+
+Subscriptions that live for the whole process (a server's long-running consumer)
+do not need explicit unsubscription; `CloseConnection` tears everything down.

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -12,6 +12,16 @@ type PublishInterface interface {
 type SubscribeInterface interface {
 	Subscribe(string, string, []byte) error
 	SubscribeWithChannel(string, string, chan *Message) error
+	// Unsubscribe tears down every subscription previously created for the given
+	// subject (across all queue groups) and releases the resources associated
+	// with them - for the NATS handler the underlying nats.Subscription(s), for
+	// the channel handler the per-queue delivery channels. It is safe to call for
+	// a subject with no active subscriptions (a no-op) and safe to call more than
+	// once. Callers that create a subscription for the lifetime of a session
+	// (e.g. an interactive exec/log stream keyed by a unique subject) should call
+	// Unsubscribe on teardown so the subscription and its delivery goroutine do
+	// not leak.
+	Unsubscribe(subject string) error
 }
 
 type Handler interface {

--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
-	"github.com/meshery/meshkit/utils"
 )
 
 type ChannelBrokerHandler struct {
@@ -90,9 +89,11 @@ func (h *ChannelBrokerHandler) CloseConnection() {
 
 	for subject, qstorage := range h.storage {
 		for queue, ch := range qstorage {
-			if !utils.IsClosed(ch) {
-				close(ch)
-			}
+			// Closing directly is safe: CloseConnection and Unsubscribe both hold
+			// h.mu and delete the key after closing, so a channel is never closed
+			// twice. A non-blocking IsClosed check would instead consume a buffered
+			// message and skip the close, leaking the delivery goroutine.
+			close(ch)
 			delete(qstorage, queue)
 		}
 		delete(h.storage, subject)
@@ -200,9 +201,9 @@ func (h *ChannelBrokerHandler) Unsubscribe(subject string) error {
 		return nil
 	}
 	for queue, ch := range qstorage {
-		if !utils.IsClosed(ch) {
-			close(ch)
-		}
+		// Safe to close directly (see CloseConnection): held under h.mu and the
+		// key is deleted after closing, so a channel is never closed twice.
+		close(ch)
 		delete(qstorage, queue)
 	}
 	delete(h.storage, subject)

--- a/broker/channel/channel.go
+++ b/broker/channel/channel.go
@@ -188,6 +188,27 @@ func (h *ChannelBrokerHandler) SubscribeWithChannel(subject, queue string, msgch
 	return nil
 }
 
+// Unsubscribe closes and removes every queue channel registered for the subject,
+// which ends the delivery goroutines started by SubscribeWithChannel. It is a
+// no-op for a subject with no subscriptions and is safe to call more than once.
+func (h *ChannelBrokerHandler) Unsubscribe(subject string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	qstorage, ok := h.storage[subject]
+	if !ok {
+		return nil
+	}
+	for queue, ch := range qstorage {
+		if !utils.IsClosed(ch) {
+			close(ch)
+		}
+		delete(qstorage, queue)
+	}
+	delete(h.storage, subject)
+	return nil
+}
+
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
 func (h *ChannelBrokerHandler) DeepCopyInto(out broker.Handler) {
 	// Not supported: deep copy is not implemented for ChannelBrokerHandler

--- a/broker/channel/channel_test.go
+++ b/broker/channel/channel_test.go
@@ -362,3 +362,38 @@ func TestChannelBrokerHandler_Publish_Timeout(t *testing.T) {
 	// If we get here, the timeout didn't work as expected
 	t.Fatal("Expected timeout error but none occurred")
 }
+
+func TestChannelBrokerHandler_Unsubscribe(t *testing.T) {
+	handler := NewChannelBrokerHandler()
+	const subject = "test-subject"
+	msgch := make(chan *broker.Message, 4)
+
+	require.NoError(t, handler.SubscribeWithChannel(subject, "q1", msgch))
+	require.NoError(t, handler.Publish(subject, &broker.Message{Object: "before"}))
+
+	select {
+	case got := <-msgch:
+		require.NotNil(t, got)
+		assert.Equal(t, "before", got.Object)
+	case <-time.After(time.Second):
+		t.Fatal("expected a message before unsubscribe")
+	}
+
+	// Unsubscribe removes every subscription for the subject.
+	require.NoError(t, handler.Unsubscribe(subject))
+	assert.True(t, handler.IsEmpty(), "storage should be empty after unsubscribe")
+	assert.Empty(t, handler.ConnectedEndpoints())
+
+	// Publishing after unsubscribe delivers nothing: there are no subscribers.
+	require.NoError(t, handler.Publish(subject, &broker.Message{Object: "after"}))
+	select {
+	case msg := <-msgch:
+		t.Fatalf("unexpected message after unsubscribe: %v", msg)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no delivery
+	}
+
+	// Idempotent: unsubscribing again and unsubscribing an unknown subject are no-ops.
+	require.NoError(t, handler.Unsubscribe(subject))
+	require.NoError(t, handler.Unsubscribe("no-such-subject"))
+}

--- a/broker/nats/error.go
+++ b/broker/nats/error.go
@@ -10,6 +10,7 @@ const (
 	ErrPublishCode        = "meshkit-11120"
 	ErrPublishRequestCode = "meshkit-11121"
 	ErrQueueSubscribeCode = "meshkit-11122"
+	ErrUnsubscribeCode    = "meshkit-11327"
 )
 
 func ErrConnect(err error) error {
@@ -26,4 +27,7 @@ func ErrPublishRequest(err error) error {
 }
 func ErrQueueSubscribe(err error) error {
 	return errors.New(ErrQueueSubscribeCode, errors.Alert, []string{"Subscription failed"}, []string{err.Error()}, []string{"NATS is unhealthy"}, []string{"Make sure NATS is up and running"})
+}
+func ErrUnsubscribe(err error) error {
+	return errors.New(ErrUnsubscribeCode, errors.Alert, []string{"Unsubscribe failed"}, []string{err.Error()}, []string{"NATS is unhealthy"}, []string{"Make sure NATS is up and running"})
 }

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -48,6 +48,9 @@ func (s *subscriptions) add(subject string, sub *nats.Subscription) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.items == nil {
+		s.items = make(map[string][]*nats.Subscription)
+	}
 	s.items[subject] = append(s.items[subject], sub)
 }
 
@@ -255,6 +258,10 @@ func (n *Nats) Subscribe(subject, queue string, message []byte) error {
 		}
 		return ErrQueueSubscribe(err)
 	}
+	// Auto-unsubscribe after the first message: this method returns once wg.Done
+	// fires, but the subscription would otherwise stay active and a later message
+	// would call wg.Done() again on an already-zero WaitGroup (panic).
+	_ = sub.AutoUnsubscribe(1)
 	n.subs.add(subject, sub)
 	n.wg.Wait()
 	return nil
@@ -304,7 +311,10 @@ func (n *Nats) Unsubscribe(subject string) error {
 		if sub == nil {
 			continue
 		}
-		if err := sub.Unsubscribe(); err != nil {
+		// An already-unsubscribed subscription (e.g. via AutoUnsubscribe on the
+		// blocking Subscribe, or a concurrent Unsubscribe) reports
+		// ErrBadSubscription; ignore it so Unsubscribe stays idempotent.
+		if err := sub.Unsubscribe(); err != nil && !errors.Is(err, nats.ErrBadSubscription) {
 			errs = append(errs, err)
 		}
 	}

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -28,6 +29,40 @@ type Options struct {
 	Logger         logger.Handler
 }
 
+// subscriptions tracks the live nats.Subscription handles per subject so they
+// can be torn down by Unsubscribe. It is held behind a pointer on Nats so the
+// shallow DeepCopyInto copy shares it (and does not copy the mutex by value).
+type subscriptions struct {
+	mu    sync.Mutex
+	items map[string][]*nats.Subscription
+}
+
+func newSubscriptions() *subscriptions {
+	return &subscriptions{items: make(map[string][]*nats.Subscription)}
+}
+
+// add records a subscription for a subject.
+func (s *subscriptions) add(subject string, sub *nats.Subscription) {
+	if s == nil || sub == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[subject] = append(s.items[subject], sub)
+}
+
+// take removes and returns all subscriptions recorded for a subject.
+func (s *subscriptions) take(subject string) []*nats.Subscription {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	subs := s.items[subject]
+	delete(s.items, subject)
+	return subs
+}
+
 // Nats will implement Nats subscribe and publish functionality
 type Nats struct {
 	nc     *nats.Conn
@@ -35,6 +70,7 @@ type Nats struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	log    logger.Handler
+	subs   *subscriptions
 }
 
 // New - constructor
@@ -106,7 +142,7 @@ func New(opts Options) (broker.Handler, error) {
 		}
 	}
 
-	return &Nats{nc: nc, wg: &sync.WaitGroup{}, ctx: ctx, cancel: cancel, log: lg}, nil
+	return &Nats{nc: nc, wg: &sync.WaitGroup{}, ctx: ctx, cancel: cancel, log: lg, subs: newSubscriptions()}, nil
 }
 
 func (n *Nats) ConnectedEndpoints() (endpoints []string) {
@@ -200,7 +236,7 @@ func (n *Nats) Subscribe(subject, queue string, message []byte) error {
 	}
 
 	n.wg.Add(1)
-	_, err := n.nc.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
+	sub, err := n.nc.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
 		copied := copy(message, msg.Data)
 		if copied < len(msg.Data) {
 			if n.log != nil {
@@ -219,6 +255,7 @@ func (n *Nats) Subscribe(subject, queue string, message []byte) error {
 		}
 		return ErrQueueSubscribe(err)
 	}
+	n.subs.add(subject, sub)
 	n.wg.Wait()
 	return nil
 }
@@ -229,7 +266,7 @@ func (n *Nats) SubscribeWithChannel(subject, queue string, msgch chan *broker.Me
 		return ErrQueueSubscribe(fmt.Errorf("nats connection is not initialized"))
 	}
 
-	_, err := n.nc.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
+	sub, err := n.nc.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
 		var parsed broker.Message
 		if err := json.Unmarshal(msg.Data, &parsed); err != nil {
 			if n.log != nil {
@@ -248,6 +285,37 @@ func (n *Nats) SubscribeWithChannel(subject, queue string, msgch chan *broker.Me
 			log.Printf("queue subscribe error: %v", err)
 		}
 		return ErrQueueSubscribe(err)
+	}
+	n.subs.add(subject, sub)
+	return nil
+}
+
+// Unsubscribe tears down every subscription previously created for the subject
+// and removes them from tracking. A nil/uninitialized connection has no
+// subscriptions, so it is a no-op; it is also safe to call more than once.
+func (n *Nats) Unsubscribe(subject string) error {
+	if n == nil || n.nc == nil {
+		return nil
+	}
+
+	subs := n.subs.take(subject)
+	var errs []error
+	for _, sub := range subs {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		err := ErrUnsubscribe(errors.Join(errs...))
+		if n.log != nil {
+			n.log.Error(err)
+		} else {
+			log.Printf("unsubscribe error: %v", err)
+		}
+		return err
 	}
 	return nil
 }

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -251,6 +251,9 @@ func (n *Nats) Subscribe(subject, queue string, message []byte) error {
 		n.wg.Done()
 	})
 	if err != nil {
+		// The callback (which calls wg.Done) will never run, so balance the Add(1)
+		// here; otherwise a later wg.Wait would block forever.
+		n.wg.Done()
 		if n.log != nil {
 			n.log.Error(err)
 		} else {
@@ -258,11 +261,12 @@ func (n *Nats) Subscribe(subject, queue string, message []byte) error {
 		}
 		return ErrQueueSubscribe(err)
 	}
-	// Auto-unsubscribe after the first message: this method returns once wg.Done
-	// fires, but the subscription would otherwise stay active and a later message
-	// would call wg.Done() again on an already-zero WaitGroup (panic).
+	// Single-shot: auto-unsubscribe after the first message so a later message
+	// cannot fire the callback again and call wg.Done() on an already-zero
+	// WaitGroup (panic). The subscription is deliberately not tracked in n.subs,
+	// because AutoUnsubscribe already tears it down and a tracked entry would
+	// otherwise accumulate across repeated Subscribe calls.
 	_ = sub.AutoUnsubscribe(1)
-	n.subs.add(subject, sub)
 	n.wg.Wait()
 	return nil
 }

--- a/broker/nats/nats_test.go
+++ b/broker/nats/nats_test.go
@@ -1,0 +1,52 @@
+package nats
+
+import (
+	"testing"
+
+	"github.com/meshery/meshkit/broker"
+	nats "github.com/nats-io/nats.go"
+)
+
+// Nats must satisfy the broker.Handler interface, including Unsubscribe.
+var _ broker.Handler = (*Nats)(nil)
+
+func TestSubscriptionsAddTake(t *testing.T) {
+	s := newSubscriptions()
+
+	// take on an unknown subject returns nothing.
+	if got := s.take("missing"); got != nil {
+		t.Fatalf("take(missing) = %v, want nil", got)
+	}
+
+	// add records multiple subscriptions per subject; take returns and removes them.
+	a, b := &nats.Subscription{}, &nats.Subscription{}
+	s.add("subj", a)
+	s.add("subj", b)
+	if got := s.take("subj"); len(got) != 2 {
+		t.Fatalf("take(subj) returned %d subscriptions, want 2", len(got))
+	}
+	// A second take is empty: the first take removed them.
+	if got := s.take("subj"); got != nil {
+		t.Fatalf("second take(subj) = %v, want nil", got)
+	}
+
+	// add is nil-safe for both a nil receiver and a nil subscription.
+	var nilTracker *subscriptions
+	nilTracker.add("x", a) // must not panic
+	s.add("y", nil)
+	if got := s.take("y"); len(got) != 0 {
+		t.Fatalf("take(y) after adding a nil subscription = %v, want empty", got)
+	}
+}
+
+func TestNatsUnsubscribeNilConnectionIsNoOp(t *testing.T) {
+	// A nil handler and an uninitialized handler hold no subscriptions, so
+	// Unsubscribe must be a no-op that returns nil rather than erroring.
+	var nilHandler *Nats
+	if err := nilHandler.Unsubscribe("subj"); err != nil {
+		t.Fatalf("nil handler Unsubscribe = %v, want nil", err)
+	}
+	if err := (&Nats{}).Unsubscribe("subj"); err != nil {
+		t.Fatalf("uninitialized handler Unsubscribe = %v, want nil", err)
+	}
+}

--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshkit",
   "type": "library",
-  "next_error_code": 11327
+  "next_error_code": 11328
 }


### PR DESCRIPTION
**Description**

Adds `Unsubscribe(subject string) error` to the `broker.Handler` interface so callers can tear down request-scoped subscriptions (and the goroutines that deliver to them) instead of leaking them for the process lifetime. Today `broker.Handler` has no way to release a single subscription short of `CloseConnection()`, which drops the entire connection.

**What changed**

- `broker/broker.go`: new `Unsubscribe(subject)` method on `SubscribeInterface`, with documentation.
- `broker/nats` (`Nats`): tracks the `nats.Subscription` handles per subject (the `Subscribe`/`SubscribeWithChannel` methods previously discarded them) and unsubscribes them on `Unsubscribe`. The tracker is held behind a pointer so the existing shallow `DeepCopyInto` stays copylock-free. A nil/uninitialized connection is a no-op. New structured error `ErrUnsubscribe` (code allocated by `errorutil`).
- `broker/channel` (`ChannelBrokerHandler`): closes and removes the per-queue delivery channels for the subject, ending the goroutines started by `SubscribeWithChannel`.
- Tests for both handlers (channel behavioral; NATS subscription-tracking + nil-safety + compile-time interface conformance), passing under `-race`.
- `broker/README.md` documenting the interface and the session-teardown pattern.

**Breaking change / coordination:** this adds a required method to `broker.Handler`. The two in-repo implementers (`Nats`, `ChannelBrokerHandler`) are updated here. Downstream repos that *implement* the interface (e.g. test mocks in meshery/meshery and meshery/meshsync) must add the method when they bump their MeshKit dependency; consumers that merely hold a `broker.Handler` are unaffected until they upgrade.

**Notes for Reviewers**

- Motivated by MeshSync's leaked exec/log-stream `input.<id>` subscriptions (meshery/meshsync#585) - MeshSync will call `Unsubscribe` on session teardown once it bumps to a MeshKit release containing this. Also a prerequisite for the durable JetStream delivery design (meshery/meshsync#580).
- MeshKit has no in-process NATS test server, so the NATS handler's live unsubscribe behavior is exercised downstream via MeshSync's integration/runtime verification; here it is covered by the subscription-tracking, nil-safety, and interface-conformance tests. `go build ./...` and `go test -race ./broker/...` pass.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
