### PR TITLE
fix(registry): re-hydrate component styles dropped by the meshmodel list query

### DIFF
--- a/models/meshmodel/registry/v1beta1/component_filter.go
+++ b/models/meshmodel/registry/v1beta1/component_filter.go
@@ -73,11 +73,11 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 		Joins("JOIN connections ON connections.id = model_dbs.connection_id")
 
 	componentStatus := "enabled"
-    if componentFilter.Status != "" {
-        componentStatus = componentFilter.Status
-    }
-    finder = finder.Where("component_definition_dbs.status = ?", componentStatus)
-	
+	if componentFilter.Status != "" {
+		componentStatus = componentFilter.Status
+	}
+	finder = finder.Where("component_definition_dbs.status = ?", componentStatus)
+
 	if componentFilter.Greedy {
 		if componentFilter.Name != "" && componentFilter.DisplayName != "" {
 			finder = finder.Where("component_definition_dbs.component->>'kind' LIKE ? OR display_name LIKE ?", "%"+componentFilter.Name+"%", componentFilter.DisplayName+"%")
@@ -158,7 +158,51 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 		defs = append(defs, &cd)
 	}
 
+	// The four-table `SELECT *` scan above does not apply the json serializer to
+	// the component's `styles` column: GORM cannot resolve the serializer through
+	// a multi-embedded composite scan, so every scanned ComponentDefinition.Styles
+	// comes back nil even though the column holds valid JSON. Re-hydrate it with a
+	// simple single-table query, which applies the serializer correctly, so the
+	// meshmodel API serves component-level icons/colors instead of null styles.
+	hydrateComponentStyles(db, defs)
+
 	uniqueCount := countUniqueComponents(componentDefinitionsWithModel)
 
 	return defs, count, uniqueCount, nil
+}
+
+// hydrateComponentStyles reloads the serializer-backed `styles` for the given
+// components (see Get). It only touches components whose Styles is nil, so it is
+// a no-op once the underlying multi-table scan is able to populate them.
+func hydrateComponentStyles(db *database.Handler, defs []entity.Entity) {
+	ids := make([]string, 0, len(defs))
+	for _, e := range defs {
+		if cd, ok := e.(*component.ComponentDefinition); ok && cd.Styles == nil {
+			ids = append(ids, cd.ID.String())
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	var rows []component.ComponentDefinition
+	if err := db.Model(&component.ComponentDefinition{}).
+		Select("id", "styles").
+		Find(&rows, "id IN ?", ids).Error; err != nil {
+		return
+	}
+
+	stylesByID := make(map[string]*component.ComponentDefinition, len(rows))
+	for i := range rows {
+		stylesByID[rows[i].ID.String()] = &rows[i]
+	}
+	for _, e := range defs {
+		cd, ok := e.(*component.ComponentDefinition)
+		if !ok || cd.Styles != nil {
+			continue
+		}
+		if src := stylesByID[cd.ID.String()]; src != nil {
+			cd.Styles = src.Styles
+		}
+	}
 }

--- a/models/meshmodel/registry/v1beta1/component_filter.go
+++ b/models/meshmodel/registry/v1beta1/component_filter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
+	"github.com/meshery/schemas/models/core"
 	"github.com/meshery/schemas/models/v1beta1/category"
 	"github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/model"
@@ -164,7 +165,9 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 	// comes back nil even though the column holds valid JSON. Re-hydrate it with a
 	// simple single-table query, which applies the serializer correctly, so the
 	// meshmodel API serves component-level icons/colors instead of null styles.
-	hydrateComponentStyles(db, defs)
+	if err := hydrateComponentStyles(db, defs); err != nil {
+		return nil, 0, 0, err
+	}
 
 	uniqueCount := countUniqueComponents(componentDefinitionsWithModel)
 
@@ -173,36 +176,46 @@ func (componentFilter *ComponentFilter) Get(db *database.Handler) ([]entity.Enti
 
 // hydrateComponentStyles reloads the serializer-backed `styles` for the given
 // components (see Get). It only touches components whose Styles is nil, so it is
-// a no-op once the underlying multi-table scan is able to populate them.
-func hydrateComponentStyles(db *database.Handler, defs []entity.Entity) {
-	ids := make([]string, 0, len(defs))
+// a no-op once the underlying multi-table scan is able to populate them. The
+// query error is returned so callers can surface it rather than silently serving
+// null styles.
+func hydrateComponentStyles(db *database.Handler, defs []entity.Entity) error {
+	seen := make(map[core.Uuid]struct{}, len(defs))
+	ids := make([]core.Uuid, 0, len(defs))
 	for _, e := range defs {
-		if cd, ok := e.(*component.ComponentDefinition); ok && cd.Styles == nil {
-			ids = append(ids, cd.ID.String())
+		cd, ok := e.(*component.ComponentDefinition)
+		if !ok || cd.Styles != nil {
+			continue
 		}
+		if _, dup := seen[cd.ID]; dup {
+			continue
+		}
+		seen[cd.ID] = struct{}{}
+		ids = append(ids, cd.ID)
 	}
 	if len(ids) == 0 {
-		return
+		return nil
 	}
 
 	var rows []component.ComponentDefinition
 	if err := db.Model(&component.ComponentDefinition{}).
 		Select("id", "styles").
 		Find(&rows, "id IN ?", ids).Error; err != nil {
-		return
+		return err
 	}
 
-	stylesByID := make(map[string]*component.ComponentDefinition, len(rows))
+	stylesByID := make(map[core.Uuid]*component.ComponentDefinition, len(rows))
 	for i := range rows {
-		stylesByID[rows[i].ID.String()] = &rows[i]
+		stylesByID[rows[i].ID] = &rows[i]
 	}
 	for _, e := range defs {
 		cd, ok := e.(*component.ComponentDefinition)
 		if !ok || cd.Styles != nil {
 			continue
 		}
-		if src := stylesByID[cd.ID.String()]; src != nil {
+		if src := stylesByID[cd.ID]; src != nil {
 			cd.Styles = src.Styles
 		}
 	}
+	return nil
 }

--- a/models/meshmodel/registry/v1beta1/component_filter_test.go
+++ b/models/meshmodel/registry/v1beta1/component_filter_test.go
@@ -1,0 +1,75 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/meshkit/models/meshmodel/entity"
+	"github.com/meshery/schemas/models/core"
+	"github.com/meshery/schemas/models/v1beta3/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The four-table `SELECT *` scan in Get() drops the serializer-backed `styles`
+// column: GORM cannot apply the json serializer through a multi-embedded
+// composite scan, so components come back with Styles == nil even though the
+// column holds valid JSON. hydrateComponentStyles must restore it from the
+// authoritative single-table row.
+func TestHydrateComponentStylesRestoresDroppedStyles(t *testing.T) {
+	db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&component.ComponentDefinition{}))
+
+	wantSvg := map[string]string{}
+	var stored []component.ComponentDefinition
+	for _, kind := range []string{"BGPPolicy", "Egress", "Tier"} {
+		id, err := uuid.NewV4()
+		require.NoError(t, err)
+		svg := "ui/public/static/img/meshmodels/antrea/color/" + kind + "-color.svg"
+		cd := component.ComponentDefinition{
+			ID:        id,
+			Component: component.Component{Kind: kind, Version: "v1"},
+			Styles:    &core.ComponentStyles{PrimaryColor: "#00c1d5", SvgColor: svg},
+		}
+		require.NoError(t, db.Create(&cd).Error)
+		stored = append(stored, cd)
+		wantSvg[id.String()] = svg
+	}
+
+	// Simulate the join scan dropping Styles on every returned component.
+	defs := make([]entity.Entity, 0, len(stored))
+	for i := range stored {
+		dropped := stored[i]
+		dropped.Styles = nil
+		defs = append(defs, &dropped)
+	}
+
+	hydrateComponentStyles(&db, defs)
+
+	for _, e := range defs {
+		cd := e.(*component.ComponentDefinition)
+		require.NotNilf(t, cd.Styles, "styles not re-hydrated for %s", cd.Component.Kind)
+		assert.Equal(t, "#00c1d5", cd.Styles.PrimaryColor)
+		assert.Equal(t, wantSvg[cd.ID.String()], cd.Styles.SvgColor)
+	}
+}
+
+// hydrateComponentStyles must be a no-op for components that already have styles
+// and must tolerate an empty input slice.
+func TestHydrateComponentStylesNoopWhenPopulated(t *testing.T) {
+	db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&component.ComponentDefinition{}))
+
+	hydrateComponentStyles(&db, nil) // must not panic on empty input
+
+	existing := &core.ComponentStyles{PrimaryColor: "#123456", SvgColor: "keep.svg"}
+	cd := &component.ComponentDefinition{
+		Component: component.Component{Kind: "Keep", Version: "v1"},
+		Styles:    existing,
+	}
+	hydrateComponentStyles(&db, []entity.Entity{cd})
+	assert.Same(t, existing, cd.Styles, "already-populated styles must be left untouched")
+}

--- a/models/meshmodel/registry/v1beta1/component_filter_test.go
+++ b/models/meshmodel/registry/v1beta1/component_filter_test.go
@@ -46,13 +46,38 @@ func TestHydrateComponentStylesRestoresDroppedStyles(t *testing.T) {
 		defs = append(defs, &dropped)
 	}
 
-	hydrateComponentStyles(&db, defs)
+	require.NoError(t, hydrateComponentStyles(&db, defs))
 
 	for _, e := range defs {
 		cd := e.(*component.ComponentDefinition)
 		require.NotNilf(t, cd.Styles, "styles not re-hydrated for %s", cd.Component.Kind)
 		assert.Equal(t, "#00c1d5", cd.Styles.PrimaryColor)
 		assert.Equal(t, wantSvg[cd.ID.String()], cd.Styles.SvgColor)
+	}
+}
+
+// Duplicate component rows in the input (the join can return duplicates) must be
+// de-duplicated and still hydrated correctly.
+func TestHydrateComponentStylesDeduplicatesIDs(t *testing.T) {
+	db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&component.ComponentDefinition{}))
+
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&component.ComponentDefinition{
+		ID:        id,
+		Component: component.Component{Kind: "Egress", Version: "v1"},
+		Styles:    &core.ComponentStyles{PrimaryColor: "#00c1d5", SvgColor: "egress-color.svg"},
+	}).Error)
+
+	first := &component.ComponentDefinition{ID: id, Component: component.Component{Kind: "Egress", Version: "v1"}}
+	second := &component.ComponentDefinition{ID: id, Component: component.Component{Kind: "Egress", Version: "v1"}}
+	require.NoError(t, hydrateComponentStyles(&db, []entity.Entity{first, second}))
+
+	for _, cd := range []*component.ComponentDefinition{first, second} {
+		require.NotNil(t, cd.Styles)
+		assert.Equal(t, "egress-color.svg", cd.Styles.SvgColor)
 	}
 }
 
@@ -63,13 +88,13 @@ func TestHydrateComponentStylesNoopWhenPopulated(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&component.ComponentDefinition{}))
 
-	hydrateComponentStyles(&db, nil) // must not panic on empty input
+	require.NoError(t, hydrateComponentStyles(&db, nil)) // must not error on empty input
 
 	existing := &core.ComponentStyles{PrimaryColor: "#123456", SvgColor: "keep.svg"}
 	cd := &component.ComponentDefinition{
 		Component: component.Component{Kind: "Keep", Version: "v1"},
 		Styles:    existing,
 	}
-	hydrateComponentStyles(&db, []entity.Entity{cd})
+	require.NoError(t, hydrateComponentStyles(&db, []entity.Entity{cd}))
 	assert.Same(t, existing, cd.Styles, "already-populated styles must be left untouched")
 }


### PR DESCRIPTION
## Problem

Every component served by `/api/meshmodels/.../components` came back with `styles: null`, so Kanvas rendered every canvas node with the placeholder icon (`meshery.svg`) and the default teal color instead of the component's own icon/color. The registry **stored** styles correctly and a simple `db.First` returned them — the loss was in the list query.

## Root cause

`ComponentFilter.Get()` does:

```go
Select("component_definition_dbs.*, model_dbs.*, category_dbs.*, connections.*")
  …Scan(&componentDefinitionsWithModel)   // struct with 4 gorm:"embedded" structs
```

The joined tables share column names (`id`, `metadata`, `status`, `created_at`, …). GORM cannot apply the `serializer:json` on the component's `styles` column through this multi-embedded composite scan, so every returned `ComponentDefinition.Styles` is `nil` even though the `styles` column holds valid JSON.

This query has been unchanged since v1.0.8 — a latent GORM fragility. It is **not** caused by the `server/meshmodels` → `models/` relocation or the v1beta3 migration.

## Fix

Re-hydrate `Styles` for the result set after the join with a simple single-table query (`hydrateComponentStyles`), which applies the serializer correctly. It only touches components whose `Styles` is `nil`, so it is a no-op once the scan can populate them.

## Verification

- New unit tests: `hydrateComponentStyles` restores dropped styles via the real DB serializer round-trip, and is a no-op when styles are already populated.
- Verified end-to-end against a live seeded registry: 0/8 → **8/8** components had populated styles for antrea, istio-base, and kubernetes.

## Audit

`component_filter.go` is the only multi-table `SELECT t1.*, t2.*` embedded scan in meshkit; `policy_filter` (single table), `model_filter` (Preload), and `category_filter` (single table `First`/`Find`) are unaffected.

## Notes

Meshery Server picks this up via a `go.mod` bump. The Kanvas defensive fallback (render model metadata when component styles are empty) is a companion change in meshery-extensions.