### PR TITLE
[registry] Make Artifact Hub rate limit configurable

### DIFF
--- a/registry/helpers.go
+++ b/registry/helpers.go
@@ -57,9 +57,9 @@ type GenerationOptions struct {
 // DefaultGenerationOptions returns GenerationOptions with default values
 func DefaultGenerationOptions() GenerationOptions {
 	return GenerationOptions{
-		ModelTimeout:              DefaultModelTimeout,
-		LatestVersionOnly:         false,
-		ProgressCallback:          nil,
+		ModelTimeout:      DefaultModelTimeout,
+		LatestVersionOnly: false,
+		ProgressCallback:  nil,
 		ArtifactHubRequestLimit:   DefaultArtifactHubRequestLimit,
 		ArtifactHubWaitDuration:   DefaultArtifactHubWaitDuration,
 	}

--- a/registry/helpers.go
+++ b/registry/helpers.go
@@ -32,6 +32,10 @@ const (
 	overridedURLPathAndQueryParams = "/export?format=csv&gid="
 	// DefaultModelTimeout is the default timeout for generating a single model (5 minutes)
 	DefaultModelTimeout = 5 * time.Minute
+	// DefaultArtifactHubRequestLimit is how many Artifact Hub calls before a wait (matches prior hardcoded behavior)
+	DefaultArtifactHubRequestLimit = 100
+	// DefaultArtifactHubWaitDuration is how long to wait when the Artifact Hub batch limit is hit
+	DefaultArtifactHubWaitDuration = 5 * time.Minute
 )
 
 // GenerationOptions contains configuration options for model generation
@@ -44,14 +48,20 @@ type GenerationOptions struct {
 	// ProgressCallback is called to report generation progress
 	// Parameters: currentModel (name), currentIndex (1-based), totalModels
 	ProgressCallback func(modelName string, currentIndex, totalModels int)
+	// ArtifactHubRequestLimit sleeps after this many Artifact Hub API calls (default 100)
+	ArtifactHubRequestLimit int
+	// ArtifactHubWaitDuration is how long to wait when the batch limit is hit (default 5m)
+	ArtifactHubWaitDuration time.Duration
 }
 
 // DefaultGenerationOptions returns GenerationOptions with default values
 func DefaultGenerationOptions() GenerationOptions {
 	return GenerationOptions{
-		ModelTimeout:      DefaultModelTimeout,
-		LatestVersionOnly: false,
-		ProgressCallback:  nil,
+		ModelTimeout:              DefaultModelTimeout,
+		LatestVersionOnly:         false,
+		ProgressCallback:          nil,
+		ArtifactHubRequestLimit:   DefaultArtifactHubRequestLimit,
+		ArtifactHubWaitDuration:   DefaultArtifactHubWaitDuration,
 	}
 }
 

--- a/registry/model.go
+++ b/registry/model.go
@@ -51,10 +51,8 @@ var (
 	shouldRegisterMod = "publishToSites"
 )
 var (
-	artifactHubCount        = 0
-	artifactHubRateLimit    = 100
-	artifactHubRateLimitDur = 5 * time.Minute
-	artifactHubMutex        sync.Mutex
+	artifactHubCount = 0
+	artifactHubMutex sync.Mutex
 )
 var defVersion = "v1.0.0"
 
@@ -660,13 +658,20 @@ func GenerateModels(registrant string, sourceURl string, modelName string) (mode
 	return pkg, version, nil
 }
 
-func RateLimitArtifactHub() {
+func RateLimitArtifactHub(requestLimit int, waitDuration time.Duration) {
+	if requestLimit <= 0 {
+		requestLimit = 100
+	}
+	if waitDuration <= 0 {
+		waitDuration = 5 * time.Minute
+	}
+
 	artifactHubMutex.Lock()
 	defer artifactHubMutex.Unlock()
 
-	if artifactHubCount > 0 && artifactHubCount%artifactHubRateLimit == 0 {
-		Log.Info("Rate limit reached for Artifact Hub. Waiting for ", artifactHubRateLimitDur)
-		time.Sleep(artifactHubRateLimitDur)
+	if artifactHubCount > 0 && artifactHubCount%requestLimit == 0 {
+		Log.Info("Rate limit reached for Artifact Hub. Waiting for ", waitDuration)
+		time.Sleep(waitDuration)
 	}
 	artifactHubCount++
 }
@@ -932,7 +937,7 @@ func InvokeGenerationFromSheetWithOptions(wg *sync.WaitGroup, path string, model
 				}
 
 				if utils.ReplaceSpacesAndConvertToLowercase(model.Registrant) == "artifacthub" {
-					RateLimitArtifactHub()
+					RateLimitArtifactHub(opts.ArtifactHubRequestLimit, opts.ArtifactHubWaitDuration)
 				}
 
 				Log.Debug(fmt.Sprintf("Model %s: Fetching package from source", model.Model))


### PR DESCRIPTION
**Description**

Relates to meshery/meshery [#11034](https://github.com/meshery/meshery/issues/11034)

Fixes the meshkit side of [meshery#11034](https://github.com/meshery/meshery/issues/11034) — rate-limited model generation during `mesheryctl registry generate`.

### Issue

The daily model generator CI runs `registry generate` over many Artifact Hub models. When too many requests hit artifacthub.io at once, the API returns **HTTP 429** and those models fail:

status code 429 for https://artifacthub.io/api/v1/packages/search?...

meshkit already had basic rate limiting in `RateLimitArtifactHub()` — sleep **5 minutes** after every **100** Artifact Hub model starts — but both values were **hardcoded globals**. mesheryctl and the CI workflow had no way to configure a longer wait or a lower request limit when 429s show up.

### Solution (this PR)

Make the existing rate limit **configurable** through `GenerationOptions`, without changing default behavior.

**`registry/helpers.go`**
- `ArtifactHubRequestLimit` — sleep after this many Artifact Hub model starts (default: `100`)
- `ArtifactHubWaitDuration` — how long to sleep when the limit is hit (default: `5m`)
- Defaults set in `DefaultGenerationOptions()`

**`registry/model.go`**
- `RateLimitArtifactHub(requestLimit, waitDuration)` uses the passed values (falls back to 100 / 5m if zero)
- `InvokeGenerationFromSheetWithOptions` passes `opts.ArtifactHubRequestLimit` and `opts.ArtifactHubWaitDuration`

If no options are set, behavior is **identical to before**. Callers (mesheryctl, once wired) can tune values for CI, e.g. limit `20` and wait `10m` to sleep sooner and reduce 429s.

### Out of scope (follow-up)

- **meshery:** mesheryctl flags and `model-generator.yml` workflow inputs — needed to close meshery#11034 fully
- **meshkit:** HTTP 429 retry in `generators/artifacthub/scanner.go` — separate improvement (#11161)
- **meshkit:** changing parallel worker count (`semaphore.NewWeighted(20)`)

**Notes for Reviewers**

- 2 files changed; same mutex + counter logic, only parameterized
- meshery PR to follow after meshkit release: bump meshkit + expose CLI/workflow knobs

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
