### PR TITLE
Guard chartUrl extraction against a malformed helm index

### DIFF
--- a/generators/artifacthub/package.go
+++ b/generators/artifacthub/package.go
@@ -116,11 +116,31 @@ func (pkg *AhPackage) UpdatePackageData() error {
 	if pkgEntry == nil || !ok {
 		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
 	}
-	urls, ok := pkgEntry.([]interface{})[0].(map[interface{}]interface{})["urls"]
+	// The helm index maps each chart name to a list of version entries. Every
+	// type assertion and index access below operates on data parsed from a
+	// remote index.yaml (utils.ReadRemoteFile), so an unexpected shape — a
+	// non-list entry, an empty version list, a missing/empty urls list, or a
+	// non-string url — must return an error rather than panic. The previous
+	// code asserted and indexed (`pkgEntry.([]interface{})[0]` and
+	// `urls.([]interface{})[0]`) without guarding, so a malformed index
+	// crashed the generator with an index-out-of-range / type-assertion panic.
+	entryVersions, ok := pkgEntry.([]interface{})
+	if !ok || len(entryVersions) == 0 {
+		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
+	}
+	firstVersion, ok := entryVersions[0].(map[interface{}]interface{})
+	if !ok {
+		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
+	}
+	urls, ok := firstVersion["urls"]
 	if urls == nil || !ok {
 		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
 	}
-	chartUrl, ok := urls.([]interface{})[0].(string)
+	urlList, ok := urls.([]interface{})
+	if !ok || len(urlList) == 0 {
+		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
+	}
+	chartUrl, ok := urlList[0].(string)
 	if !ok || chartUrl == "" {
 		return ErrGetChartUrl(fmt.Errorf("Cannot extract chartUrl from repository helm index"))
 	}

--- a/generators/artifacthub/package_test.go
+++ b/generators/artifacthub/package_test.go
@@ -3,7 +3,10 @@ package artifacthub
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -67,6 +70,73 @@ func TestGetChartUrl(t *testing.T) {
 					continue
 				}
 				_, _ = f.Write(byt)
+			}
+		})
+	}
+}
+
+// TestUpdatePackageDataMalformedIndex verifies that UpdatePackageData returns an
+// error (and does not panic) when the remote helm repository index.yaml has an
+// unexpected shape. The chartUrl extraction previously asserted and indexed the
+// parsed index without guards, so a malformed index crashed the generator.
+func TestUpdatePackageDataMalformedIndex(t *testing.T) {
+	serve := func(index string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, index)
+		}))
+	}
+
+	tests := []struct {
+		name      string
+		index     string
+		expectErr bool
+	}{
+		{
+			name:      "empty version list for the chart",
+			index:     "entries:\n  mychart: []\n",
+			expectErr: true,
+		},
+		{
+			name:      "chart entry is not a list",
+			index:     "entries:\n  mychart:\n    foo: bar\n",
+			expectErr: true,
+		},
+		{
+			name:      "version entry has an empty urls list",
+			index:     "entries:\n  mychart:\n    - urls: []\n",
+			expectErr: true,
+		},
+		{
+			name:      "first url is not a string",
+			index:     "entries:\n  mychart:\n    - urls:\n        - 123\n",
+			expectErr: true,
+		},
+		{
+			name:      "well-formed index",
+			index:     "entries:\n  mychart:\n    - urls:\n        - https://example.com/mychart-1.0.0.tgz\n",
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := serve(tt.index)
+			defer srv.Close()
+
+			pkg := AhPackage{Name: "mychart", RepoUrl: srv.URL}
+			// Must return an error instead of panicking on malformed index data.
+			err := pkg.UpdatePackageData()
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for a malformed helm index, got nil (ChartUrl=%q)", pkg.ChartUrl)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for a well-formed index: %v", err)
+			}
+			if pkg.ChartUrl == "" {
+				t.Fatal("expected ChartUrl to be populated for a well-formed index")
 			}
 		})
 	}


### PR DESCRIPTION
## Description

`UpdatePackageData` extracted the chart URL from a remote helm repository `index.yaml` with unguarded type assertions and index accesses (details in #1061):

```go
urls, ok := pkgEntry.([]interface{})[0].(map[interface{}]interface{})["urls"]
chartUrl, ok := urls.([]interface{})[0].(string)
```

The comma-ok only guarded the final map/type lookups; the `.([]interface{})` assertions and the `[0]` indexes were unchecked. Since this index data is remote/externally controlled (`utils.ReadRemoteFile`), a malformed but valid-YAML index — a non-list chart entry, an empty version list, or an empty `urls` list — panicked the model generator with an index-out-of-range / type-assertion error.

This guards each assertion and index and returns the existing `ErrGetChartUrl` instead. No behavior change for well-formed indexes.

## Testing

Adds a hermetic `httptest`-based test (`TestUpdatePackageDataMalformedIndex`) covering the malformed shapes (empty version list, non-list entry, empty `urls`, non-string url) and the well-formed happy path. `go test ./generators/artifacthub/` passes; `gofmt`/`go vet` clean.

Fixes #1061

---

I noticed #856 and #845 are also open on this file, touching different parts of `UpdatePackageData`/`GenerateComponents`; this change is on the chartUrl-extraction hunk only and should rebase cleanly. Happy to coordinate ordering.

- [x] Signed off all commits (DCO).
