### PR TITLE
fix: update dir.go to deny walkthrough non supported file types

### DIFF
--- a/models/registration/dir.go
+++ b/models/registration/dir.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/meshkit/models/oci"
@@ -83,7 +84,7 @@ func processDir(dirPath string, pkg *PackagingUnit, regErrStore RegistrationErro
 
 		// Skip files that are not Meshery model entity definitions.
 		// The registration pipeline only understands JSON, YAML, and archive
-		ext := filepath.Ext(path)
+		ext := strings.ToLower(filepath.Ext(path))
 		nonEntityExtensions := map[string]bool{
 			".rego":     true, // OPA policy scripts (e.g. meshery-core/policies/)
 			".template": true, // Rego template files

--- a/models/registration/dir.go
+++ b/models/registration/dir.go
@@ -81,6 +81,20 @@ func processDir(dirPath string, pkg *PackagingUnit, regErrStore RegistrationErro
 			return nil
 		}
 
+		// Skip files that are not Meshery model entity definitions.
+		// The registration pipeline only understands JSON, YAML, and archive
+		ext := filepath.Ext(path)
+		nonEntityExtensions := map[string]bool{
+			".rego":     true, // OPA policy scripts (e.g. meshery-core/policies/)
+			".template": true, // Rego template files
+			".svg":      true, // SVG icon assets
+			".png":      true, // PNG image assets
+			".md":       true, // Markdown documentation
+		}
+		if nonEntityExtensions[ext] {
+			return nil
+		}
+
 		// Read the file content
 		data, err := os.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes meshery/meshery#20892

### Description

Model directory registration (`registration.NewDir(...).Register(...)`) walks every file in a model package and tries to parse it as an entity definition. Non-JSON/YAML files like OPA `.rego` policy scripts (e.g. under `meshery-core/policies/`) were being sniffed as YAML (since `.rego` is plain text), then failing JSON parsing — surfacing misleading `unsupported extension for operation 'import'` errors during registration.

### Fix

Skip known non-entity file extensions (`.rego`, `.template`, `.svg`, `.png`, `.md`) early in `processDir` (`models/registration/dir.go`), before any content parsing is attempted. Genuinely malformed entity files (bad `.json`/`.yaml`) still surface as errors — only known non-model assets are ignored.

### Testing

- `go build ./...` — clean
- `go test ./models/registration/...` — pass
- Built Meshery server against this branch via local `replace` in `meshery/go.mod` — clean
- Confirmed `.rego` files no longer appear as invalid definitions in `~/.meshery/logs/registery/registry-errors.logs`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration scanning by ignoring non-model files, such as assets, documentation, policies, templates, and other unsupported content types.
  * Prevents unsupported files from being read and processed during directory scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->