### PR TITLE
[meshkit] fix: disable tracing when no endpoint configured, suppress repeated export-failure logs

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -25,12 +26,39 @@ type Config struct {
 	Endpoint string `yaml:"endpoint" json:"endpoint"`
 	// Insecure determines whether to use an insecure connection (no TLS)
 	Insecure bool `yaml:"insecure" json:"insecure"`
+	// Enabled explicitly controls whether tracing is active. When nil,
+	// tracing is enabled only if Endpoint is set. When explicitly false,
+	// tracing is always disabled regardless of Endpoint.
+	Enabled *bool `yaml:"enabled" json:"enabled"`
+}
+
+var (
+	exportErrMu     sync.Mutex
+	wasFailing      bool
+	previousHandler otel.ErrorHandler
+)
+
+// suppressRepeatedExportErrors logs the first export failure encountered,
+// then stays quiet on subsequent failures, to avoid flooding logs when a
+// configured collector endpoint is unreachable. Retries by the underlying
+// exporter continue unaffected; only the logging is suppressed.
+func suppressRepeatedExportErrors(err error) {
+	exportErrMu.Lock()
+	if !wasFailing {
+		fmt.Printf("tracing export failing, collector may be unreachable: %v\n", err)
+		wasFailing = true
+	}
+	exportErrMu.Unlock()
+
+	if previousHandler != nil {
+		previousHandler.Handle(err)
+	}
 }
 
 func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.TracerProvider, error) {
 	cfg := Config{}
 
-	err := yaml.Unmarshal([]byte(config),&cfg)
+	err := yaml.Unmarshal([]byte(config), &cfg)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tracing config: %w", err)
@@ -42,13 +70,22 @@ func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.Tra
 // InitTracer initializes and configures the global OpenTelemetry trace provider
 // It sets up OTLP gRPC exporter, resource attributes, and W3C trace context propagation
 func InitTracer(ctx context.Context, cfg Config) (*sdktrace.TracerProvider, error) {
+	// Tracing is a no-op if explicitly disabled, or if no endpoint is
+	// configured — this is not an error, just an intentional off state.
+	if (cfg.Enabled != nil && !*cfg.Enabled) || cfg.Endpoint == "" {
+		return nil, nil
+	}
+
 	// Validate configuration
 	if cfg.ServiceName == "" {
 		return nil, fmt.Errorf("service name is required")
 	}
-	if cfg.Endpoint == "" {
-		return nil, fmt.Errorf("endpoint is required")
-	}
+
+	// Suppress repeated identical export-failure logs (e.g. when the
+	// configured endpoint is unreachable) so noisy retries don't flood logs.
+	// Preserves and still invokes any previously-registered handler.
+	previousHandler = otel.GetErrorHandler()
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(suppressRepeatedExportErrors))
 
 	// Configure OTLP exporter options
 	opts := []otlptracegrpc.Option{

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -14,10 +14,14 @@ import (
 
 func TestInitTracer(t *testing.T) {
 	// Note: These tests validate configuration without attempting real connections
+	falseVal := false
+	trueVal := true
+
 	tests := []struct {
-		name    string
-		config  Config
-		wantErr bool
+		name        string
+		config      Config
+		wantErr     bool
+		wantNilProv bool
 	}{
 		{
 			name: "missing service name",
@@ -29,24 +33,77 @@ func TestInitTracer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing endpoint",
+			name: "missing endpoint is a no-op, not an error",
 			config: Config{
 				ServiceName:    "test-service",
 				ServiceVersion: "1.0.0",
 				Insecure:       true,
 			},
-			wantErr: true,
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "explicitly disabled is a no-op, even with endpoint set",
+			config: Config{
+				ServiceName: "test-service",
+				Endpoint:    "localhost:4317",
+				Enabled:     &falseVal,
+			},
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "explicitly enabled with empty endpoint is still a no-op",
+			config: Config{
+				ServiceName: "test-service",
+				Enabled:     &trueVal,
+			},
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "enabled with valid endpoint returns a real provider",
+			config: Config{
+				ServiceName: "test-service",
+				Endpoint:    "localhost:4317",
+				Insecure:    true,
+				Enabled:     &trueVal,
+			},
+			wantErr:     false,
+			wantNilProv: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			prevProvider := otel.GetTracerProvider()
+			prevHandler := otel.GetErrorHandler()
+			prevPropagator := otel.GetTextMapPropagator()
+			t.Cleanup(func() {
+				otel.SetTracerProvider(prevProvider)
+				otel.SetErrorHandler(prevHandler)
+				otel.SetTextMapPropagator(prevPropagator)
+			})
 			ctx := context.Background()
-			_, err := InitTracer(ctx, tt.config)
+			tp, err := InitTracer(ctx, tt.config)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InitTracer() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			// Only check provider state when no error was expected —
+			// error cases always return a nil provider, which is correct
+			// but not meaningfully described by wantNilProv.
+			if !tt.wantErr {
+				if tt.wantNilProv && tp != nil {
+					t.Errorf("InitTracer() expected nil provider, got %v", tp)
+				}
+				if !tt.wantNilProv && tp == nil {
+					t.Errorf("InitTracer() expected non-nil provider, got nil")
+				}
+			}
+			if tp != nil {
+				_ = tp.Shutdown(ctx)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes: #894

## Summary
This PR makes two related fixes to `tracing/tracing.go`:

1. **Treats a missing/empty endpoint as implicitly disabled tracing**: Previously, `InitTracer` returned a hard error if `Endpoint` was empty, even when tracing was never intended to be used. Now, if no endpoint is configured (or tracing is explicitly disabled via a new `Enabled *bool` field), `InitTracer` returns `nil, nil` — a clean no-op, not an error.

2. **Suppresses repeated identical export-failure logs** : when an endpoint *is* configured but unreachable (e.g. collector down, wrong address, not yet started), the OTLP exporter retries indefinitely, and previously logged a failure on every retry (~every 10-15s). This adds an error handler (via `otel.SetErrorHandler`) that logs the first failure once, then suppresses further identical failures, without affecting the underlying retry behavior itself.Any previously registered OTel error handler is preserved and still invoked, so this doesn't silently override unrelated error handling that may already be in place.


## Why
Meshery Server was logging repeated "connection refused" errors when no trace collector was configured, because it kept trying to reach a default.
OTLP address. Investigation showed this had two separate causes:
- The original reported scenario (nothing configured at all) was independently fixed in meshery's `main.go`/Makefile defaults, but the same protection was never added at the meshkit layer, so any other meshkit consumer remained exposed to it.
- A related, still-open case: a user (or a Helm deployment, once meshery/meshery#20898 lands) explicitly configuring an endpoint that's unreachable still produces the same noisy log loop today.

## Known limitation
- The suppression does not currently reset on recovery, if the collector comes back online and later goes down again, the second failure streak won't log again, since `otel.SetErrorHandler` only exposes a failure hook, not a success hook. This still resolves the reported issue (no more infinite log spam) but is noted here as a possible future improvement (e.g. wrapping the exporter directly to detect successful exports).
- The suppression currently applies to all OTel errors process-wide, not specifically to export failures, it doesn't distinguish "collector unreachable" from other kinds of OTel errors that might occur. A more precise fix would inspect the error type or wrap the exporter directly instead of using the global handler, which felt like a larger change than this PR's scope.

## Testing
- Added unit tests covering: explicit disable, missing endpoint (no-op, not an error), and explicit enable with no endpoint (still a no-op).
- Verified live, against a real collector:

  1. Confirmed `make server` with no `OTEL_CONFIG` already logs cleanly  ("tracing disabled"), unaffected by this change.
     
https://github.com/user-attachments/assets/3b7ffb50-3dac-47c3-8081-69b53328167a

  2. Demonstrated the still-open problem this PR fixes: with an endpoint configured but unreachable, the exporter retries and logs a failure on every attempt, continuously (~every 10-15s), before this fix.
     

https://github.com/user-attachments/assets/9d08ff30-2990-4862-bc37-113c10798fbc

  3. With the fix applied: configured the same unreachable endpoint and confirmed the failure now logs only once, not on every retry. Then started a local Jaeger instance (OTLP on 4317) and confirmed traces from `meshery-server` appear correctly in Jaeger's UI. Then stopped Jaeger again and confirmed no renewed log spam occurs (consistent with the known limitation noted above, suppression persists rather than resetting on recovery).

https://github.com/user-attachments/assets/74e3c2da-76ce-4ecb-a499-15ea555d3e94


## Related
Companion Helm chart change (exposes `OTEL_CONFIG` in `values.yaml`):
meshery/meshery#20898

**Signed commits**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an `enabled` option to explicitly turn tracing on or off via YAML/JSON configuration.

* **Bug Fixes**
  * Tracing now behaves as a safe no-op when tracing is disabled or when no endpoint is configured, instead of failing to start.
  * Prevented repeated tracing export failures from repeatedly flooding logs.

* **Tests**
  * Expanded tracer initialization tests to verify nil/no-op behavior and correct shutdown handling when tracing is disabled or omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->