### PR TITLE
Propagate DB errors in CategoryFilter.Get

### DIFF
--- a/models/meshmodel/registry/v1beta1/category_filter.go
+++ b/models/meshmodel/registry/v1beta1/category_filter.go
@@ -76,7 +76,7 @@ func (cf *CategoryFilter) Get(db *database.Handler) ([]entity.Entity, int64, int
 
 	err := finder.Find(&catdb).Error
 	if err != nil {
-		return cat, count, int(count), nil
+		return nil, 0, 0, err
 	}
 
 	for _, c := range catdb {


### PR DESCRIPTION
Fixes #1075.

### What

`CategoryFilter.Get` dropped the error from `finder.Find` and returned an empty result with a nil error:

```go
err := finder.Find(&catdb).Error
if err != nil {
    return cat, count, int(count), nil   // swallowed
}
```

So a real query failure (e.g. a bad `OrderOn` column from a caller-supplied sort param → SQL error, or a transient DB error) surfaced as an **empty category list reported as success** — nothing returned to the client, nothing logged.

### Change

Return `nil, 0, 0, err`, matching every sibling filter — `ModelFilter.Get` and `ConnectionFilter.Get` both already propagate the error this way. `CategoryFilter` was the only outlier.

### Testing

One-line change; `GOOS=linux go build ./models/meshmodel/registry/...` and `go vet` both pass. Behaviour for the success path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected category filtering error handling so failed requests now return the appropriate error instead of appearing successful.
  * Ensured pagination counts are reset when category data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->