### PR TITLE
Skip component definitions with no status during registration

### DIFF
--- a/models/meshmodel/registry/v1beta1/category_filter.go
+++ b/models/meshmodel/registry/v1beta1/category_filter.go
@@ -76,7 +76,7 @@ func (cf *CategoryFilter) Get(db *database.Handler) ([]entity.Entity, int64, int
 
 	err := finder.Find(&catdb).Error
 	if err != nil {
-		return cat, count, int(count), nil
+		return nil, 0, 0, err
 	}
 
 	for _, c := range catdb {

--- a/models/registration/register.go
+++ b/models/registration/register.go
@@ -1,6 +1,8 @@
 package registration
 
 import (
+	"fmt"
+
 	"github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	meshmodel "github.com/meshery/meshkit/models/meshmodel/registry"
@@ -111,6 +113,11 @@ func (rh *RegistrationHelper) register(pkg PackagingUnit) {
 	var registeredRelationships []relationship.RelationshipDefinition
 	// 2. Register components
 	for _, comp := range pkg.Components {
+		if comp.Status == nil {
+			err := ErrRegisterEntity(fmt.Errorf("component definition has no status"), string(comp.Type()), comp.DisplayName)
+			rh.regErrStore.InsertEntityRegError(hostname, model.DisplayName, entity.ComponentDefinition, comp.DisplayName, err)
+			continue
+		}
 		status := *comp.Status
 		if status == component.Ignored {
 			continue


### PR DESCRIPTION
Fixes #1077.

### What

`register()` dereferenced `*comp.Status` unconditionally. `ComponentDefinition.Status` is a `*ComponentDefinitionStatus` and `getEntity` unmarshals definitions without requiring it, so a definition that omits `status` unmarshals with `Status == nil` and panics on the first component — aborting the entire import batch before the loop's per-item error handling can skip just the bad item.

### Change

Guard `comp.Status == nil`: record an `InsertEntityRegError` for that component and `continue`, exactly how the loop already handles other per-item failures (RegisterEntity errors).

### Testing

`GOOS=linux go build ./models/registration/` and `go vet` both pass. No behaviour change for components that have a status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query failures now correctly return an error instead of appearing successful with incomplete or misleading results.
  * Registration now handles components with missing status information safely, reporting the issue and continuing without interruption to other components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->