### PR TITLE
fix: return ErrEndpointNotFound when PortSelector matches no port

### DIFF
--- a/utils/kubernetes/service.go
+++ b/utils/kubernetes/service.go
@@ -33,6 +33,7 @@ func GetServiceEndpoint(ctx context.Context, client kubernetes.Interface, opts *
 // GetEndpoint returns those endpoints in the given service which match the selector. Eg: service name = "client"
 func GetEndpoint(ctx context.Context, opts *ServiceOptions, obj *corev1.Service) (*utils.Endpoint, error) {
 	var nodePort, clusterPort int32
+	var matched bool
 	endpoint := utils.Endpoint{}
 	if opts.WorkerNodeIP == "" {
 		opts.WorkerNodeIP = "localhost"
@@ -41,8 +42,15 @@ func GetEndpoint(ctx context.Context, opts *ServiceOptions, obj *corev1.Service)
 		nodePort = port.NodePort
 		clusterPort = port.Port
 		if opts.PortSelector != "" && port.Name == opts.PortSelector {
+			matched = true
 			break
 		}
+	}
+	// A non-empty PortSelector that matched no port would otherwise fall through
+	// with the last port's values and be returned as if it were the requested
+	// port; report that the endpoint was not found instead.
+	if opts.PortSelector != "" && !matched {
+		return nil, ErrEndpointNotFound
 	}
 	// get clusterip endpoint
 	endpoint.Internal = &utils.HostPort{

--- a/utils/kubernetes/service_test.go
+++ b/utils/kubernetes/service_test.go
@@ -522,6 +522,35 @@ func TestGetEndpoint(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "PortSelector matching no port returns ErrEndpointNotFound",
+			args: args{
+				ctx: context.TODO(),
+				opts: &ServiceOptions{
+					PortSelector: "does-not-exist",
+					Mock: &utils.MockOptions{
+						DesiredEndpoint: "1.1.1.1:1001",
+					},
+				},
+				obj: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test_service",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: v1.ServiceSpec{
+						ClusterIP: "1.1.1.1",
+						Ports: []v1.ServicePort{
+							{Name: "test_port_1", Port: 1000},
+							{Name: "test_port_2", Port: 1001},
+						},
+						Type: v1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What**

`GetEndpoint` ranges over a service's ports and only `break`s on a name match:

```go
for _, port := range obj.Spec.Ports {
    nodePort = port.NodePort
    clusterPort = port.Port
    if opts.PortSelector != "" && port.Name == opts.PortSelector {
        break
    }
}
```

If a non-empty `PortSelector` matches no port, the loop runs to completion and `nodePort`/`clusterPort` keep the **last** port's values, which are then returned as if they were the requested port, with a `nil` error — contradicting the doc comment ("endpoints which match the selector").

Real impact: the broker and meshsync controllers probe a port named `monitor` (`GetEndpointForPort("monitor")` → `ServiceOptions{PortSelector: "monitor"}`). Against a service that doesn't expose a `monitor` port, the probe silently targets the last port and reports a false connectivity status instead of "endpoint not found".

**Fix**

Track whether the selector matched and return the existing `ErrEndpointNotFound` when a non-empty `PortSelector` matches no port. The empty-selector behavior is unchanged, so existing callers don't regress.

**Test**

Added a case to `TestGetEndpoint`: a `PortSelector` that matches no port now returns `ErrEndpointNotFound` (`want: nil, wantErr: true`). It fails on the current code (the call returns the last port with a nil error) and passes with the fix; the existing empty-selector and matching-selector cases are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected service endpoint selection when a requested port does not exist.
  * The system now reports that no endpoint was found instead of returning incorrect port information.

* **Tests**
  * Added coverage for missing port selections on ClusterIP services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->