### PR TITLE
fix(registry): guard against nil logger in RelationshipCSVHelper

### DIFF
--- a/registry/relationship.go
+++ b/registry/relationship.go
@@ -85,7 +85,9 @@ func (mrh *RelationshipCSVHelper) ParseRelationshipsSheet(modelName string) erro
 	currentRow := rowIndex
 
 	go func() {
-		Log.Info("Parsing Relationships...")
+		if Log != nil {
+			Log.Info("Parsing Relationships...")
+		}
 
 		err := csvReader.Parse(ch, errorChan)
 		if err != nil {
@@ -103,7 +105,12 @@ func (mrh *RelationshipCSVHelper) ParseRelationshipsSheet(modelName string) erro
 			currentRow++
 			mrh.Relationships = append(mrh.Relationships, data)
 		case err := <-errorChan:
-			Log.Error(err)
+			if err != nil {
+				if Log != nil {
+					Log.Error(err)
+				}
+				return err
+			}
 		case <-csvReader.Context.Done():
 			return nil
 		}

--- a/registry/relationship.go
+++ b/registry/relationship.go
@@ -106,10 +106,7 @@ func (mrh *RelationshipCSVHelper) ParseRelationshipsSheet(modelName string) erro
 			mrh.Relationships = append(mrh.Relationships, data)
 		case err := <-errorChan:
 			if err != nil {
-				if Log != nil {
-					Log.Error(err)
-				}
-				return err
+				return csv.ErrReadCSVRow(err, "relationship")
 			}
 		case <-csvReader.Context.Done():
 			return nil


### PR DESCRIPTION
**Description**
This fixes a nil pointer panic in `RelationshipCSVHelper.ParseRelationshipsSheet()` when `Log` is not initialized.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved relationship parsing when optional logging is unavailable.
- Parsing errors are now returned consistently with clearer CSV row context.
- Reduced unnecessary logging during relationship processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->