### PR TITLE
fix: treat missing/disabled endpoint as no-op tracing, not an error

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -25,12 +25,16 @@ type Config struct {
 	Endpoint string `yaml:"endpoint" json:"endpoint"`
 	// Insecure determines whether to use an insecure connection (no TLS)
 	Insecure bool `yaml:"insecure" json:"insecure"`
+	// Enabled explicitly controls whether tracing is active. When nil,
+	// tracing is enabled only if Endpoint is set. When explicitly false,
+	// tracing is always disabled regardless of Endpoint.
+	Enabled *bool `yaml:"enabled" json:"enabled"`
 }
 
 func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.TracerProvider, error) {
 	cfg := Config{}
 
-	err := yaml.Unmarshal([]byte(config),&cfg)
+	err := yaml.Unmarshal([]byte(config), &cfg)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tracing config: %w", err)
@@ -42,14 +46,16 @@ func InitTracerFromYamlConfig(ctx context.Context, config string) (*sdktrace.Tra
 // InitTracer initializes and configures the global OpenTelemetry trace provider
 // It sets up OTLP gRPC exporter, resource attributes, and W3C trace context propagation
 func InitTracer(ctx context.Context, cfg Config) (*sdktrace.TracerProvider, error) {
+
+	// Tracing is a no-op if explicitly disabled, or if no endpoint is
+	// configured — this is not an error, just an intentional off state.
+	if (cfg.Enabled != nil && !*cfg.Enabled) || cfg.Endpoint == "" {
+		return nil, nil
+	}
 	// Validate configuration
 	if cfg.ServiceName == "" {
 		return nil, fmt.Errorf("service name is required")
 	}
-	if cfg.Endpoint == "" {
-		return nil, fmt.Errorf("endpoint is required")
-	}
-
 	// Configure OTLP exporter options
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.Endpoint),

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -14,10 +14,14 @@ import (
 
 func TestInitTracer(t *testing.T) {
 	// Note: These tests validate configuration without attempting real connections
+	falseVal := false
+	trueVal := true
+
 	tests := []struct {
-		name    string
-		config  Config
-		wantErr bool
+		name        string
+		config      Config
+		wantErr     bool
+		wantNilProv bool
 	}{
 		{
 			name: "missing service name",
@@ -29,26 +33,99 @@ func TestInitTracer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing endpoint",
+			name: "missing endpoint is a no-op, not an error",
 			config: Config{
 				ServiceName:    "test-service",
 				ServiceVersion: "1.0.0",
 				Insecure:       true,
 			},
-			wantErr: true,
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "explicitly disabled is a no-op, even with endpoint set",
+			config: Config{
+				ServiceName: "test-service",
+				Endpoint:    "localhost:4317",
+				Enabled:     &falseVal,
+			},
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "explicitly enabled with empty endpoint is still a no-op",
+			config: Config{
+				ServiceName: "test-service",
+				Enabled:     &trueVal,
+			},
+			wantErr:     false,
+			wantNilProv: true,
+		},
+		{
+			name: "enabled with valid endpoint returns a real provider",
+			config: Config{
+				ServiceName: "test-service",
+				Endpoint:    "localhost:4317",
+				Insecure:    true,
+				Enabled:     &trueVal,
+			},
+			wantErr:     false,
+			wantNilProv: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			prevProvider := otel.GetTracerProvider()
+			prevPropagator := otel.GetTextMapPropagator()
+			t.Cleanup(func() {
+				otel.SetTracerProvider(prevProvider)
+				otel.SetTextMapPropagator(prevPropagator)
+			})
 			ctx := context.Background()
-			_, err := InitTracer(ctx, tt.config)
+			tp, err := InitTracer(ctx, tt.config)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InitTracer() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if !tt.wantErr {
+				if tt.wantNilProv && tp != nil {
+					t.Errorf("InitTracer() expected nil provider, got %v", tp)
+				}
+				if !tt.wantNilProv && tp == nil {
+					t.Errorf("InitTracer() expected non-nil provider, got nil")
+				}
+			}
+			if tp != nil {
+				_ = tp.Shutdown(ctx)
+			}
 		})
+	}
+}
+
+func TestInitTracerFromYamlConfig_Disabled(t *testing.T) {
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+	})
+
+	yamlConfig := `
+service_name: test-service
+endpoint: localhost:4317
+enabled: false
+`
+	ctx := context.Background()
+	tp, err := InitTracerFromYamlConfig(ctx, yamlConfig)
+
+	if err != nil {
+		t.Errorf("InitTracerFromYamlConfig() unexpected error = %v", err)
+	}
+	if tp != nil {
+		t.Errorf("InitTracerFromYamlConfig() expected nil provider when enabled: false, got %v", tp)
+		_ = tp.Shutdown(ctx)
 	}
 }
 


### PR DESCRIPTION

Fixes: #894

## Summary
Makes tracing opt-in rather than attempted-by-default:

- Adds an `Enabled *bool` field to `Config`. When nil, tracing is enabled
  only if `Endpoint` is set. When explicitly `false`, tracing is always
  disabled regardless of `Endpoint`.
- `InitTracer` now returns `nil, nil` (a clean no-op, not an error) when
  either no endpoint is configured, or tracing is explicitly disabled.
  Previously, an empty `Endpoint` caused a hard error.

## Why
Meshery Server was logging repeated "connection refused" errors when no
trace collector was configured, because it kept attempting to reach a
default OTLP address. The original scenario (nothing configured at all)
has separately been mitigated in meshery's `main.go`, but the same
protection was missing at the meshkit layer, leaving any other meshkit
consumer exposed to the same issue.

## Scope
This PR is intentionally narrow, per review feedback, and covers only
the opt-in/endpoint-check behavior. 

## Testing
Unit tests cover: missing service name (unchanged behavior), missing
endpoint (no-op, not an error), explicit disable with an endpoint set,
explicit enable with no endpoint (still a no-op), and explicit enable
with a valid endpoint (returns a real provider). All existing tests
continue to pass.

## Related
- Companion Helm chart change (exposes `OTEL_CONFIG` in `values.yaml`):
  meshery/meshery#20898
- Superseded PR (previously combined this fix with log-suppression,
  split per maintainer feedback): #1070

**Signed commits**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to explicitly enable or disable tracing.
  * Tracing now operates silently when disabled or when no endpoint is configured.

* **Bug Fixes**
  * Missing tracing endpoints no longer cause initialization errors.
  * Improved handling of tracing configuration across supported settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->