### PR TITLE
[registration] Close SVG files after writing to prevent fd leak

### DIFF
--- a/models/registration/svg_helper.go
+++ b/models/registration/svg_helper.go
@@ -31,6 +31,8 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		defer func() { _ = f.Close() }()
+
 		_, err = f.WriteString(svgColor)
 		if err != nil {
 			fmt.Println(err)
@@ -53,6 +55,8 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		defer func() { _ = f.Close() }()
+
 		_, err = f.WriteString(svgWhite)
 		if err != nil {
 			fmt.Println(err)
@@ -75,6 +79,8 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		defer func() { _ = f.Close() }()
+
 		_, err = f.WriteString(svgComplete)
 		if err != nil {
 			fmt.Println(err)

--- a/models/registration/svg_helper_test.go
+++ b/models/registration/svg_helper_test.go
@@ -1,0 +1,38 @@
+package registration
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openFDCount reports the number of open file descriptors for this process.
+// Only meaningful on Linux, where /proc/self/fd is available - this is what
+// CI runs on (see .github/workflows/ci.yml).
+func openFDCount(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+func TestWriteAndReplaceSVGWithFileSystemPathClosesFiles(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("fd-count check relies on /proc/self/fd, only available on linux")
+	}
+
+	tmp := t.TempDir()
+	before := openFDCount(t)
+
+	for i := 0; i < 50; i++ {
+		dirname := filepath.Join("model", "component")
+		WriteAndReplaceSVGWithFileSystemPath("<svg>color</svg>", "<svg>white</svg>", "<svg>complete</svg>", tmp, dirname, "icon", false)
+	}
+
+	after := openFDCount(t)
+	assert.Less(t, after-before, 10, "open file descriptors grew by %d after 50 calls (3 unclosed *os.File per call would leak 150)", after-before)
+}

--- a/models/registration/svg_helper_test.go
+++ b/models/registration/svg_helper_test.go
@@ -25,6 +25,13 @@ func TestWriteAndReplaceSVGWithFileSystemPathClosesFiles(t *testing.T) {
 		t.Skip("fd-count check relies on /proc/self/fd, only available on linux")
 	}
 
+	// WriteAndReplaceSVGWithFileSystemPath appends to the package-level UISVGPaths on
+	// every successful call, so 50 iterations would leave 50 entries behind in shared
+	// process state and make any later test that reads UISVGPaths order-dependent.
+	// Snapshot and restore it rather than leaking that across the package.
+	originalUISVGPaths := UISVGPaths
+	t.Cleanup(func() { UISVGPaths = originalUISVGPaths })
+
 	tmp := t.TempDir()
 	before := openFDCount(t)
 


### PR DESCRIPTION
Fixes #1091

## What
`WriteAndReplaceSVGWithFileSystemPath` opens up to 3 files per call via `os.Create` (color, white, complete) and never closes any of them. Adds a `defer func() { _ = f.Close() }()` right after each successful `os.Create`, matching the same defer-close idiom already used in this codebase (e.g. `mesheryctl/internal/cli/root/system/logs.go`).

## Why it matters
This function is called once per model and once per component during registration (`models/registration/register.go` lines 81, 130), so a single package import leaks 3 fds per entity registered.

## Test
Added `TestWriteAndReplaceSVGWithFileSystemPathClosesFiles`, which calls the function 50 times and checks the process's open fd count via `/proc/self/fd` before and after (Linux-only, CI runs ubuntu-24.04 - skips elsewhere). Confirmed locally: fails without the fix (fd count grows by ~150), passes with it (flat).

## Metrics
- 2 files changed: `models/registration/svg_helper.go`, `models/registration/svg_helper_test.go`
- Before: 3 leaked fds per call, unconditionally. After: 0.
- `go build ./...` and `go test ./models/registration/...` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could leave SVG file handles open after processing.
  * Improved reliability when repeatedly creating and replacing SVG files.

* **Tests**
  * Added Linux-specific coverage to detect file-handle leaks during repeated SVG processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->