### PR TITLE
[broadcast] Use non-blocking send in broadcast() so one stalled subscriber cannot freeze the bus

### DIFF
--- a/utils/broadcast/broadcaster.go
+++ b/utils/broadcast/broadcaster.go
@@ -52,7 +52,10 @@ type Broadcaster interface {
 
 func (b *broadcaster) broadcast(m BroadcastMessage) {
 	for ch := range b.outputs {
-		ch <- m
+		select {
+		case ch <- m:
+		default:
+		}
 	}
 }
 

--- a/utils/broadcast/broadcaster_test.go
+++ b/utils/broadcast/broadcaster_test.go
@@ -1,0 +1,50 @@
+package broadcast
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBroadcasterSlowSubscriberDoesNotBlockOthers(t *testing.T) {
+	b := NewBroadcaster(10)
+
+	// A subscriber that never drains its channel.
+	slow := make(chan BroadcastMessage)
+	b.Register(slow)
+
+	// A subscriber that does drain, buffered so Submit below doesn't need a
+	// live reader yet.
+	fast := make(chan BroadcastMessage, 1)
+	b.Register(fast)
+
+	b.Submit(BroadcastMessage{Type: "first"})
+
+	// The fast subscriber must still receive the message even though the
+	// slow one never reads it.
+	select {
+	case got := <-fast:
+		assert.Equal(t, "first", got.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast subscriber never received the broadcast message")
+	}
+
+	// Register/Unregister go through the same goroutine as broadcast(), so
+	// they must not be blocked by the stalled slow subscriber either.
+	for _, op := range []struct {
+		name string
+		fn   func()
+	}{
+		{"Register", func() { b.Register(make(chan BroadcastMessage, 1)) }},
+		{"Unregister", func() { b.Unregister(slow) }},
+	} {
+		done := make(chan struct{})
+		go func() { op.fn(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s blocked for >2s behind the stalled subscriber", op.name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1092

## What
`broadcaster.broadcast()` sent to each registered channel with a plain blocking `ch <- m`. `Register`, `Unregister` and `Submit` all funnel through the same single `run()` goroutine, so if any one subscriber stops draining its channel, that blocking send wedges `run()` - freezing delivery to every other subscriber and every subsequent `Register`/`Unregister` call, indefinitely, not just for the stalled one.

Fix wraps the send in `select` with a `default` case, so an unready subscriber has its message dropped instead of blocking the shared goroutine.

## Why it isn't a meshkit-only issue, and why fix it anyway
This exact pattern is inherited from the reference implementation this file's own header cites (`github.com/dustin/go-broadcast`) - upstream's `broadcast()` has the identical unprotected `ch <- m` as of today. Not a regression introduced here. But it's a real gap in an exported, shared-library `Broadcaster` type, and `meshery/meshery`'s server already instantiates one (`server/cmd/main.go`) - any current or future caller that registers a slow consumer hits this. I checked: the server's GraphQL subscriptions currently use their own separate channels rather than `Broadcaster.Register`, so this specific deadlock isn't live in that codepath today, but the exported type still ships the bug.

## Test
Added `TestBroadcasterSlowSubscriberDoesNotBlockOthers`: registers a slow (never-drained) subscriber and a fast one, submits a message, and asserts (a) the fast subscriber still receives it and (b) a follow-up `Register` and `Unregister` each return within 2s. Confirmed locally: fails on master (fast subscriber times out waiting for the message), passes with the fix.

## Metrics
- 2 files changed: `utils/broadcast/broadcaster.go`, `utils/broadcast/broadcaster_test.go`
- Before: one stalled subscriber blocks the entire broadcaster forever. After: it only drops its own message.
- `go build ./...` and `go test ./utils/broadcast/...` both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broadcast responsiveness by preventing slow or inactive subscribers from blocking message delivery.
  * Ensured subscriber registration and removal remain responsive while broadcasts are in progress.

* **Tests**
  * Added coverage for delivery to responsive subscribers and concurrent subscriber management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->