### PR TITLE
Accept v1beta3 relationship schemaVersion at registration

### DIFF
--- a/models/registration/utils.go
+++ b/models/registration/utils.go
@@ -45,7 +45,12 @@ func getEntity(byt []byte) (et entity.Entity, _ error) {
 			return nil, ErrGetEntity(fmt.Errorf("Invalid model definition: %s", err.Error()))
 		}
 		et = &model
-	case schema.RelationshipSchemaVersionV1Beta2, v1alpha3.RelationshipSchemaVersion:
+	// Accept v1alpha3, v1beta2, and v1beta3 relationship schema version
+	// strings, mirroring the component/model compatibility above. The wire
+	// shapes are compatible with the v1alpha3 Go struct (meshery/meshery's
+	// relationship_version_bridge.go round-trips them with shallow typed
+	// copies), so all three decode into the same registration type.
+	case schema.RelationshipSchemaVersionV1Beta2, schema.RelationshipSchemaVersionV1Beta3, v1alpha3.RelationshipSchemaVersion:
 		var rel relationship.RelationshipDefinition
 		err := encoding.Unmarshal(byt, &rel)
 		if err != nil {

--- a/models/registration/utils_test.go
+++ b/models/registration/utils_test.go
@@ -29,3 +29,40 @@ func TestGetEntityAcceptsV1Beta2RelationshipSchemaVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, entity.RelationshipDefinition, actual.Type())
 }
+
+func TestGetEntityAcceptsV1Beta3RelationshipSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	relationshipDocument := []byte(`{
+		"schemaVersion": "relationships.meshery.io/v1beta3",
+		"kind": "edge",
+		"type": "non-binding",
+		"subType": "reference",
+		"model": {
+			"name": "kubernetes",
+			"model": {
+				"version": "v1.0.0"
+			}
+		},
+		"version": "v1.0.0"
+	}`)
+
+	actual, err := getEntity(relationshipDocument)
+	require.NoError(t, err)
+	assert.Equal(t, entity.RelationshipDefinition, actual.Type())
+}
+
+func TestGetEntityRejectsUnknownRelationshipSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	relationshipDocument := []byte(`{
+		"schemaVersion": "relationships.meshery.io/v1beta9",
+		"kind": "edge",
+		"type": "non-binding",
+		"subType": "reference",
+		"version": "v1.0.0"
+	}`)
+
+	_, err := getEntity(relationshipDocument)
+	require.Error(t, err)
+}

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -33,6 +33,12 @@ const (
 // the string to keep all packages in sync.
 const RelationshipSchemaVersionV1Beta2 = "relationships.meshery.io/v1beta2"
 
+// RelationshipSchemaVersionV1Beta3 is the schema version string for v1beta3
+// relationship definitions, the current authoring target published by
+// meshery/schemas. Use this constant instead of hard-coding the string to
+// keep all packages in sync.
+const RelationshipSchemaVersionV1Beta3 = "relationships.meshery.io/v1beta3"
+
 // Ref identifies which schema should be used to validate a document.
 type Ref struct {
 	SchemaVersion string       `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty"`


### PR DESCRIPTION
**Description**

This PR fixes meshery/meshkit#1095.

`getEntity` dispatched relationship documents only on the `v1beta2` and `v1alpha3` schema version strings, so a definition authored against the canonical v1beta3 construct published by meshery/schemas fell through to the default case and failed to register - in Meshery Server seeding and `mesheryctl model import` alike. Components and models in the same switch already accept both their legacy and current version strings; relationships were left out of that compatibility pattern.

**Changes**

- Accept `relationships.meshery.io/v1beta3` in the relationship case, decoding into the same shape-compatible registration struct (meshery/meshery's `relationship_version_bridge.go` already round-trips these shapes with shallow typed copies).
- Add `RelationshipSchemaVersionV1Beta3` beside the existing v1beta2 constant in `schema/validator.go`.
- Tests: v1beta3 acceptance plus a pin that unknown versions are still rejected.

**Verification**

- `go build ./...` - clean
- `go test ./...` - full suite passes
- `golangci-lint run models/registration/... schema/...` - 0 issues

**Cross-repo context**

meshery/meshery#21479 documents v1beta3 as the relationship authoring target; until this fix reaches a meshkit release consumed by meshery/meshery, definitions that must register on current servers still need to declare `v1beta2` (that PR's wording is being corrected to say exactly that).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for relationship schema version `v1beta3`.
  * Existing supported relationship versions continue to work as before.

* **Bug Fixes**
  * Unknown relationship schema versions are now correctly rejected.

* **Tests**
  * Added coverage for accepting `v1beta3` and rejecting unsupported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->