### PR TITLE
Escape sjson path specials in patch path segments

### DIFF
--- a/utils/patching/patch.go
+++ b/utils/patching/patch.go
@@ -45,7 +45,38 @@ func ApplyPatches(data map[string]interface{}, patches []Patch) (map[string]inte
 	return result, nil
 }
 
-// convertPathToSjsonPath converts a path array to sjson path format
+// sjsonPathSpecials are the characters gjson/sjson path syntax assigns meaning
+// to inside a key. Escaping them makes every path segment a literal key.
+const sjsonPathSpecials = `.*?|#@`
+
+// convertPathToSjsonPath converts a path array to sjson path format. Each
+// segment is a literal key: dotted Kubernetes annotation and label keys such
+// as "cert-manager.io/cluster-issuer" or "kubernetes.io/service-name" must
+// reach sjson as one key, so path specials inside a segment are escaped before
+// segments are joined with the "." separator. A bare join split such keys into
+// nested objects and silently corrupted the patched configuration.
 func convertPathToSjsonPath(pathArray []string) string {
-	return strings.Join(pathArray, ".")
+	escaped := make([]string, len(pathArray))
+	for i, segment := range pathArray {
+		escaped[i] = escapeSjsonKey(segment)
+	}
+	return strings.Join(escaped, ".")
+}
+
+// escapeSjsonKey backslash-escapes gjson/sjson path specials in a single key.
+// The escape character itself is escaped first so pre-existing backslashes in
+// a key survive the round trip.
+func escapeSjsonKey(key string) string {
+	if !strings.ContainsAny(key, sjsonPathSpecials+`\`) {
+		return key
+	}
+	var b strings.Builder
+	b.Grow(len(key) + 4)
+	for _, r := range key {
+		if r == '\\' || strings.ContainsRune(sjsonPathSpecials, r) {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/utils/patching/patch.go
+++ b/utils/patching/patch.go
@@ -46,8 +46,11 @@ func ApplyPatches(data map[string]interface{}, patches []Patch) (map[string]inte
 }
 
 // sjsonPathSpecials are the characters gjson/sjson path syntax assigns meaning
-// to inside a key. Escaping them makes every path segment a literal key.
-const sjsonPathSpecials = `.*?|#@`
+// to inside a key. Escaping them makes every path segment a literal key. The
+// colon is included because sjson treats a leading ":" as force-object-key
+// syntax (":2313" addresses the key "2313" instead of an array index), so an
+// unescaped literal key beginning with ":" would be silently rewritten.
+const sjsonPathSpecials = `.*?|#@:`
 
 // convertPathToSjsonPath converts a path array to sjson path format. Each
 // segment is a literal key: dotted Kubernetes annotation and label keys such

--- a/utils/patching/patch_test.go
+++ b/utils/patching/patch_test.go
@@ -1,0 +1,86 @@
+package patch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyPatchesPlainSegments(t *testing.T) {
+	data := map[string]interface{}{
+		"spec": map[string]interface{}{"replicas": float64(1)},
+	}
+	result, err := ApplyPatches(data, []Patch{
+		{Path: []string{"spec", "replicas"}, Value: float64(3)},
+		{Path: []string{"spec", "paused"}, Value: true},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	spec := result["spec"].(map[string]interface{})
+	if spec["replicas"] != float64(3) || spec["paused"] != true {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+// A path segment that is itself a dotted key - Kubernetes annotation and label
+// keys - must be written as one literal key, not split into nested objects.
+func TestApplyPatchesDottedKeySegment(t *testing.T) {
+	data := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{},
+		},
+	}
+	result, err := ApplyPatches(data, []Patch{
+		{Path: []string{"metadata", "annotations", "cert-manager.io/cluster-issuer"}, Value: "letsencrypt-prod"},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	annotations := result["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+	got, ok := annotations["cert-manager.io/cluster-issuer"]
+	if !ok {
+		t.Fatalf("dotted key was split instead of written literally: %#v", annotations)
+	}
+	if got != "letsencrypt-prod" {
+		t.Fatalf("unexpected value: %#v", got)
+	}
+	if _, split := annotations["cert-manager"]; split {
+		t.Fatalf("dotted key was additionally written as nested objects: %#v", annotations)
+	}
+}
+
+func TestApplyPatchesDottedLabelKey(t *testing.T) {
+	data := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{"app": "web"},
+		},
+	}
+	result, err := ApplyPatches(data, []Patch{
+		{Path: []string{"metadata", "labels", "kubernetes.io/service-name"}, Value: "web-svc"},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	labels := result["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+	want := map[string]interface{}{"app": "web", "kubernetes.io/service-name": "web-svc"}
+	if !reflect.DeepEqual(labels, want) {
+		t.Fatalf("labels = %#v, want %#v", labels, want)
+	}
+}
+
+func TestEscapeSjsonKey(t *testing.T) {
+	cases := map[string]string{
+		"name":                           "name",
+		"0":                              "0",
+		"_":                              "_",
+		"cert-manager.io/cluster-issuer": `cert-manager\.io/cluster-issuer`,
+		"a*b?c":                          `a\*b\?c`,
+		`back\slash`:                     `back\\slash`,
+		"pipe|hash#at@":                  `pipe\|hash\#at\@`,
+	}
+	for in, want := range cases {
+		if got := escapeSjsonKey(in); got != want {
+			t.Errorf("escapeSjsonKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/utils/patching/patch_test.go
+++ b/utils/patching/patch_test.go
@@ -77,6 +77,8 @@ func TestEscapeSjsonKey(t *testing.T) {
 		"a*b?c":                          `a\*b\?c`,
 		`back\slash`:                     `back\\slash`,
 		"pipe|hash#at@":                  `pipe\|hash\#at\@`,
+		":2313":                          `\:2313`,
+		"a:b":                            `a\:b`,
 	}
 	for in, want := range cases {
 		if got := escapeSjsonKey(in); got != want {


### PR DESCRIPTION
**Description**

This PR fixes meshery/meshkit#1097.

`convertPathToSjsonPath` joined patch path segments with a bare `strings.Join(path, ".")`. sjson treats every unescaped dot as a separator, so a segment that is itself a dotted key - Kubernetes annotation/label keys like `cert-manager.io/cluster-issuer` or `kubernetes.io/service-name` - was split into nested objects instead of written as one literal key, silently corrupting the patched component configuration whenever such a relationship was applied.

**Changes**

- Escape gjson/sjson path specials (`\`, `.`, `*`, `?`, `|`, `#`, `@`) per segment before joining, making every segment a literal key. Segments without specials are unchanged, so existing corpus behavior is preserved.
- Tests: literal dotted annotation/label keys land as single keys (and are not additionally nested), plain segments unchanged, escape table.

**Context**

Surfaced by review of the meshery/meshery Ingress + cert-manager relationship coverage work (meshery/meshery#21482): the ingress-shim annotation relationships patch `metadata.annotations["cert-manager.io/cluster-issuer"]`, and the in-tree corpus already carries dotted-key paths.

**Verification**

- `go test ./...` - full suite passes
- `go build ./...` - clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed patch application for keys containing dots, colons, and other path-special characters.
  - Preserved literal Kubernetes annotation and label keys during updates.
  - Improved handling of keys containing wildcards, backslashes, question marks, pipes, hashes, and at-signs.

- **Tests**
  - Added coverage for plain path segments and special-character keys, including colons and backslashes, to help ensure reliable patch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->