### PR TITLE
fix: close SVG files after writing

### DIFF
--- a/models/registration/svg_helper.go
+++ b/models/registration/svg_helper.go
@@ -9,14 +9,43 @@ import (
 
 var UISVGPaths = make([]string, 1)
 
+type svgFile interface {
+	WriteString(string) (int, error)
+	Close() error
+}
+
+var createSVGFile = func(path string) (svgFile, error) {
+	return os.Create(path)
+}
+
+func writeAndCloseSVG(path, content string) error {
+	f, err := createSVGFile(path)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string, baseDir, dirname, filename string, isModel bool) (svgColorPath, svgWhitePath, svgCompletePath string) {
 	filename = strings.ToLower(filename)
 	successCreatingDirectory := false
+
 	defer func() {
 		if successCreatingDirectory {
 			UISVGPaths = append(UISVGPaths, filepath.Join(baseDir, dirname))
 		}
 	}()
+
 	if svgColor != "" {
 		path := filepath.Join(baseDir, dirname, "color")
 		err := os.MkdirAll(path, 0777)
@@ -26,20 +55,21 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 		}
 		successCreatingDirectory = true
 
-		f, err := os.Create(filepath.Join(path, filename+"-color.svg"))
-		if err != nil {
+		if err := writeAndCloseSVG(
+			filepath.Join(path, filename+"-color.svg"),
+			svgColor,
+		); err != nil {
 			fmt.Println(err)
+			svgColorPath, svgWhitePath, svgCompletePath = "", "", ""
 			return
 		}
-		_, err = f.WriteString(svgColor)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		f.Close()
-		svgColorPath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "color", filename+"-color.svg")) //Replace the actual SVG with path to SVG
 
+		svgColorPath = getRelativePathForAPI(
+			baseDir,
+			filepath.Join(dirname, "color", filename+"-color.svg"),
+		)
 	}
+
 	if svgWhite != "" {
 		path := filepath.Join(baseDir, dirname, "white")
 		err := os.MkdirAll(path, 0777)
@@ -49,20 +79,21 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 		}
 		successCreatingDirectory = true
 
-		f, err := os.Create(filepath.Join(path, filename+"-white.svg"))
-		if err != nil {
+		if err := writeAndCloseSVG(
+			filepath.Join(path, filename+"-white.svg"),
+			svgWhite,
+		); err != nil {
 			fmt.Println(err)
+			svgColorPath, svgWhitePath, svgCompletePath = "", "", ""
 			return
 		}
-		_, err = f.WriteString(svgWhite)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		f.Close()
-		svgWhitePath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "white", filename+"-white.svg")) //Replace the actual SVG with path to SVG
 
+		svgWhitePath = getRelativePathForAPI(
+			baseDir,
+			filepath.Join(dirname, "white", filename+"-white.svg"),
+		)
 	}
+
 	if svgComplete != "" {
 		path := filepath.Join(baseDir, dirname, "complete")
 		err := os.MkdirAll(path, 0777)
@@ -72,20 +103,21 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 		}
 		successCreatingDirectory = true
 
-		f, err := os.Create(filepath.Join(path, filename+"-complete.svg"))
-		if err != nil {
+		if err := writeAndCloseSVG(
+			filepath.Join(path, filename+"-complete.svg"),
+			svgComplete,
+		); err != nil {
 			fmt.Println(err)
+			svgColorPath, svgWhitePath, svgCompletePath = "", "", ""
 			return
 		}
-		_, err = f.WriteString(svgComplete)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		f.Close()
-		svgCompletePath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "complete", filename+"-complete.svg")) //Replace the actual SVG with path to SVG
 
+		svgCompletePath = getRelativePathForAPI(
+			baseDir,
+			filepath.Join(dirname, "complete", filename+"-complete.svg"),
+		)
 	}
+
 	return
 }
 

--- a/models/registration/svg_helper.go
+++ b/models/registration/svg_helper.go
@@ -36,6 +36,7 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		f.Close()
 		svgColorPath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "color", filename+"-color.svg")) //Replace the actual SVG with path to SVG
 
 	}
@@ -58,6 +59,7 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		f.Close()
 		svgWhitePath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "white", filename+"-white.svg")) //Replace the actual SVG with path to SVG
 
 	}
@@ -80,6 +82,7 @@ func WriteAndReplaceSVGWithFileSystemPath(svgColor, svgWhite, svgComplete string
 			fmt.Println(err)
 			return
 		}
+		f.Close()
 		svgCompletePath = getRelativePathForAPI(baseDir, filepath.Join(dirname, "complete", filename+"-complete.svg")) //Replace the actual SVG with path to SVG
 
 	}

--- a/models/registration/svg_helper_test.go
+++ b/models/registration/svg_helper_test.go
@@ -1,0 +1,96 @@
+package registration
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeSVGFile struct {
+	writeErr error
+	closeErr error
+	content  string
+	closed   bool
+}
+
+func (f *fakeSVGFile) WriteString(content string) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+
+	f.content += content
+	return len(content), nil
+}
+
+func (f *fakeSVGFile) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+func TestWriteAndCloseSVG(t *testing.T) {
+	t.Run("writes and closes file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.svg")
+		content := "<svg>test</svg>"
+
+		if err := writeAndCloseSVG(path, content); err != nil {
+			t.Fatalf("writeAndCloseSVG() error = %v", err)
+		}
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read SVG: %v", err)
+		}
+
+		if string(got) != content {
+			t.Errorf("content = %q, want %q", string(got), content)
+		}
+	})
+
+	t.Run("returns write error and closes file", func(t *testing.T) {
+		wantErr := errors.New("write failed")
+		fake := &fakeSVGFile{writeErr: wantErr}
+
+		oldCreate := createSVGFile
+		createSVGFile = func(string) (svgFile, error) {
+			return fake, nil
+		}
+		defer func() {
+			createSVGFile = oldCreate
+		}()
+
+		err := writeAndCloseSVG("test.svg", "content")
+
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want %v", err, wantErr)
+		}
+
+		if !fake.closed {
+			t.Error("file was not closed after write failure")
+		}
+	})
+
+	t.Run("returns close error", func(t *testing.T) {
+		wantErr := errors.New("close failed")
+		fake := &fakeSVGFile{closeErr: wantErr}
+
+		oldCreate := createSVGFile
+		createSVGFile = func(string) (svgFile, error) {
+			return fake, nil
+		}
+		defer func() {
+			createSVGFile = oldCreate
+		}()
+
+		err := writeAndCloseSVG("test.svg", "content")
+
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want %v", err, wantErr)
+		}
+
+		if !fake.closed {
+			t.Error("file was not closed")
+		}
+	})
+}


### PR DESCRIPTION
## Description

This change fixes a file handle leak in `WriteAndReplaceSVGWithFileSystemPath`.

The function creates SVG files using `os.Create()` and writes the SVG content to them, but the files were not closed after writing. On Windows, this caused the files to remain locked and made test cleanup fail with a file-in-use error.

### Changes Made

* Added `f.Close()` after writing the color SVG.
* Added `f.Close()` after writing the white SVG.
* Added `f.Close()` after writing the complete SVG.

### Testing

The following tests were run successfully:

```text
go test ./models/registration/...
PASS

go test ./server/models -run "^TestSeedConnectionsSkipsKubernetesRegistrant$" -v
PASS
```

This ensures the generated SVG files are properly released and temporary test directories can be cleaned up successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG file handling to ensure files are properly closed after successful or failed writes.
  * Improved error reporting when SVG generation encounters writing or closing failures.
  * Prevented incomplete or invalid file paths from being returned after generation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->