### PR TITLE
[utils] Add SanitizePattern to recursively trim whitespace in Configuration maps

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -923,3 +923,38 @@ func TruncateErrorMessage(err error, wordLimit int) error {
 
 	return err
 }
+
+// SanitizePattern recursively trims leading and trailing whitespace from all
+// string keys and string values within a map (such as a component's
+// Configuration). Non-string types (bool, int, float64, nil, etc.) are
+// passed through unchanged.
+func SanitizePattern(input map[string]interface{}) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]interface{}, len(input))
+	for k, v := range input {
+		trimmedKey := strings.TrimSpace(k)
+		output[trimmedKey] = sanitizeValue(v)
+	}
+	return output
+}
+
+// sanitizeValue trims strings, recurses into maps and slices, and leaves
+// every other type untouched.
+func sanitizeValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		return strings.TrimSpace(val)
+	case map[string]interface{}:
+		return SanitizePattern(val)
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, item := range val {
+			out[i] = sanitizeValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -927,34 +927,50 @@ func TruncateErrorMessage(err error, wordLimit int) error {
 // SanitizePattern recursively trims leading and trailing whitespace from all
 // string keys and string values within a map (such as a component's
 // Configuration). Non-string types (bool, int, float64, nil, etc.) are
-// passed through unchanged.
-func SanitizePattern(input map[string]interface{}) map[string]interface{} {
+// passed through unchanged. Returns an error if trimming causes two distinct
+// keys to collide (e.g. " name" and "name ").
+func SanitizePattern(input map[string]interface{}) (map[string]interface{}, error) {
 	if input == nil {
-		return nil
+		return nil, nil
 	}
 	output := make(map[string]interface{}, len(input))
 	for k, v := range input {
 		trimmedKey := strings.TrimSpace(k)
-		output[trimmedKey] = sanitizeValue(v)
+		if _, exists := output[trimmedKey]; exists {
+			return nil, fmt.Errorf("key collision after trimming whitespace: %q", trimmedKey)
+		}
+		sanitizedValue, err := sanitizeValue(v)
+		if err != nil {
+			return nil, err
+		}
+		output[trimmedKey] = sanitizedValue
 	}
-	return output
+	return output, nil
 }
 
 // sanitizeValue trims strings, recurses into maps and slices, and leaves
-// every other type untouched.
-func sanitizeValue(v interface{}) interface{} {
+// every other type untouched. Nil slices are preserved as nil rather than
+// converted to empty slices.
+func sanitizeValue(v interface{}) (interface{}, error) {
 	switch val := v.(type) {
 	case string:
-		return strings.TrimSpace(val)
+		return strings.TrimSpace(val), nil
 	case map[string]interface{}:
 		return SanitizePattern(val)
 	case []interface{}:
+		if val == nil {
+			return val, nil
+		}
 		out := make([]interface{}, len(val))
 		for i, item := range val {
-			out[i] = sanitizeValue(item)
+			sanitizedItem, err := sanitizeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = sanitizedItem
 		}
-		return out
+		return out, nil
 	default:
-		return v
+		return v, nil
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -78,3 +78,84 @@ func TestTransformMapKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizePattern(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]interface{}
+	}{
+		{
+			name: "trims whitespace from keys and string values",
+			input: map[string]interface{}{
+				" storage ": "1Gi ",
+				"name ":     " test-volume ",
+			},
+			want: map[string]interface{}{
+				"storage": "1Gi",
+				"name":    "test-volume",
+			},
+		},
+		{
+			name: "recurses into nested maps",
+			input: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					" labels ": map[string]interface{}{
+						" app ": " my-app ",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "my-app",
+					},
+				},
+			},
+		},
+		{
+			name: "recurses into slices containing maps and strings",
+			input: map[string]interface{}{
+				"items": []interface{}{
+					" first ",
+					map[string]interface{}{" nested ": " value "},
+				},
+			},
+			want: map[string]interface{}{
+				"items": []interface{}{
+					"first",
+					map[string]interface{}{"nested": "value"},
+				},
+			},
+		},
+		{
+			name: "passes non-string types through unchanged",
+			input: map[string]interface{}{
+				"replicas": 3,
+				"enabled":  true,
+				"ratio":    1.5,
+				"empty":    nil,
+			},
+			want: map[string]interface{}{
+				"replicas": 3,
+				"enabled":  true,
+				"ratio":    1.5,
+				"empty":    nil,
+			},
+		},
+		{
+			name:  "nil input returns nil",
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := SanitizePattern(tt.input)
+			if !reflect.DeepEqual(ans, tt.want) {
+				t.Errorf("got %v, want %v", ans, tt.want)
+			}
+		})
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -158,6 +158,28 @@ func TestSanitizePattern(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "collision in a nested map returns an error",
+			input: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					" labels": "foo",
+					"labels ": "bar",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "collision inside a map within a slice returns an error",
+			input: map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						" name": "foo",
+						"name ": "bar",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "nil slice is preserved as nil, not an empty slice",
 			input: map[string]interface{}{
 				"items": []interface{}(nil),

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -81,9 +81,10 @@ func TestTransformMapKeys(t *testing.T) {
 
 func TestSanitizePattern(t *testing.T) {
 	var tests = []struct {
-		name  string
-		input map[string]interface{}
-		want  map[string]interface{}
+		name    string
+		input   map[string]interface{}
+		want    map[string]interface{}
+		wantErr bool
 	}{
 		{
 			name: "trims whitespace from keys and string values",
@@ -148,11 +149,38 @@ func TestSanitizePattern(t *testing.T) {
 			input: nil,
 			want:  nil,
 		},
+		{
+			name: "distinct keys colliding after trim return an error",
+			input: map[string]interface{}{
+				" name": "foo",
+				"name ": "bar",
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil slice is preserved as nil, not an empty slice",
+			input: map[string]interface{}{
+				"items": []interface{}(nil),
+			},
+			want: map[string]interface{}{
+				"items": []interface{}(nil),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ans := SanitizePattern(tt.input)
+			ans, err := SanitizePattern(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
 			if !reflect.DeepEqual(ans, tt.want) {
 				t.Errorf("got %v, want %v", ans, tt.want)
 			}


### PR DESCRIPTION
**Description**
This PR fixes #1089

Adds `SanitizePattern`, a utility function in `utils/utils.go` that recursively
trims leading and trailing whitespace from all string keys and string values
within a map (e.g. a component's `Configuration`). Stray whitespace left in
config values forces YAML serializers (like `yaml.v3`) to wrap fields in
quotes on export, which breaks Kubernetes manifest validation.

Non-string types (`bool`, `int`, `float64`, `nil`) are passed through
unchanged, ensuring type safety. Covered by tests for whitespace trimming,
nested maps, nested slices, mixed types, and nil input.

**Notes for Reviewers**
This adds the utility function itself. Wiring it into the actual pattern/design
serialization path (so it's called during export) can be a follow-up if
maintainers prefer it split into a separate PR — happy to do that here instead
if preferred.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pattern sanitization that removes extra whitespace from keys and text values.
  * Supports nested maps and lists while preserving non-text values.
  * Safely handles empty input and preserves nil lists.
  * Reports errors when trimming creates duplicate keys.
* **Bug Fixes**
  * Improved error handling so issues found in nested data are returned to the caller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->