### PR TITLE
Feat/errorutil local allocation validation

### DIFF
--- a/cmd/errorutil/internal/coder/commands.go
+++ b/cmd/errorutil/internal/coder/commands.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 
 	"github.com/meshery/meshkit/cmd/errorutil/internal/component"
 
@@ -176,7 +178,7 @@ This tool produces three files:
 - errorutil_errors_export.json: export of errors which can be used to create the error code reference on the Meshery website
 
 Typically, the 'analyze' command of the tool is used by the developer to verify errors, i.e. that there are no duplicate names or details.
-A CI workflow is used to replace the placeholder code strings with integer code, and export errors. Using this export, the workflow updates 
+A CI workflow is used to replace the placeholder code strings with integer code, and export errors. Using this export, the workflow updates
 the error code reference documentation in the Meshery repository.
 
 Meshery components and this tool:
@@ -191,37 +193,99 @@ Meshery components and this tool:
     "next_error_code": 1014
   }
 - next_error_code is the value used by the tool to replace the error code placeholder string with the next integer.
-- The tool updates next_error_code. 
+- The tool updates next_error_code.
 `)
 		},
 	}
 }
 
-func ValidateNewErrors(baseline, current mesherr.InfoAll, out io.Writer) error {
-	baselineErrors := make(map[string]bool)
+func ValidateNewErrors(baseline, current mesherr.InfoAll, baselineNext, currentNext int, out io.Writer) error {
+	baselineCodes := make(map[string]bool)
+	baselineCounts := make(map[string]int)
+	baselineDup := make(map[string]bool)
 	for _, entry := range baseline.Entries {
-		baselineErrors[entry.Name] = true
+		if entry.CodeIsInt {
+			baselineCodes[entry.Code] = true
+			baselineCounts[entry.Code]++
+			if baselineCounts[entry.Code] > 1 {
+				baselineDup[entry.Code] = true
+			}
+		}
 	}
 
 	hasError := false
+
+	// R1: Duplicate codes in current state (ignoring inherited baseline duplicates)
+	seen := make(map[string][]string)
 	for _, entry := range current.Entries {
-		if _, exists := baselineErrors[entry.Name]; !exists && entry.CodeIsInt {
-			fmt.Fprintf(out, "Error: New error %s uses a manually assigned code \"%s\"; use \"replace_me\" and let errorutil allocate the code\n", entry.Name, entry.Code)
+		if entry.CodeIsInt {
+			seen[entry.Code] = append(seen[entry.Code], entry.Name)
+		}
+	}
+
+	var duplicateCodes []string
+	for code, names := range seen {
+		if len(names) > 1 && !baselineDup[code] {
+			duplicateCodes = append(duplicateCodes, code)
+		}
+	}
+	sort.Strings(duplicateCodes)
+
+	for _, code := range duplicateCodes {
+		fmt.Fprintf(out, "Error: duplicate error code \"%s\" used by %v\n", code, seen[code])
+		hasError = true
+	}
+
+	// R2: Counter regression
+	if baselineNext > 0 && currentNext > 0 && currentNext < baselineNext {
+		fmt.Fprintf(out, "Error: Allocation counter regression detected (baseline: %d, current: %d)\n", baselineNext, currentNext)
+		hasError = true
+	}
+
+	for _, entry := range current.Entries {
+		if !entry.CodeIsInt {
+			continue
+		}
+
+		// R3: Identify newly introduced integer codes BY CODE, NOT NAME
+		if baselineCodes[entry.Code] {
+			continue // Legitimate rename or no-op
+		}
+
+		// R4: Validate genuinely new integer codes
+		validLocalAllocation := false
+		if baselineNext > 0 && currentNext > 0 {
+			codeInt, err := strconv.Atoi(entry.Code)
+			if err == nil {
+				if codeInt >= baselineNext && codeInt < currentNext {
+					validLocalAllocation = true
+				}
+			}
+		}
+
+		if !validLocalAllocation {
+			if baselineNext > 0 && currentNext > 0 {
+				fmt.Fprintf(out, "Error: New error %s uses manually assigned code \"%s\"; must use \"replace_me\" or be in valid local allocation range [%d, %d)\n", entry.Name, entry.Code, baselineNext, currentNext)
+			} else {
+				fmt.Fprintf(out, "Error: New error %s uses manually assigned code \"%s\"; use \"replace_me\" and let errorutil allocate the code\n", entry.Name, entry.Code)
+			}
 			hasError = true
 		}
 	}
 
 	if hasError {
-		return fmt.Errorf("newly introduced error codes must use placeholder 'replace_me'")
+		return fmt.Errorf("error validation failed")
 	}
 	return nil
 }
 
 func commandCheck() *cobra.Command {
-	return &cobra.Command{
+	var baselineSummaryPath, currentSummaryPath string
+
+	cmd := &cobra.Command{
 		Use:          "check [baseline JSON] [current JSON]",
 		Short:        "Checks that newly introduced error codes use a placeholder (e.g. replace_me)",
-		Long:         `check compares the errors from the two provided JSON files (baseline and current) and ensures that any newly introduced error code does not use a manually assigned integer code, but rather a placeholder string.`,
+		Long:         `check compares the errors from the two provided JSON files (baseline and current) and ensures that any newly introduced error code does not use a manually assigned integer code, but rather a placeholder string. It validates local allocations if summary files are provided.`,
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -242,9 +306,49 @@ func commandCheck() *cobra.Command {
 				return err
 			}
 
-			return ValidateNewErrors(baseline, current, cmd.OutOrStdout())
+			baselineNext := -1
+			currentNext := -1
+
+			if baselineSummaryPath != "" && currentSummaryPath != "" {
+				type analysisSummary struct {
+					NextCode int `json:"next_code"`
+				}
+
+				bSumBytes, err := os.ReadFile(baselineSummaryPath)
+				if err != nil {
+					return fmt.Errorf("failed to read baseline summary: %w", err)
+				}
+				var bSum analysisSummary
+				if err := json.Unmarshal(bSumBytes, &bSum); err != nil {
+					return fmt.Errorf("failed to parse baseline summary: %w", err)
+				}
+				if bSum.NextCode <= 0 {
+					return fmt.Errorf("%s: next_code missing or zero — expected an errorutil_analyze_summary.json", baselineSummaryPath)
+				}
+				baselineNext = bSum.NextCode
+
+				cSumBytes, err := os.ReadFile(currentSummaryPath)
+				if err != nil {
+					return fmt.Errorf("failed to read current summary: %w", err)
+				}
+				var cSum analysisSummary
+				if err := json.Unmarshal(cSumBytes, &cSum); err != nil {
+					return fmt.Errorf("failed to parse current summary: %w", err)
+				}
+				if cSum.NextCode <= 0 {
+					return fmt.Errorf("%s: next_code missing or zero — expected an errorutil_analyze_summary.json", currentSummaryPath)
+				}
+				currentNext = cSum.NextCode
+			} else if baselineSummaryPath != "" || currentSummaryPath != "" {
+				return fmt.Errorf("both --baseline-summary and --current-summary must be provided if one is provided")
+			}
+
+			return ValidateNewErrors(baseline, current, baselineNext, currentNext, cmd.OutOrStdout())
 		},
 	}
+	cmd.Flags().StringVar(&baselineSummaryPath, "baseline-summary", "", "path to baseline errorutil_analyze_summary.json")
+	cmd.Flags().StringVar(&currentSummaryPath, "current-summary", "", "path to current errorutil_analyze_summary.json")
+	return cmd
 }
 
 func RootCommand() *cobra.Command {

--- a/cmd/errorutil/internal/coder/commands.go
+++ b/cmd/errorutil/internal/coder/commands.go
@@ -194,51 +194,89 @@ Meshery components and this tool:
   }
 - next_error_code is the value used by the tool to replace the error code placeholder string with the next integer.
 - The tool updates next_error_code.
+
+Both "replace_me" and locally-running 'errorutil update' are valid ways to arrive at an integer code.
+Note a precondition for the check command: baseline must be the analysis of current's merge-base (the commit this branch forked from), NOT the current tip of the base branch. This tool does not resolve two independent branches allocating the same code from the same baseline — that is handled by the post-merge allocation process re-encountering the collision, not by this check.
 `)
 		},
 	}
 }
 
+// ValidateNewErrors rejects newly introduced integer error codes that are
+// not backed by a legitimate local allocation.
+//
+// Precondition: baseline must be the analysis of current's merge-base (the
+// commit this branch forked from), NOT the current tip of the base branch.
+// The allocation-counter checks (R2, R4) assume baseline is an ancestor of
+// current; if baseline's own next_error_code has advanced past current's
+// (e.g. because the base branch's post-merge allocation bot ran on
+// unrelated PRs after this branch diverged), R2 reports a false counter
+// regression. Callers wiring this into CI must construct baseline from the
+// PR's merge-base, not from the base branch's tip at CI-run time.
 func ValidateNewErrors(baseline, current mesherr.InfoAll, baselineNext, currentNext int, out io.Writer) error {
-	baselineCodes := make(map[string]bool)
-	baselineCounts := make(map[string]int)
-	baselineDup := make(map[string]bool)
+	baselineCodes := make(map[string]bool) // normalized numeric key
+	baselineCounts := make(map[string]int) // normalized numeric key -> baseline occurrence count
 	for _, entry := range baseline.Entries {
-		if entry.CodeIsInt {
-			baselineCodes[entry.Code] = true
-			baselineCounts[entry.Code]++
-			if baselineCounts[entry.Code] > 1 {
-				baselineDup[entry.Code] = true
-			}
+		if !entry.CodeIsInt {
+			continue
 		}
+		n, err := strconv.Atoi(entry.Code)
+		if err != nil {
+			continue // defensive; CodeIsInt already guarantees this parses
+		}
+		key := strconv.Itoa(n)
+		baselineCodes[key] = true
+		baselineCounts[key]++
 	}
 
 	hasError := false
 
-	// R1: Duplicate codes in current state (ignoring inherited baseline duplicates)
+	// R1: a code's occurrence count in `current` must not exceed its baseline
+	// count. Baseline debt (a code already duplicated pre-PR) is tolerated as
+	// long as it doesn't grow; any growth - including a duplicated code gaining
+	// a THIRD user - is a newly introduced collision and must fail.
 	seen := make(map[string][]string)
 	for _, entry := range current.Entries {
-		if entry.CodeIsInt {
-			seen[entry.Code] = append(seen[entry.Code], entry.Name)
+		if !entry.CodeIsInt {
+			continue
 		}
+		n, err := strconv.Atoi(entry.Code)
+		if err != nil {
+			continue
+		}
+		key := strconv.Itoa(n)
+		seen[key] = append(seen[key], entry.Name)
 	}
 
 	var duplicateCodes []string
 	for code, names := range seen {
-		if len(names) > 1 && !baselineDup[code] {
+		if len(names) > 1 && len(names) > baselineCounts[code] {
 			duplicateCodes = append(duplicateCodes, code)
 		}
 	}
-	sort.Strings(duplicateCodes)
+	sort.Slice(duplicateCodes, func(i, j int) bool {
+		a, _ := strconv.Atoi(duplicateCodes[i])
+		b, _ := strconv.Atoi(duplicateCodes[j])
+		return a < b
+	})
 
 	for _, code := range duplicateCodes {
-		fmt.Fprintf(out, "Error: duplicate error code \"%s\" used by %v\n", code, seen[code])
+		fmt.Fprintf(out, "Error: duplicate error code %q used by %v (was %d occurrence(s) in baseline, now %d)\n",
+			code, seen[code], baselineCounts[code], len(seen[code]))
 		hasError = true
 	}
 
-	// R2: Counter regression
+	// R2: the allocation counter must never appear to move backwards from
+	// baseline to current. This is only a sound check when baseline is the
+	// analysis of current's merge-base (fork point) with the base branch, NOT
+	// the base branch's current tip - see the precondition documented on
+	// ValidateNewErrors below.
 	if baselineNext > 0 && currentNext > 0 && currentNext < baselineNext {
-		fmt.Fprintf(out, "Error: Allocation counter regression detected (baseline: %d, current: %d)\n", baselineNext, currentNext)
+		fmt.Fprintf(out, "Error: allocation counter went backwards (baseline next_error_code: %d, current next_error_code: %d). "+
+			"This usually means the baseline analysis is not the merge-base of this branch - "+
+			"if the base branch's own error-code counter has advanced since this branch diverged "+
+			"(e.g. post-merge allocation on unrelated PRs), re-analyze against the merge-base, not the base branch tip.\n",
+			baselineNext, currentNext)
 		hasError = true
 	}
 
@@ -246,35 +284,43 @@ func ValidateNewErrors(baseline, current mesherr.InfoAll, baselineNext, currentN
 		if !entry.CodeIsInt {
 			continue
 		}
+		codeInt, err := strconv.Atoi(entry.Code)
+		if err != nil {
+			continue // CodeIsInt guarantees this parses; defensive only
+		}
+		key := strconv.Itoa(codeInt)
 
-		// R3: Identify newly introduced integer codes BY CODE, NOT NAME
-		if baselineCodes[entry.Code] {
-			continue // Legitimate rename or no-op
+		// R3: identify newly introduced integer codes BY CODE, NOT NAME, so a
+		// rename or a package move of an existing code is never treated as new.
+		if baselineCodes[key] {
+			continue
 		}
 
-		// R4: Validate genuinely new integer codes
-		validLocalAllocation := false
+		// R4: a genuinely new integer code is only valid if it falls inside the
+		// allocation window errorutil update actually produced.
 		if baselineNext > 0 && currentNext > 0 {
-			codeInt, err := strconv.Atoi(entry.Code)
-			if err == nil {
-				if codeInt >= baselineNext && codeInt < currentNext {
-					validLocalAllocation = true
-				}
+			if codeInt >= baselineNext && codeInt < currentNext {
+				continue // legitimate local allocation
 			}
-		}
-
-		if !validLocalAllocation {
-			if baselineNext > 0 && currentNext > 0 {
-				fmt.Fprintf(out, "Error: New error %s uses manually assigned code \"%s\"; must use \"replace_me\" or be in valid local allocation range [%d, %d)\n", entry.Name, entry.Code, baselineNext, currentNext)
+			if baselineNext == currentNext {
+				fmt.Fprintf(out, "Error: %s (%s) uses integer code %q; the allocation counter did not advance between baseline and current, so no new integer code can be valid - use \"replace_me\", or run `errorutil update` to allocate it\n",
+					entry.Name, entry.Path, entry.Code)
 			} else {
-				fmt.Fprintf(out, "Error: New error %s uses manually assigned code \"%s\"; use \"replace_me\" and let errorutil allocate the code\n", entry.Name, entry.Code)
+				fmt.Fprintf(out, "Error: %s (%s) uses integer code %q which is not present in the baseline and not within the recorded local allocation range [%d, %d); use \"replace_me\", or run `errorutil update` to allocate it\n",
+					entry.Name, entry.Path, entry.Code, baselineNext, currentNext)
 			}
 			hasError = true
+			continue
 		}
+
+		// No allocation metadata supplied: fall back to strict mode.
+		fmt.Fprintf(out, "Error: %s (%s) uses integer code %q; use \"replace_me\" and let errorutil allocate the code\n",
+			entry.Name, entry.Path, entry.Code)
+		hasError = true
 	}
 
 	if hasError {
-		return fmt.Errorf("error validation failed")
+		return fmt.Errorf("error code validation failed; see details above")
 	}
 	return nil
 }
@@ -285,7 +331,7 @@ func commandCheck() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "check [baseline JSON] [current JSON]",
 		Short:        "Checks that newly introduced error codes use a placeholder (e.g. replace_me)",
-		Long:         `check compares the errors from the two provided JSON files (baseline and current) and ensures that any newly introduced error code does not use a manually assigned integer code, but rather a placeholder string. It validates local allocations if summary files are provided.`,
+		Long:         `check compares the errors from the two provided JSON files (baseline and current) and ensures that any newly introduced error code does not use a manually assigned integer code, but rather a placeholder string. It validates local allocations if summary files are provided. Precondition: baseline must be the analysis of current's merge-base (the commit this branch forked from), NOT the current tip of the base branch.`,
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/errorutil/internal/coder/commands.go
+++ b/cmd/errorutil/internal/coder/commands.go
@@ -325,6 +325,23 @@ func ValidateNewErrors(baseline, current mesherr.InfoAll, baselineNext, currentN
 	return nil
 }
 
+func readSummaryNextCode(path, label string) (int, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s summary: %w", label, err)
+	}
+	var sum struct {
+		NextCode int `json:"next_code"`
+	}
+	if err := json.Unmarshal(bytes, &sum); err != nil {
+		return 0, fmt.Errorf("failed to parse %s summary: %w", label, err)
+	}
+	if sum.NextCode <= 0 {
+		return 0, fmt.Errorf("%s: next_code missing or zero — expected an errorutil_analyze_summary.json", path)
+	}
+	return sum.NextCode, nil
+}
+
 func commandCheck() *cobra.Command {
 	var baselineSummaryPath, currentSummaryPath string
 
@@ -334,6 +351,12 @@ func commandCheck() *cobra.Command {
 		Long:         `check compares the errors from the two provided JSON files (baseline and current) and ensures that any newly introduced error code does not use a manually assigned integer code, but rather a placeholder string. It validates local allocations if summary files are provided. Precondition: baseline must be the analysis of current's merge-base (the commit this branch forked from), NOT the current tip of the base branch.`,
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if (baselineSummaryPath != "" && currentSummaryPath == "") || (baselineSummaryPath == "" && currentSummaryPath != "") {
+				return fmt.Errorf("both --baseline-summary and --current-summary must be provided if one is provided")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			baselineBytes, err := os.ReadFile(args[0])
 			if err != nil {
@@ -356,37 +379,15 @@ func commandCheck() *cobra.Command {
 			currentNext := -1
 
 			if baselineSummaryPath != "" && currentSummaryPath != "" {
-				type analysisSummary struct {
-					NextCode int `json:"next_code"`
-				}
-
-				bSumBytes, err := os.ReadFile(baselineSummaryPath)
+				var err error
+				baselineNext, err = readSummaryNextCode(baselineSummaryPath, "baseline")
 				if err != nil {
-					return fmt.Errorf("failed to read baseline summary: %w", err)
+					return err
 				}
-				var bSum analysisSummary
-				if err := json.Unmarshal(bSumBytes, &bSum); err != nil {
-					return fmt.Errorf("failed to parse baseline summary: %w", err)
-				}
-				if bSum.NextCode <= 0 {
-					return fmt.Errorf("%s: next_code missing or zero — expected an errorutil_analyze_summary.json", baselineSummaryPath)
-				}
-				baselineNext = bSum.NextCode
-
-				cSumBytes, err := os.ReadFile(currentSummaryPath)
+				currentNext, err = readSummaryNextCode(currentSummaryPath, "current")
 				if err != nil {
-					return fmt.Errorf("failed to read current summary: %w", err)
+					return err
 				}
-				var cSum analysisSummary
-				if err := json.Unmarshal(cSumBytes, &cSum); err != nil {
-					return fmt.Errorf("failed to parse current summary: %w", err)
-				}
-				if cSum.NextCode <= 0 {
-					return fmt.Errorf("%s: next_code missing or zero — expected an errorutil_analyze_summary.json", currentSummaryPath)
-				}
-				currentNext = cSum.NextCode
-			} else if baselineSummaryPath != "" || currentSummaryPath != "" {
-				return fmt.Errorf("both --baseline-summary and --current-summary must be provided if one is provided")
 			}
 
 			return ValidateNewErrors(baseline, current, baselineNext, currentNext, cmd.OutOrStdout())

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -9,11 +9,14 @@ import (
 
 func TestCheckLogic(t *testing.T) {
 	tests := []struct {
-		name       string
-		baseline   mesherr.InfoAll
-		current    mesherr.InfoAll
-		wantErrors bool
+		name         string
+		baseline     mesherr.InfoAll
+		current      mesherr.InfoAll
+		baselineNext int
+		currentNext  int
+		wantErrors   bool
 	}{
+		// 1. new + replace_me -> PASS
 		{
 			name: "New placeholder passes",
 			baseline: mesherr.InfoAll{
@@ -27,10 +30,13 @@ func TestCheckLogic(t *testing.T) {
 					{Name: "ErrNew", Code: "replace_me", CodeIsInt: false},
 				},
 			},
-			wantErrors: false,
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
 		},
+		// 2. single legitimate local allocation -> PASS
 		{
-			name: "New unique manual code fails",
+			name: "Single legitimate local allocation passes",
 			baseline: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
@@ -42,10 +48,13 @@ func TestCheckLogic(t *testing.T) {
 					{Name: "ErrNew", Code: "1001", CodeIsInt: true},
 				},
 			},
-			wantErrors: true,
+			baselineNext: 1001,
+			currentNext:  1002,
+			wantErrors:   false,
 		},
+		// 3. multiple legitimate local allocations -> PASS
 		{
-			name: "New manual code reusing existing code fails",
+			name: "Multiple legitimate local allocations pass",
 			baseline: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
@@ -54,11 +63,105 @@ func TestCheckLogic(t *testing.T) {
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
-					{Name: "ErrNew", Code: "1000", CodeIsInt: true}, // Old name still exists, reuse fails
+					{Name: "ErrNew1", Code: "1001", CodeIsInt: true},
+					{Name: "ErrNew2", Code: "1002", CodeIsInt: true},
 				},
 			},
-			wantErrors: true,
+			baselineNext: 1001,
+			currentNext:  1003,
+			wantErrors:   false,
 		},
+		// 4. manually hardcoded integer -> FAIL
+		{
+			name: "Manually hardcoded integer without metadata fails",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1001", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   true,
+		},
+		// 5. vanity/out-of-range integer -> FAIL
+		{
+			name: "Vanity or out-of-range integer fails",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "2000", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1002,
+			wantErrors:   true, // Code 2000 is not in [1001, 1002)
+		},
+		// 6. counter regression -> FAIL
+		{
+			name: "Counter regression fails",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  999, // Regression!
+			wantErrors:   true,
+		},
+		// 7. duplicate code in current state (NOT in baseline) -> FAIL
+		{
+			name: "Duplicate code introduced by PR fails",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1000", CodeIsInt: true}, // Duplicate
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   true,
+		},
+		// 7.5. duplicate code inherited from baseline -> PASS
+		{
+			name: "Existing duplicate inherited from baseline passes",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrA", Code: "1000", CodeIsInt: true},
+					{Name: "ErrB", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrA", Code: "1000", CodeIsInt: true},
+					{Name: "ErrB", Code: "1000", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
+		},
+		// 8. no change -> PASS
 		{
 			name: "Unchanged existing code passes",
 			baseline: mesherr.InfoAll{
@@ -71,10 +174,13 @@ func TestCheckLogic(t *testing.T) {
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
 				},
 			},
-			wantErrors: false,
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
 		},
+		// 9. pure rename preserving existing code -> PASS
 		{
-			name: "Rename existing error fails",
+			name: "Rename existing error preserving code passes",
 			baseline: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
@@ -82,11 +188,91 @@ func TestCheckLogic(t *testing.T) {
 			},
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
-					{Name: "ErrRenamed", Code: "1000", CodeIsInt: true}, // Old name removed, but new name has manual code -> fails
+					{Name: "ErrRenamed", Code: "1000", CodeIsInt: true},
 				},
 			},
-			wantErrors: true,
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
 		},
+		// 10. rename + one genuinely new allocation -> PASS
+		{
+			name: "Rename + genuinely new allocation passes",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrRenamed", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1001", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1002,
+			wantErrors:   false,
+		},
+		// 10.5. delete existing error + reuse its code for a new error -> PASS
+		{
+			name: "Delete old error and reuse its code passes (indistinguishable from rename)",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOldCode", Code: "1463", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrNewCode", Code: "1463", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
+		},
+		// 11. allocate-then-delete -> PASS
+		// 12. over-advanced counter -> PASS with explanatory comment
+		{
+			name: "Allocate-then-delete / Over-advanced counter passes",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1002", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1005,
+			// Explanation: The counter has advanced from 1001 to 1005.
+			// Code 1002 falls within the [1001, 1005) range.
+			// This represents a legitimate workflow where an error code (e.g. 1001)
+			// was allocated, but later deleted from the PR. We shouldn't enforce
+			// strict equality between the count of new errors and currentNext - baselineNext.
+			wantErrors:   false,
+		},
+		// 13. unrelated integer/string constant -> unaffected
+		{
+			name: "Unrelated non-int or placeholder code passes",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrString", Code: "some_string_val", CodeIsInt: false},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1001,
+			wantErrors:   false,
+		},
+		// 14. existing code moved between files/packages -> PASS
 		{
 			name: "Move existing error passes",
 			baseline: mesherr.InfoAll{
@@ -99,48 +285,56 @@ func TestCheckLogic(t *testing.T) {
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true, Path: "pkg/new/error.go"},
 				},
 			},
-			wantErrors: false,
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   false,
 		},
+		// 15. Two new errors both left as replace_me (simulating the 'place_' normalization collision)
 		{
-			name: "Multiple additions",
+			name: "Multiple new placeholders simulating normalization collision passes",
 			baseline: mesherr.InfoAll{
 				Entries: []mesherr.Info{
-					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrExistingCode", Code: "1463", CodeIsInt: true},
 				},
 			},
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
-					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
-					{Name: "ErrNew1", Code: "replace_me", CodeIsInt: false},
-					{Name: "ErrNew2", Code: "replace_me", CodeIsInt: false},
+					{Name: "ErrExistingCode", Code: "1463", CodeIsInt: true},
+					{Name: "ErrNewOneCode", Code: "place_", CodeIsInt: false},
+					{Name: "ErrNewTwoCode", Code: "place_", CodeIsInt: false},
 				},
 			},
-			wantErrors: false,
+			baselineNext: 1464,
+			currentNext:  1464,
+			wantErrors:   false,
 		},
+		// 16. Two new errors both hardcoded to the same existing integer
 		{
-			name: "Mixed additions with one invalid",
+			name: "Two new errors hardcoded to the same integer fail",
 			baseline: mesherr.InfoAll{
 				Entries: []mesherr.Info{
-					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrExistingCode", Code: "1463", CodeIsInt: true},
 				},
 			},
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
-					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
-					{Name: "ErrNew1", Code: "replace_me", CodeIsInt: false},
-					{Name: "ErrNew2", Code: "1001", CodeIsInt: true},
+					{Name: "ErrExistingCode", Code: "1463", CodeIsInt: true},
+					{Name: "ErrNewOneCode", Code: "1463", CodeIsInt: true},
+					{Name: "ErrNewTwoCode", Code: "1463", CodeIsInt: true},
 				},
 			},
-			wantErrors: true,
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := ValidateNewErrors(tt.baseline, tt.current, &buf)
+			err := ValidateNewErrors(tt.baseline, tt.current, tt.baselineNext, tt.currentNext, &buf)
 			if (err != nil) != tt.wantErrors {
-				t.Errorf("ValidateNewErrors() error = %v, wantErrors %v", err, tt.wantErrors)
+				t.Errorf("ValidateNewErrors() error = %v, wantErrors %v. Output: %s", err, tt.wantErrors, buf.String())
 			}
 		})
 	}

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -597,6 +597,19 @@ func TestCommandCheck(t *testing.T) {
 			wantError:      true,
 			wantErrorMatch: "both --baseline-summary and --current-summary must be provided",
 		},
+		// 5.5. Only one summary supplied with nonexistent positional error files (proves PreRunE exits before RunE file I/O)
+		{
+			name: "Only one summary supplied fails in PreRunE before opening positional files",
+			setup: func(t *testing.T, dir string) []string {
+				return []string{
+					"--baseline-summary", filepath.Join(dir, "b_sum.json"),
+					filepath.Join(dir, "nonexistent_baseline_err.json"),
+					filepath.Join(dir, "nonexistent_current_err.json"),
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "both --baseline-summary and --current-summary must be provided",
+		},
 		// 6. Wrong file supplied as summary
 		{
 			name: "Wrong file supplied as summary",
@@ -754,6 +767,128 @@ func TestCommandCheck(t *testing.T) {
 				t.Fatalf("commandCheck().Execute() error = %v, wantError %v", err, tt.wantError)
 			}
 
+			if tt.wantError && tt.wantErrorMatch != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrorMatch)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrorMatch) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrorMatch)
+				}
+			}
+		})
+	}
+}
+
+func TestReadSummaryNextCode(t *testing.T) {
+	dir := t.TempDir()
+
+	validFile := filepath.Join(dir, "valid_summary.json")
+	if err := os.WriteFile(validFile, []byte(`{"next_code": 1042}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	invalidJSONFile := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(invalidJSONFile, []byte(`{invalid json`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	zeroCodeFile := filepath.Join(dir, "zero_code.json")
+	if err := os.WriteFile(zeroCodeFile, []byte(`{"next_code": 0}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	negativeCodeFile := filepath.Join(dir, "neg_code.json")
+	if err := os.WriteFile(negativeCodeFile, []byte(`{"next_code": -5}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	missingCodeFile := filepath.Join(dir, "missing_code.json")
+	if err := os.WriteFile(missingCodeFile, []byte(`{"other_field": "val"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		path           string
+		label          string
+		wantCode       int
+		wantError      bool
+		wantErrorMatch string
+	}{
+		{
+			name:      "Valid summary file parses next_code",
+			path:      validFile,
+			label:     "baseline",
+			wantCode:  1042,
+			wantError: false,
+		},
+		{
+			name:           "Nonexistent baseline file returns read error",
+			path:           filepath.Join(dir, "does_not_exist.json"),
+			label:          "baseline",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "failed to read baseline summary",
+		},
+		{
+			name:           "Nonexistent current file returns read error",
+			path:           filepath.Join(dir, "does_not_exist.json"),
+			label:          "current",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "failed to read current summary",
+		},
+		{
+			name:           "Malformed JSON baseline returns parse error",
+			path:           invalidJSONFile,
+			label:          "baseline",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "failed to parse baseline summary",
+		},
+		{
+			name:           "Malformed JSON current returns parse error",
+			path:           invalidJSONFile,
+			label:          "current",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "failed to parse current summary",
+		},
+		{
+			name:           "Zero next_code returns validation error",
+			path:           zeroCodeFile,
+			label:          "baseline",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "next_code missing or zero — expected an errorutil_analyze_summary.json",
+		},
+		{
+			name:           "Negative next_code returns validation error",
+			path:           negativeCodeFile,
+			label:          "current",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "next_code missing or zero — expected an errorutil_analyze_summary.json",
+		},
+		{
+			name:           "Missing next_code field returns validation error",
+			path:           missingCodeFile,
+			label:          "baseline",
+			wantCode:       0,
+			wantError:      true,
+			wantErrorMatch: "next_code missing or zero — expected an errorutil_analyze_summary.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := readSummaryNextCode(tt.path, tt.label)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("readSummaryNextCode() error = %v, wantError %v", err, tt.wantError)
+			}
+			if code != tt.wantCode {
+				t.Errorf("readSummaryNextCode() code = %d, wantCode %d", code, tt.wantCode)
+			}
 			if tt.wantError && tt.wantErrorMatch != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErrorMatch)

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/meshery/meshkit/cmd/errorutil/internal/component"
 	mesherr "github.com/meshery/meshkit/cmd/errorutil/internal/error"
 )
 
@@ -19,6 +20,7 @@ func TestCheckLogic(t *testing.T) {
 		baselineNext int
 		currentNext  int
 		wantErrors   bool
+		wantOut      []string
 	}{
 		// 1. new + replace_me -> PASS
 		{
@@ -31,7 +33,7 @@ func TestCheckLogic(t *testing.T) {
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
-					{Name: "ErrNew", Code: "replace_me", CodeIsInt: false},
+					{Name: "ErrNew", Code: "replace_", CodeIsInt: false},
 				},
 			},
 			baselineNext: -1,
@@ -256,7 +258,7 @@ func TestCheckLogic(t *testing.T) {
 			// This represents a legitimate workflow where an error code (e.g. 1001)
 			// was allocated, but later deleted from the PR. We shouldn't enforce
 			// strict equality between the count of new errors and currentNext - baselineNext.
-			wantErrors:   false,
+			wantErrors: false,
 		},
 		// 13. unrelated integer/string constant -> unaffected
 		{
@@ -293,7 +295,124 @@ func TestCheckLogic(t *testing.T) {
 			currentNext:  -1,
 			wantErrors:   false,
 		},
-		// 15. Two new errors both left as replace_me (simulating the 'place_' normalization collision)
+		// Third user of a pre-existing duplicate
+		{
+			name: "Third user of a pre-existing duplicate",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrA", Code: "1000", CodeIsInt: true},
+					{Name: "ErrB", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrA", Code: "1000", CodeIsInt: true},
+					{Name: "ErrB", Code: "1000", CodeIsInt: true},
+					{Name: "ErrC", Code: "1000", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   true,
+			wantOut:      []string{"1000"},
+		},
+		// Stale/regressed baseline with NO new codes
+		{
+			name: "Stale/regressed baseline with NO new codes",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1050,
+			currentNext:  1010,
+			wantErrors:   true,
+			wantOut:      []string{"1050", "1010"},
+		},
+		// Code equal to currentNext
+		{
+			name: "Code equal to currentNext",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1005", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1005,
+			wantErrors:   true,
+			wantOut:      []string{"1005"},
+		},
+		// Code one below baselineNext
+		{
+			name: "Code one below baselineNext",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "900", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "900", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1000", CodeIsInt: true},
+				},
+			},
+			baselineNext: 1001,
+			currentNext:  1010,
+			wantErrors:   true,
+			wantOut:      []string{"1000"},
+		},
+		// Only one of baselineNext/currentNext supplied
+		{
+			name: "Only one of baselineNext/currentNext supplied",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew", Code: "1001", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  1002,
+			wantErrors:   true,
+			wantOut:      []string{"1001"},
+		},
+		// Restore the mixed-additions case dropped from #1080
+		{
+			name: "Restore the mixed-additions case",
+			baseline: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+				},
+			},
+			current: mesherr.InfoAll{
+				Entries: []mesherr.Info{
+					{Name: "ErrOld", Code: "1000", CodeIsInt: true},
+					{Name: "ErrNew1", Code: "replace_", CodeIsInt: false},
+					{Name: "ErrNew2", Code: "1002", CodeIsInt: true},
+				},
+			},
+			baselineNext: -1,
+			currentNext:  -1,
+			wantErrors:   true,
+			wantOut:      []string{"ErrNew2", "1002"},
+		},
+
+		// 15. Two new errors both left as replace_me (simulating two new replace_-normalized placeholders colliding)
 		{
 			name: "Multiple new placeholders simulating normalization collision passes",
 			baseline: mesherr.InfoAll{
@@ -304,8 +423,8 @@ func TestCheckLogic(t *testing.T) {
 			current: mesherr.InfoAll{
 				Entries: []mesherr.Info{
 					{Name: "ErrExistingCode", Code: "1463", CodeIsInt: true},
-					{Name: "ErrNewOneCode", Code: "place_", CodeIsInt: false},
-					{Name: "ErrNewTwoCode", Code: "place_", CodeIsInt: false},
+					{Name: "ErrNewOneCode", Code: "replace_", CodeIsInt: false},
+					{Name: "ErrNewTwoCode", Code: "replace_", CodeIsInt: false},
 				},
 			},
 			baselineNext: 1464,
@@ -339,6 +458,11 @@ func TestCheckLogic(t *testing.T) {
 			err := ValidateNewErrors(tt.baseline, tt.current, tt.baselineNext, tt.currentNext, &buf)
 			if (err != nil) != tt.wantErrors {
 				t.Errorf("ValidateNewErrors() error = %v, wantErrors %v. Output: %s", err, tt.wantErrors, buf.String())
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("ValidateNewErrors() output missing expected substring %q. Full output: %s", want, buf.String())
+				}
 			}
 		})
 	}
@@ -382,10 +506,26 @@ func TestCommandCheck(t *testing.T) {
 		{
 			name: "Both summary flags with valid local allocation",
 			setup: func(t *testing.T, dir string) []string {
-				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
-				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
-				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
-				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+				err1 := makeErrors("1000", true)
+				err2 := makeErrors("1001", true)
+				bErr := writeJSON(t, dir, "b_err.json", err1)
+				cErr := writeJSON(t, dir, "c_err.json", err2)
+
+				comp1 := &component.Info{NextErrorCode: 1001}
+				err := mesherr.SummarizeAnalysis(comp1, &err1, dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "b_sum.json"))
+				bSum := filepath.Join(dir, "b_sum.json")
+
+				comp2 := &component.Info{NextErrorCode: 1002}
+				err = mesherr.SummarizeAnalysis(comp2, &err2, dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "c_sum.json"))
+				cSum := filepath.Join(dir, "c_sum.json")
 
 				return []string{
 					"--baseline-summary", bSum,
@@ -411,7 +551,7 @@ func TestCommandCheck(t *testing.T) {
 				}
 			},
 			wantError:      true,
-			wantErrorMatch: "error validation failed",
+			wantErrorMatch: "error code validation failed; see details above",
 		},
 		// 3. No summary flags (legacy strict behavior)
 		{
@@ -423,7 +563,7 @@ func TestCommandCheck(t *testing.T) {
 				return []string{bErr, cErr}
 			},
 			wantError:      true,
-			wantErrorMatch: "error validation failed",
+			wantErrorMatch: "error code validation failed; see details above",
 		},
 		// 4. Only baseline summary supplied
 		{
@@ -516,7 +656,9 @@ func TestCommandCheck(t *testing.T) {
 				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
 
 				bSum := filepath.Join(dir, "b_sum.json")
-				os.WriteFile(bSum, []byte("not valid json"), 0644)
+				if err := os.WriteFile(bSum, []byte("not valid json"), 0644); err != nil {
+					t.Fatal(err)
+				}
 
 				return []string{
 					"--baseline-summary", bSum,
@@ -536,7 +678,9 @@ func TestCommandCheck(t *testing.T) {
 				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
 
 				cSum := filepath.Join(dir, "c_sum.json")
-				os.WriteFile(cSum, []byte("not valid json"), 0644)
+				if err := os.WriteFile(cSum, []byte("not valid json"), 0644); err != nil {
+					t.Fatal(err)
+				}
 
 				return []string{
 					"--baseline-summary", bSum,

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -514,7 +514,7 @@ func TestCommandCheck(t *testing.T) {
 				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
 				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
 				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
-				
+
 				bSum := filepath.Join(dir, "b_sum.json")
 				os.WriteFile(bSum, []byte("not valid json"), 0644)
 
@@ -534,7 +534,7 @@ func TestCommandCheck(t *testing.T) {
 				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
 				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
 				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
-				
+
 				cSum := filepath.Join(dir, "c_sum.json")
 				os.WriteFile(cSum, []byte("not valid json"), 0644)
 
@@ -598,7 +598,7 @@ func TestCommandCheck(t *testing.T) {
 			args := tt.setup(t, dir)
 
 			cmd := commandCheck()
-			
+
 			// We only want to capture out/err, not pollute real stdout
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
@@ -609,7 +609,7 @@ func TestCommandCheck(t *testing.T) {
 			if (err != nil) != tt.wantError {
 				t.Fatalf("commandCheck().Execute() error = %v, wantError %v", err, tt.wantError)
 			}
-			
+
 			if tt.wantError && tt.wantErrorMatch != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErrorMatch)

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -2,6 +2,10 @@ package coder
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	mesherr "github.com/meshery/meshkit/cmd/errorutil/internal/error"
@@ -335,6 +339,284 @@ func TestCheckLogic(t *testing.T) {
 			err := ValidateNewErrors(tt.baseline, tt.current, tt.baselineNext, tt.currentNext, &buf)
 			if (err != nil) != tt.wantErrors {
 				t.Errorf("ValidateNewErrors() error = %v, wantErrors %v. Output: %s", err, tt.wantErrors, buf.String())
+			}
+		})
+	}
+}
+
+func TestCommandCheck(t *testing.T) {
+	// Helper to write JSON files
+	writeJSON := func(t *testing.T, dir, filename string, v interface{}) string {
+		t.Helper()
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, filename)
+		if err := os.WriteFile(path, b, 0644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	// Helpers for standard payloads
+	makeErrors := func(code string, codeIsInt bool) mesherr.InfoAll {
+		return mesherr.InfoAll{
+			Entries: []mesherr.Info{
+				{Name: "ErrTest", Code: code, CodeIsInt: codeIsInt},
+			},
+		}
+	}
+
+	type analysisSummary struct {
+		NextCode int `json:"next_code"`
+	}
+
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T, dir string) (args []string)
+		wantError      bool
+		wantErrorMatch string
+	}{
+		// 1. Both summary flags with valid local allocation
+		{
+			name: "Both summary flags with valid local allocation",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError: false,
+		},
+		// 2. Both summary flags with invalid/manual integer
+		{
+			name: "Both summary flags with invalid manual integer",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("2000", true)) // Outside 1001..1002
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "error validation failed",
+		},
+		// 3. No summary flags (legacy strict behavior)
+		{
+			name: "No summary flags",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true)) // Valid if local, but fails in strict
+
+				return []string{bErr, cErr}
+			},
+			wantError:      true,
+			wantErrorMatch: "error validation failed",
+		},
+		// 4. Only baseline summary supplied
+		{
+			name: "Only baseline summary supplied",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
+
+				return []string{
+					"--baseline-summary", bSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "both --baseline-summary and --current-summary must be provided",
+		},
+		// 5. Only current summary supplied
+		{
+			name: "Only current summary supplied",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+
+				return []string{
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "both --baseline-summary and --current-summary must be provided",
+		},
+		// 6. Wrong file supplied as summary
+		{
+			name: "Wrong file supplied as summary",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+
+				return []string{
+					"--baseline-summary", bErr, // Passing error JSON instead of summary
+					"--current-summary", cErr,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "next_code",
+		},
+		// 7. Missing baseline summary file
+		{
+			name: "Missing baseline summary file",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+
+				return []string{
+					"--baseline-summary", filepath.Join(dir, "nonexistent.json"),
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "failed to read baseline summary",
+		},
+		// 8. Missing current summary file
+		{
+			name: "Missing current summary file",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", filepath.Join(dir, "nonexistent.json"),
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "failed to read current summary",
+		},
+		// 9. Malformed baseline summary JSON
+		{
+			name: "Malformed baseline summary JSON",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+				
+				bSum := filepath.Join(dir, "b_sum.json")
+				os.WriteFile(bSum, []byte("not valid json"), 0644)
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "failed to parse baseline summary",
+		},
+		// 10. Malformed current summary JSON
+		{
+			name: "Malformed current summary JSON",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 1001})
+				
+				cSum := filepath.Join(dir, "c_sum.json")
+				os.WriteFile(cSum, []byte("not valid json"), 0644)
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "failed to parse current summary",
+		},
+		// 11. Summary with missing/zero next_code
+		{
+			name: "Summary with missing/zero next_code",
+			setup: func(t *testing.T, dir string) []string {
+				bErr := writeJSON(t, dir, "b_err.json", makeErrors("1000", true))
+				cErr := writeJSON(t, dir, "c_err.json", makeErrors("1001", true))
+				bSum := writeJSON(t, dir, "b_sum.json", analysisSummary{NextCode: 0})
+				cSum := writeJSON(t, dir, "c_sum.json", analysisSummary{NextCode: 1002})
+
+				return []string{
+					"--baseline-summary", bSum,
+					"--current-summary", cSum,
+					bErr, cErr,
+				}
+			},
+			wantError:      true,
+			wantErrorMatch: "next_code",
+		},
+		// 12. Positional argument validation
+		{
+			name: "Positional argument validation (no args)",
+			setup: func(t *testing.T, dir string) []string {
+				return []string{}
+			},
+			wantError:      true,
+			wantErrorMatch: "accepts 2 arg(s), received 0",
+		},
+		{
+			name: "Positional argument validation (1 arg)",
+			setup: func(t *testing.T, dir string) []string {
+				return []string{"one"}
+			},
+			wantError:      true,
+			wantErrorMatch: "accepts 2 arg(s), received 1",
+		},
+		{
+			name: "Positional argument validation (3 args)",
+			setup: func(t *testing.T, dir string) []string {
+				return []string{"one", "two", "three"}
+			},
+			wantError:      true,
+			wantErrorMatch: "accepts 2 arg(s), received 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			args := tt.setup(t, dir)
+
+			cmd := commandCheck()
+			
+			// We only want to capture out/err, not pollute real stdout
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			if (err != nil) != tt.wantError {
+				t.Fatalf("commandCheck().Execute() error = %v, wantError %v", err, tt.wantError)
+			}
+			
+			if tt.wantError && tt.wantErrorMatch != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrorMatch)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrorMatch) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrorMatch)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This PR extends `errorutil check` to validate newly introduced error-code allocations while supporting both supported MeshKit development workflows:

* New errors using `"replace_me"` for allocation through the existing CI workflow.
* Developers running `errorutil update` locally to allocate an integer error code before committing.

Previously, newly introduced integer error codes were rejected outright. This change allows legitimate locally allocated integers while continuing to reject invalid manual assignments.

## What changed

* Added allocation-aware validation to `errorutil check`.
* Added support for baseline and current allocation summaries through:

  * `--baseline-summary`
  * `--current-summary`
* Validates newly introduced integer codes against the allocation window represented by the baseline and current `next_error_code` values.
* Detects allocation counter regression.
* Detects newly introduced duplicate integer error codes while tolerating duplicate codes already present in the baseline.
* Identifies existing integer codes by their numeric value rather than error constant name, so renames and moves preserving an existing code remain valid.
* Preserves the existing strict behavior when allocation summaries are not supplied.
* Added CLI and validation tests covering normal and edge-case allocation scenarios.

## Validation behavior

The allocation-aware validation requires newly introduced integer codes to satisfy:

```text
baselineNext <= code < currentNext
```

This means:

* valid locally allocated codes pass;
* arbitrary/manual integers outside the allocation window fail;
* allocation counter regression fails;
* newly introduced duplicate integer codes fail;
* duplicate codes already present in the baseline do not cause unrelated changes to fail;
* existing integer codes remain valid when an error is renamed or moved.

`errorutil check` remains validation-only. It does not allocate or modify error codes.

## Dependency

Depends on [[meshery/meshkit#1080](https://github.com/meshery/meshkit/pull/1080)](https://github.com/meshery/meshkit/pull/1080), which introduced the original `errorutil check` validation workflow.

The allocation-aware validator introduced here is consumed by downstream integration work in:

* [[meshery/meshery#21009](https://github.com/meshery/meshery/pull/21009)](https://github.com/meshery/meshery/pull/21009) — Meshery CI validation
* [[meshery/meshkit#1107](https://github.com/meshery/meshkit/pull/1107)](https://github.com/meshery/meshkit/pull/1107) — MeshKit CI and pre-commit validation

## Testing

Verified with:

* `go test ./cmd/errorutil/...`
* `go test ./...`
* `make check`
* CLI tests for summary-file handling and argument validation
* allocation scenarios including single and multiple local allocations
* rename handling
* duplicate-code handling
* counter regression
* allocation/deletion edge cases
* missing, malformed, and invalid summary metadata
* `git diff --check`

## Known limitations

This validation establishes consistency with the recorded allocation state; it does not provide cryptographic proof that a particular integer was produced by `errorutil update`.

It also does not provide global synchronization across independent branches that allocate from the same baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `check` command now accepts baseline and current summary files for validating allocation-counter changes.
  - Summary files are checked for valid `next_code` values and supported formats.

- **Bug Fixes**
  - Improved detection of duplicate numeric codes, invalid allocation ranges, counter regressions, and over-advanced counters.
  - Numeric codes are normalized consistently, with clearer diagnostics for invalid changes.

- **Documentation**
  - Updated command guidance to explain merge-base analysis and valid allocation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->