### PR TITLE
feat(errorutil): add MeshKit PR validation and pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# MeshKit error-code pre-commit validation.
+#
+# Validates the STAGED (index) state against HEAD using the same
+# `errorutil check` that runs in CI (.github/workflows/error-codes-updater.yaml).
+# Does not allocate codes, does not modify any file, and is not the security
+# boundary - `git commit --no-verify` bypasses this; CI remains authoritative.
+set -eu
+
+PAT_ERR='*error.go'
+PAT_INFO='helpers/component_info.json'
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- $PAT_ERR $PAT_INFO)
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cur="$tmp/current"
+base="$tmp/baseline"
+mkdir -p "$cur/helpers" "$base/helpers"
+
+all_tracked=$(git ls-files -- $PAT_ERR $PAT_INFO)
+if [ -n "$all_tracked" ]; then
+  git checkout-index --prefix="$cur/" -- $all_tracked
+fi
+
+# IMPORTANT: pass patterns directly to `git archive`, do not pre-resolve via
+# `git ls-tree ... -- <pattern>` - ls-tree's pathspec matching for a bare
+# `*error.go` does not recurse into subdirectories and silently drops nested
+# matches, which corrupts the baseline (every unchanged code looks "new").
+if git rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  git archive HEAD -- $PAT_ERR $PAT_INFO 2>/dev/null | tar -x -C "$base" 2>/dev/null || true
+fi
+
+go run ./cmd/errorutil -d "$base" analyze --skip-dirs meshery -i "$base/helpers" -o "$base/helpers" >/dev/null 2>&1 || true
+go run ./cmd/errorutil -d "$cur"  analyze --skip-dirs meshery -i "$cur/helpers"  -o "$cur/helpers"  >/dev/null 2>&1 || true
+
+if [ ! -f "$base/helpers/errorutil_analyze_summary.json" ] || [ ! -f "$cur/helpers/errorutil_analyze_summary.json" ]; then
+  echo "pre-commit: could not analyze error codes locally - skipping (CI will still validate this)" >&2
+  exit 0
+fi
+
+go run ./cmd/errorutil check \
+  "$base/helpers/errorutil_analyze_errors.json" "$cur/helpers/errorutil_analyze_errors.json" \
+  --baseline-summary "$base/helpers/errorutil_analyze_summary.json" \
+  --current-summary  "$cur/helpers/errorutil_analyze_summary.json"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,12 +5,16 @@
 # `errorutil check` that runs in CI (.github/workflows/error-codes-updater.yaml).
 # Does not allocate codes, does not modify any file, and is not the security
 # boundary - `git commit --no-verify` bypasses this; CI remains authoritative.
-set -eu
+set -euo pipefail
 
 PAT_ERR='*.go'
 PAT_INFO='helpers/component_info.json'
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR -- "$PAT_ERR" "$PAT_INFO" | grep -v '_test\.go$' || true)
+# `|| true` must cover ONLY grep's "no match" exit status. A real failure of
+# `git diff --cached` must abort the hook (via set -e), not silently yield an
+# empty file list that skips validation.
+staged_all=$(git diff --cached --name-only --diff-filter=ACMR -- "$PAT_ERR" "$PAT_INFO")
+staged=$(printf '%s' "$staged_all" | grep -v '_test\.go$' || true)
 if [ -z "$staged" ]; then
   exit 0
 fi
@@ -21,10 +25,11 @@ cur="$tmp/current"
 base="$tmp/baseline"
 mkdir -p "$cur/helpers" "$base/helpers"
 
-all_tracked=$(git ls-files -- "$PAT_ERR" "$PAT_INFO")
-if [ -n "$all_tracked" ]; then
-  git checkout-index --prefix="$cur/" -- $all_tracked
-fi
+# NUL-delimited: an unquoted "$all_tracked" word-splits on IFS, so any tracked
+# path containing a space made `git checkout-index` fail and silently drop that
+# file from the analyzed tree.
+git ls-files -z -- "$PAT_ERR" "$PAT_INFO" \
+  | git checkout-index -z --stdin --prefix="$cur/"
 
 # IMPORTANT: pass patterns directly to `git archive`, do not pre-resolve via
 # `git ls-tree ... -- <pattern>` - ls-tree's pathspec matching for a bare

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ set -eu
 PAT_ERR='*.go'
 PAT_INFO='helpers/component_info.json'
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR -- $PAT_ERR $PAT_INFO | grep -v '_test\.go$' || true)
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- "$PAT_ERR" "$PAT_INFO" | grep -v '_test\.go$' || true)
 if [ -z "$staged" ]; then
   exit 0
 fi
@@ -21,7 +21,7 @@ cur="$tmp/current"
 base="$tmp/baseline"
 mkdir -p "$cur/helpers" "$base/helpers"
 
-all_tracked=$(git ls-files -- $PAT_ERR $PAT_INFO)
+all_tracked=$(git ls-files -- "$PAT_ERR" "$PAT_INFO")
 if [ -n "$all_tracked" ]; then
   git checkout-index --prefix="$cur/" -- $all_tracked
 fi
@@ -31,7 +31,7 @@ fi
 # `*error.go` does not recurse into subdirectories and silently drops nested
 # matches, which corrupts the baseline (every unchanged code looks "new").
 if git rev-parse --verify -q HEAD >/dev/null 2>&1; then
-  git archive HEAD -- $PAT_ERR $PAT_INFO 2>/dev/null | tar -x -C "$base" 2>/dev/null || true
+  git archive HEAD -- "$PAT_ERR" "$PAT_INFO" 2>/dev/null | tar -x -C "$base" 2>/dev/null || true
 fi
 
 go run ./cmd/errorutil -d "$base" analyze --skip-dirs meshery -i "$base/helpers" -o "$base/helpers" >/dev/null 2>&1 || true

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,8 +34,15 @@ if git rev-parse --verify -q HEAD >/dev/null 2>&1; then
   git archive HEAD -- "$PAT_ERR" "$PAT_INFO" 2>/dev/null | tar -x -C "$base" 2>/dev/null || true
 fi
 
-go run ./cmd/errorutil -d "$base" analyze --skip-dirs meshery -i "$base/helpers" -o "$base/helpers" >/dev/null 2>&1 || true
-go run ./cmd/errorutil -d "$cur"  analyze --skip-dirs meshery -i "$cur/helpers"  -o "$cur/helpers"  >/dev/null 2>&1 || true
+cur_go="$cur"
+base_go="$base"
+if command -v cygpath >/dev/null 2>&1; then
+  cur_go=$(cygpath -m "$cur")
+  base_go=$(cygpath -m "$base")
+fi
+
+go run ./cmd/errorutil -d "$base_go" analyze --skip-dirs meshery -i "$base_go/helpers" -o "$base_go/helpers" >/dev/null 2>&1 || true
+go run ./cmd/errorutil -d "$cur_go"  analyze --skip-dirs meshery -i "$cur_go/helpers"  -o "$cur_go/helpers"  >/dev/null 2>&1 || true
 
 if [ ! -f "$base/helpers/errorutil_analyze_summary.json" ] || [ ! -f "$cur/helpers/errorutil_analyze_summary.json" ]; then
   echo "pre-commit: could not analyze error codes locally - skipping (CI will still validate this)" >&2
@@ -43,6 +50,6 @@ if [ ! -f "$base/helpers/errorutil_analyze_summary.json" ] || [ ! -f "$cur/helpe
 fi
 
 go run ./cmd/errorutil check \
-  "$base/helpers/errorutil_analyze_errors.json" "$cur/helpers/errorutil_analyze_errors.json" \
-  --baseline-summary "$base/helpers/errorutil_analyze_summary.json" \
-  --current-summary  "$cur/helpers/errorutil_analyze_summary.json"
+  "$base_go/helpers/errorutil_analyze_errors.json" "$cur_go/helpers/errorutil_analyze_errors.json" \
+  --baseline-summary "$base_go/helpers/errorutil_analyze_summary.json" \
+  --current-summary  "$cur_go/helpers/errorutil_analyze_summary.json"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,10 +7,10 @@
 # boundary - `git commit --no-verify` bypasses this; CI remains authoritative.
 set -eu
 
-PAT_ERR='*error.go'
+PAT_ERR='*.go'
 PAT_INFO='helpers/component_info.json'
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR -- $PAT_ERR $PAT_INFO)
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- $PAT_ERR $PAT_INFO | grep -v '_test\.go$' || true)
 if [ -z "$staged" ]; then
   exit 0
 fi

--- a/.githooks/test/run_tests.sh
+++ b/.githooks/test/run_tests.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 11 cases test script for errorutil pre-commit hook
+# Regression suite for the errorutil pre-commit hook (.githooks/pre-commit).
+#
+# Runs in CI on Linux via `make test-hooks`. Requires: bash, git, go, make.
+#
+# NOT covered here: real Windows/MSYS path conversion. Case 13 only proves the
+# cygpath branch executes; it uses a pass-through mock and asserts nothing about
+# Windows semantics. See docs/agent-instructions/errors.md for the manual
+# Git Bash procedure.
 echo "Setting up test environment..."
 
 ROOT_DIR=$(pwd)
@@ -175,7 +182,7 @@ for i in $(seq 1 5); do
     assert_pass run_hook
 done
 
-echo "13. cygpath execution path verification"
+echo "13. cygpath branch executes (Linux mock; does NOT validate Windows conversion)"
 MOCK_BIN=$(mktemp -d)
 cat > "$MOCK_BIN/cygpath" <<'EOF'
 #!/bin/sh
@@ -187,5 +194,25 @@ chmod +x "$MOCK_BIN/cygpath"
   assert_pass run_hook
 )
 rm -rf "$MOCK_BIN"
+
+echo "14. Tracked path containing spaces, valid placeholder staged"
+git reset --hard HEAD >/dev/null 2>&1
+mkdir -p "pkg with space"
+cat > "pkg with space/error.go" <<EOF
+package pkgwithspace
+const ErrSpacedCode = "replace_me"
+EOF
+git add "pkg with space/error.go"
+assert_pass run_hook
+
+echo "15. Tracked path containing spaces, hand-typed integer staged"
+cat > "pkg with space/error.go" <<EOF
+package pkgwithspace
+const ErrSpacedCode = "meshkit-11005"
+EOF
+git add "pkg with space/error.go"
+assert_fail run_hook
+git reset --hard HEAD >/dev/null 2>&1
+rm -rf "pkg with space"
 
 echo "ALL TESTS PASSED!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,16 @@ jobs:
           cache-dependency-path: go.sum
       - name: Run tests
         run: make test
+  hooks:
+    name: pre-commit hook
+    needs: [tidy]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Run pre-commit hook regression suite
+        run: make test-hooks

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -6,6 +6,13 @@ on:
       - "master"
     paths:
       - "**.go"
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "**.go"
+      - ".github/workflows/error-codes-updater.yaml"
+
 
 jobs:
   Update-error-codes:
@@ -14,6 +21,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Checkout base branch
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .baseline
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'pull_request' }}
         # token here with write access to meshkit repo
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -24,15 +45,31 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Validate error codes (PR only)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          go run github.com/meshery/meshkit/cmd/errorutil -d .baseline analyze --skip-dirs meshery -i .baseline/helpers -o .baseline/helpers
+          go run github.com/meshery/meshkit/cmd/errorutil -d . analyze --skip-dirs meshery,.baseline -i ./helpers -o ./helpers
+          go run github.com/meshery/meshkit/cmd/errorutil check \
+            .baseline/helpers/errorutil_analyze_errors.json ./helpers/errorutil_analyze_errors.json \
+            --baseline-summary .baseline/helpers/errorutil_analyze_summary.json \
+            --current-summary  ./helpers/errorutil_analyze_summary.json
+
       - name: Run utility
+        if: ${{ github.event_name != 'pull_request' }}
+
         run: |
           go run github.com/meshery/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
 
       - name: Pull changes from remote
+        if: ${{ github.event_name != 'pull_request' }}
+
         run: git pull origin master
 
       # to update errorutil* files in meshkit repo
       - name: Commit changes
+        if: ${{ github.event_name != 'pull_request' }}
+
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: meshery-ci
@@ -44,6 +81,8 @@ jobs:
 
       # to push changes to meshery docs
       - name: Checkout meshery
+        if: ${{ github.event_name != 'pull_request' }}
+
         uses: actions/checkout@v6
         with:
           repository: "meshery/meshery"
@@ -53,6 +92,8 @@ jobs:
           ref: "master"
 
       - name: Update and push docs
+        if: ${{ github.event_name != 'pull_request' }}
+
         run: |
           echo '{ "errors_export": "" }' | jq --slurpfile export ./helpers/errorutil_errors_export.json '.errors_export = $export[0]' > ./meshery/docs/data/errorref/meshkit_errors_export.json
 

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "**.go"
       - "helpers/component_info.json"
+      - ".github/workflows/error-codes-updater.yaml"
   pull_request:
     branches:
       - "master"
@@ -32,9 +33,34 @@ jobs:
           persist-credentials: false
       - name: Determine merge-base
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          echo "MERGE_BASE=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_ENV
+          set -euo pipefail
+
+          # The baseline for `errorutil check` MUST be this branch's merge-base with
+          # the base branch. If we cannot resolve it we fail the job: a missing
+          # baseline previously left MERGE_BASE empty, which made actions/checkout
+          # fall back to the event's default ref and silently turned this check into
+          # a no-op.
+          if ! git fetch --no-tags --quiet origin \
+                 "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"; then
+            echo "::error::Unable to fetch base branch '${BASE_REF}' of meshery/meshkit; cannot establish an error-code validation baseline."
+            exit 1
+          fi
+
+          if ! MERGE_BASE="$(git merge-base HEAD "refs/remotes/origin/${BASE_REF}")"; then
+            echo "::error::Unable to determine the merge-base between this pull request and '${BASE_REF}' of meshery/meshkit. Error-code validation cannot run without a baseline, so this check fails closed."
+            exit 1
+          fi
+
+          if ! printf '%s' "${MERGE_BASE}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::Resolved merge-base '${MERGE_BASE}' is not a 40-character commit SHA; refusing to continue."
+            exit 1
+          fi
+
+          echo "Resolved merge-base: ${MERGE_BASE}"
+          echo "MERGE_BASE=${MERGE_BASE}" >> "$GITHUB_ENV"
       - name: Checkout base branch
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v6
@@ -43,6 +69,17 @@ jobs:
           path: .baseline
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Verify baseline checkout
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          ACTUAL="$(git -C .baseline rev-parse HEAD)"
+          if [ "${ACTUAL}" != "${MERGE_BASE}" ]; then
+            echo "::error::Baseline checkout resolved to ${ACTUAL} but the merge-base is ${MERGE_BASE}; refusing to validate against the wrong tree."
+            exit 1
+          fi
+          echo "Baseline verified at ${ACTUAL}"
       - uses: actions/checkout@v6
         if: ${{ github.event_name != 'pull_request' }}
         # token here with write access to meshkit repo

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -24,12 +24,17 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
+      - name: Determine merge-base
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo "MERGE_BASE=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_ENV
       - name: Checkout base branch
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ env.MERGE_BASE }}
           path: .baseline
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -6,13 +6,17 @@ on:
       - "master"
     paths:
       - "**.go"
+      - "helpers/component_info.json"
   pull_request:
     branches:
       - "master"
     paths:
       - "**.go"
+      - "helpers/component_info.json"
       - ".github/workflows/error-codes-updater.yaml"
 
+permissions:
+  contents: read
 
 jobs:
   Update-error-codes:
@@ -25,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Determine merge-base
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,7 @@ build-errorutil:
 setup-hooks:
 	git config core.hooksPath .githooks
 	chmod +x .githooks/pre-commit
+
+## Run the pre-commit hook regression suite (bash; also runs in CI).
+test-hooks:
+	bash .githooks/test/run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,8 @@ errorutil-analyze:
 ## Build the Meshery Error Code Utility. 
 build-errorutil:
 	go build -o errorutil cmd/errorutil/main.go
+
+## Install the local pre-commit hook that validates error codes before commit.
+setup-hooks:
+	git config core.hooksPath .githooks
+	chmod +x .githooks/pre-commit

--- a/cmd/errorutil/internal/coder/commands.go
+++ b/cmd/errorutil/internal/coder/commands.go
@@ -196,7 +196,7 @@ Meshery components and this tool:
 - The tool updates next_error_code.
 
 Both "replace_me" and locally-running 'errorutil update' are valid ways to arrive at an integer code.
-Note a precondition for the check command: baseline must be the analysis of current's merge-base (the commit this branch forked from), NOT the current tip of the base branch. This tool does not resolve two independent branches allocating the same code from the same baseline — that is handled by the post-merge allocation process re-encountering the collision, not by this check.
+Note a precondition for the check command: baseline must be the analysis of current's merge-base (the commit this branch forked from), NOT the current tip of the base branch. This tool does not resolve two independent branches allocating the same code from the same baseline.
 `)
 		},
 	}

--- a/cmd/errorutil/internal/coder/commands_test.go
+++ b/cmd/errorutil/internal/coder/commands_test.go
@@ -516,7 +516,9 @@ func TestCommandCheck(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "b_sum.json"))
+				if err := os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "b_sum.json")); err != nil {
+					t.Fatal(err)
+				}
 				bSum := filepath.Join(dir, "b_sum.json")
 
 				comp2 := &component.Info{NextErrorCode: 1002}
@@ -524,7 +526,9 @@ func TestCommandCheck(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "c_sum.json"))
+				if err := os.Rename(filepath.Join(dir, "errorutil_analyze_summary.json"), filepath.Join(dir, "c_sum.json")); err != nil {
+					t.Fatal(err)
+				}
 				cSum := filepath.Join(dir, "c_sum.json")
 
 				return []string{

--- a/cmd/errorutil/internal/coder/node.go
+++ b/cmd/errorutil/internal/coder/node.go
@@ -124,7 +124,10 @@ func handleValueSpec(n ast.Node, update bool, updateAll bool, comp *component.In
 	if ok {
 		for _, id := range spec.Names {
 			if isErrorCodeVarName(id.Name) {
-				value0 := id.Obj.Decl.(*ast.ValueSpec).Values[0]
+				value0, hasValue := errorCodeDeclValue(id)
+				if !hasValue {
+					logger.WithFields(logrus.Fields{"name": id.Name}).Warn("Err* variable detected without an inspectable declaration value.")
+				}
 				isLiteral := false
 				isInteger := false
 				oldValue := ""
@@ -172,4 +175,22 @@ func handleValueSpec(n ast.Node, update bool, updateAll bool, comp *component.In
 		}
 	}
 	return anyValueChanged
+}
+
+// errorCodeDeclValue returns the first value expression of the ValueSpec that
+// declares id, if there is one.
+//
+// Two legal Go constructs have no inspectable value: `var ErrFooCode string`
+// declares the symbol with no initializer, and an identifier the parser did not
+// resolve has no declaration object at all. Neither is an analyzable error code,
+// and neither must crash the analyzer.
+func errorCodeDeclValue(id *ast.Ident) (ast.Expr, bool) {
+	if id.Obj == nil {
+		return nil, false
+	}
+	spec, ok := id.Obj.Decl.(*ast.ValueSpec)
+	if !ok || len(spec.Values) == 0 {
+		return nil, false
+	}
+	return spec.Values[0], true
 }

--- a/cmd/errorutil/internal/coder/node_test.go
+++ b/cmd/errorutil/internal/coder/node_test.go
@@ -1,0 +1,128 @@
+package coder
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/meshery/meshkit/cmd/errorutil/internal/component"
+	mesherr "github.com/meshery/meshkit/cmd/errorutil/internal/error"
+)
+
+// A declaration matching ^Err[A-Z].+Code$ that has no inspectable value used to
+// panic the analyzer with "index out of range [0] with length 0". It must now be
+// reported as an un-analyzable entry instead.
+func TestHandleFileErrorCodeDeclarationWithoutValue(t *testing.T) {
+	tests := []struct {
+		name          string
+		src           string
+		wantEntries   int
+		wantLiterals  int
+		wantCallExprs int
+		wantCode      string
+		wantCodeIsInt bool
+	}{
+		{
+			name:          "var without initializer is recorded, not fatal",
+			src:           "package p\n\nvar ErrNoInitCode string\n",
+			wantEntries:   1,
+			wantLiterals:  0,
+			wantCallExprs: 1,
+			wantCode:      "",
+			wantCodeIsInt: false,
+		},
+		{
+			name:          "call expression value keeps its existing handling",
+			src:           "package p\n\nfunc mk() string { return \"x\" }\n\nvar ErrCallCode = mk()\n",
+			wantEntries:   1,
+			wantLiterals:  0,
+			wantCallExprs: 1,
+			wantCode:      "",
+			wantCodeIsInt: false,
+		},
+		{
+			name:          "ordinary integer literal is unchanged",
+			src:           "package p\n\nconst ErrGoodCode = \"meshkit-1001\"\n",
+			wantEntries:   1,
+			wantLiterals:  1,
+			wantCallExprs: 0,
+			wantCode:      "1001",
+			wantCodeIsInt: true,
+		},
+		{
+			name:          "ordinary placeholder is unchanged",
+			src:           "package p\n\nconst ErrNewCode = \"replace_me\"\n",
+			wantEntries:   1,
+			wantLiterals:  1,
+			wantCallExprs: 0,
+			wantCode:      "replace_",
+			wantCodeIsInt: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "error.go")
+			if err := os.WriteFile(path, []byte(tt.src), 0600); err != nil {
+				t.Fatal(err)
+			}
+
+			infoAll := mesherr.NewInfoAll()
+			comp := &component.Info{Name: "meshkit", Type: "library", NextErrorCode: 1010}
+
+			// Must not panic, and must not return an error.
+			if err := handleFile(path, false, false, infoAll, comp); err != nil {
+				t.Fatalf("handleFile() error = %v, want nil", err)
+			}
+
+			if got := len(infoAll.Entries); got != tt.wantEntries {
+				t.Fatalf("Entries = %d, want %d (%+v)", got, tt.wantEntries, infoAll.Entries)
+			}
+			if got := len(infoAll.LiteralCodes); got != tt.wantLiterals {
+				t.Errorf("LiteralCodes = %d, want %d", got, tt.wantLiterals)
+			}
+			if got := len(infoAll.CallExprCodes); got != tt.wantCallExprs {
+				t.Errorf("CallExprCodes = %d, want %d", got, tt.wantCallExprs)
+			}
+			if got := infoAll.Entries[0].Code; got != tt.wantCode {
+				t.Errorf("Code = %q, want %q", got, tt.wantCode)
+			}
+			if got := infoAll.Entries[0].CodeIsInt; got != tt.wantCodeIsInt {
+				t.Errorf("CodeIsInt = %v, want %v", got, tt.wantCodeIsInt)
+			}
+		})
+	}
+}
+
+// `errorutil update` must not panic on the same input, and must not invent a
+// code for a declaration it cannot rewrite.
+func TestHandleFileUpdateDoesNotPanicOnValuelessDeclaration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "error.go")
+	src := "package p\n\nvar ErrNoInitCode string\n\nconst ErrRealCode = \"replace_me\"\n"
+	if err := os.WriteFile(path, []byte(src), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	infoAll := mesherr.NewInfoAll()
+	comp := &component.Info{Name: "meshkit", Type: "library", NextErrorCode: 1010}
+
+	if err := handleFile(path, true, false, infoAll, comp); err != nil {
+		t.Fatalf("handleFile() error = %v, want nil", err)
+	}
+	if comp.NextErrorCode != 1011 {
+		t.Errorf("NextErrorCode = %d, want 1011 (exactly one placeholder allocated)", comp.NextErrorCode)
+	}
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "\"meshkit-1010\""; !strings.Contains(string(out), want) {
+		t.Errorf("rewritten file does not contain %s:\n%s", want, out)
+	}
+	if strings.Contains(string(out), "ErrNoInitCode string = ") {
+		t.Errorf("valueless declaration must not be rewritten:\n%s", out)
+	}
+}

--- a/cmd/errorutil/testdata/hook/run_tests.sh
+++ b/cmd/errorutil/testdata/hook/run_tests.sh
@@ -163,4 +163,29 @@ if git commit -a -m "should fail" >/dev/null 2>&1; then
     exit 1
 fi
 
+echo "12. Repeated runs (reliability / no fail-open skips)"
+git reset --hard HEAD >/dev/null 2>&1
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+git add pkg/error.go
+for i in $(seq 1 5); do
+    assert_pass run_hook
+done
+
+echo "13. cygpath execution path verification"
+MOCK_BIN=$(mktemp -d)
+cat > "$MOCK_BIN/cygpath" <<'EOF'
+#!/bin/sh
+echo "$2"
+EOF
+chmod +x "$MOCK_BIN/cygpath"
+(
+  export PATH="$MOCK_BIN:$PATH"
+  assert_pass run_hook
+)
+rm -rf "$MOCK_BIN"
+
 echo "ALL TESTS PASSED!"

--- a/cmd/errorutil/testdata/hook/run_tests.sh
+++ b/cmd/errorutil/testdata/hook/run_tests.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 11 cases test script for errorutil pre-commit hook
+echo "Setting up test environment..."
+
+ROOT_DIR=$(pwd)
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Fast clone to get the exact toolchain and go.mod
+git clone -q --shared "$ROOT_DIR" "$TEST_DIR"
+cp -r "$ROOT_DIR/.githooks" "$TEST_DIR/"
+cd "$TEST_DIR"
+git config user.name "Test User"
+git config user.email "test@example.com"
+git config core.hooksPath .githooks
+
+# Set up baseline component info
+mkdir -p helpers pkg
+cat > helpers/component_info.json <<EOF
+{
+  "name": "meshkit",
+  "type": "library",
+  "next_error_code": 11000
+}
+EOF
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+EOF
+
+git add helpers/component_info.json pkg/error.go
+git commit --no-verify -m "baseline" -q
+
+# Run cases
+
+run_hook() {
+    # runs the hook directly so we can check exit code without needing an actual commit
+    ./.githooks/pre-commit
+}
+
+assert_pass() {
+    if ! "$@"; then
+        echo "FAIL: expected pass: $*"
+        exit 1
+    fi
+}
+
+assert_fail() {
+    if "$@"; then
+        echo "FAIL: expected fail: $*"
+        exit 1
+    fi
+}
+
+echo "1. Nothing staged"
+assert_pass run_hook
+
+echo "2. replace_me staged"
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+git add pkg/error.go
+assert_pass run_hook
+
+echo "3. Real local allocation staged"
+make errorutil >/dev/null 2>&1
+git add pkg/error.go helpers/component_info.json
+assert_pass run_hook
+
+echo "4. Hand-typed integer staged"
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "meshkit-11005"
+EOF
+git add pkg/error.go
+assert_fail run_hook
+
+echo "5. Staged clean + unstaged dirty"
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+git add pkg/error.go
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "meshkit-11005"
+EOF
+assert_pass run_hook
+
+echo "6. Staged dirty + unstaged clean"
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "meshkit-11005"
+EOF
+git add pkg/error.go
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+assert_fail run_hook
+
+echo "7. Unrelated file only staged"
+git reset --hard HEAD >/dev/null 2>&1
+echo "foo" > README.md
+git add README.md
+assert_pass run_hook
+
+echo "8. Multiple error.go staged, one bad"
+git reset --hard HEAD >/dev/null 2>&1
+mkdir -p otherpkg
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+cat > otherpkg/error.go <<EOF
+package otherpkg
+const ErrBadCode = "meshkit-11005"
+EOF
+git add pkg/error.go otherpkg/error.go
+assert_fail run_hook
+
+echo "9. Deleted error.go staged"
+git reset --hard HEAD >/dev/null 2>&1
+git rm -q pkg/error.go
+assert_pass run_hook
+
+echo "10. Index not mutated"
+git reset --hard HEAD >/dev/null 2>&1
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "replace_me"
+EOF
+git add pkg/error.go
+HASH_BEFORE=$(git ls-files -s pkg/error.go | awk '{print $2}')
+run_hook
+HASH_AFTER=$(git ls-files -s pkg/error.go | awk '{print $2}')
+if [ "$HASH_BEFORE" != "$HASH_AFTER" ]; then
+    echo "FAIL: index mutated"
+    exit 1
+fi
+
+echo "11. git commit -a"
+git reset --hard HEAD >/dev/null 2>&1
+cat > pkg/error.go <<EOF
+package pkg
+const ErrCode = "meshkit-10001"
+const ErrNewCode = "meshkit-11005"
+EOF
+# Hook invoked via git commit -a
+if git commit -a -m "should fail" >/dev/null 2>&1; then
+    echo "FAIL: git commit -a should have failed"
+    exit 1
+fi
+
+echo "ALL TESTS PASSED!"

--- a/docs/agent-instructions/errors.md
+++ b/docs/agent-instructions/errors.md
@@ -34,6 +34,15 @@ See the package documentation in `errors/errors.go` and
    `go run github.com/meshery/meshkit/cmd/errorutil -d . <update|analyze> --skip-dirs meshery -i ./helpers -o ./helpers`.
 3. Commit the changed source files together with the regenerated artifacts.
 
+## Pre-commit validation
+
+Run `make setup-hooks` once to install a local pre-commit hook that runs
+`errorutil check` against your staged changes before each commit - it accepts
+`replace_me` and codes allocated by `make errorutil` locally, and rejects
+hand-typed integers. It validates only what's staged, not your full working
+tree. It can be bypassed with `git commit --no-verify`; PR CI runs the same
+check and is authoritative regardless of whether the hook is installed.
+
 `make build-errorutil` builds a standalone `errorutil` binary from `cmd/errorutil/main.go`.
 
 ## Artifacts and code allocation (`helpers/`)

--- a/docs/agent-instructions/errors.md
+++ b/docs/agent-instructions/errors.md
@@ -37,27 +37,105 @@ See the package documentation in `errors/errors.go` and
 ## Pre-commit validation
 
 Run `make setup-hooks` once to install a local pre-commit hook that runs
-`errorutil check` against your staged changes before each commit - it accepts
-`replace_me` and codes allocated by `make errorutil` locally, and rejects
-hand-typed integers. It validates only what's staged, not your full working
-tree. It can be bypassed with `git commit --no-verify`; PR CI runs the same
-check and is authoritative regardless of whether the hook is installed.
+`errorutil check` against your **staged** changes (the index) before each commit,
+using `HEAD` as the baseline. It accepts `replace_me` and codes allocated by
+`make errorutil` locally, and rejects integer codes outside the allocation
+window recorded in `helpers/component_info.json` (see *Guarantees* below). It
+validates only what is staged, not your full working tree.
 
-`make build-errorutil` builds a standalone `errorutil` binary from `cmd/errorutil/main.go`.
+The hook is a **developer convenience, not a security boundary**:
+
+- `git commit --no-verify` bypasses it.
+- It is not installed unless you run `make setup-hooks`.
+- If the analysis itself cannot run (no Go toolchain, cold module cache, a parse
+  error), it prints `could not analyze error codes locally - skipping` and lets
+  the commit through.
+
+PR CI runs the same `errorutil check` against the pull request's **merge-base**
+and is authoritative regardless of whether the hook is installed. If CI cannot
+determine the merge-base it **fails** the check rather than passing it.
+
+`make test-hooks` runs the hook regression suite (bash; also runs in CI).
+`make build-errorutil` builds a standalone `errorutil` binary.
+
+### Manual Windows / Git Bash check
+
+CI exercises the hook on Linux only. Case 13 of the suite uses a pass-through
+`cygpath` mock and proves the branch executes, nothing more. To verify the
+MSYS-to-native path conversion for real, in Git Bash (MINGW64):
+
+```bash
+make setup-hooks
+mkdir -p pkgx && printf 'package pkgx\nconst ErrProbeCode = "meshkit-99999"\n' > pkgx/error.go
+git add pkgx/error.go
+git commit -m probe          # MUST be rejected, with a C:\... path in the message
+git reset HEAD pkgx/error.go && rm -rf pkgx
+```
 
 ## Artifacts and code allocation (`helpers/`)
 
-- `helpers/component_info.json` is the required input metadata. For this repo it holds
-  the component `name` (`meshkit`), `type` (`library`), and `next_error_code` - the
-  counter from which errorutil allocates integer codes to placeholder symbols. Do not
-  hand-pick codes; let errorutil allocate them from `next_error_code`.
-- errorutil emits `errorutil_analyze_errors.json` and `errorutil_analyze_summary.json`
-  (analysis results: duplicates, violations of the conventions above) plus
-  `errorutil_errors_export.json` (the full export consumed by the docs pipeline).
-- The `error-codes-updater` GitHub workflow (`.github/workflows/error-codes-updater.yaml`)
-  runs the update on CI and publishes `errorutil_errors_export.json` into
-  `meshery/meshery`'s `docs/data/errorref/` - that is how the public error-code
-  reference is generated from this repo's error registries.
+- `helpers/component_info.json` is the required input metadata. For this repo it
+  holds the component `name` (`meshkit`), `type` (`library`), and
+  `next_error_code` — the counter from which errorutil allocates integer codes to
+  placeholder symbols. Let errorutil move this counter: do not hand-pick codes,
+  and do not hand-edit `next_error_code`.
+- errorutil emits `errorutil_analyze_errors.json` and
+  `errorutil_analyze_summary.json` (analysis results: duplicates, violations of
+  the conventions above) plus `errorutil_errors_export.json` (the full export
+  consumed by the docs pipeline).
+- The `error-codes-updater` GitHub workflow
+  (`.github/workflows/error-codes-updater.yaml`) runs the update on CI and
+  publishes `errorutil_errors_export.json` into `meshery/meshery`'s
+  `docs/data/errorref/` — that is how the public error-code reference is
+  generated from this repo's error registries.
+
+## What the validation actually guarantees
+
+The checks are narrower than they look. Be precise about this.
+
+**Guaranteed.** For a pull request compared against its merge-base:
+
+- A new integer code that is **not** present in the baseline and **not** inside
+  the allocation window `[baseline next_error_code, current next_error_code)` is
+  rejected.
+- A code whose number of uses **grows** relative to the baseline is rejected as a
+  newly introduced duplicate. Pre-existing duplicates are tolerated at their
+  existing count, so historical debt (meshery/meshkit#1106) does not block
+  unrelated work.
+- A `next_error_code` that moves **backwards** relative to the baseline is
+  rejected.
+- If CI cannot resolve the merge-base, the check fails rather than passing.
+
+**Not guaranteed.**
+
+- *Not "all hand-typed integers are rejected."* An integer inside the allocation
+  window is accepted, and the window is derived from the pull request's own
+  `helpers/component_info.json`. `make errorutil` is the supported way to produce
+  such a code; widening the window by hand is not supported and is not
+  mechanically prevented.
+- *Allocation is local, not globally atomic.* Two branches forking from the same
+  baseline can both allocate the same code and both pass validation
+  independently. The conflict surfaces when one merges and the other is
+  revalidated against the new baseline. There is no merge-time lock and no
+  central allocator.
+- *Codes are not globally unique.* Allocation state is per component: `meshkit`
+  (`helpers/component_info.json`), `meshery-server`
+  (`server/helpers/component_info.json`) and `mesheryctl`
+  (`mesheryctl/helpers/component_info.json`) are independent counters, and the
+  same integer legitimately appears in more than one of them. MeshKit CI
+  validates MeshKit-owned codes; Meshery CI validates Meshery-owned codes.
+- *Not every declaration is visible.* `analyze`/`check` only see string constants
+  whose name matches `^Err[A-Z].+Code$` in non-`_test.go` `.go` files. A code
+  under any other symbol name, or in a test file, is invisible to both the hook
+  and CI.
+- *Placeholders are only allocated in `error.go`.* `analyze`/`check` read every
+  `.go` file, but `errorutil update` rewrites only files literally named
+  `error.go`. A `replace_me` placed anywhere else passes validation and is then
+  never allocated — it silently stays `replace_me`. Define error codes in
+  `error.go`.
+- *Deleting an error frees its code.* A new error may reuse the code of an error
+  removed in the same change; that is indistinguishable from a rename and is
+  accepted by design.
 
 ## Downstream ownership
 


### PR DESCRIPTION
This PR represents the final phase of the errorutil validation effort, following [[#1080](https://github.com/meshery/meshkit/pull/1080)](https://github.com/meshery/meshkit/pull/1080), [[#1105](https://github.com/meshery/meshkit/pull/1105)](https://github.com/meshery/meshkit/pull/1105), and [[Meshery #21009](https://github.com/meshery/meshery/pull/21009)](https://github.com/meshery/meshery/pull/21009), by adding local pre-commit and PR-level CI validation natively for MeshKit.

Previously, MeshKit did not have developer-side pre-commit validation or PR-level error-code validation. This PR closes that gap while reusing the allocation-aware validation introduced in #1105.

### Key Changes

* **CI Enforcement**: `error-codes-updater.yaml` gains a `pull_request` validation path that runs `errorutil check` against the PR's merge-base. The existing push-triggered allocation/update behavior remains isolated to push events.
* **Pre-commit Hook**: Added an opt-in local Git hook at `.githooks/pre-commit`, installed via `make setup-hooks`. The hook is read-only and validates the exact staged index state against `HEAD` using the same `errorutil check` command as CI. It supports both `replace_me` and valid locally allocated integer codes, while rejecting new integer codes that are inconsistent with the recorded allocation state. It can be bypassed with `git commit --no-verify`; CI remains the authoritative enforcement layer.
* **Documentation**: Extended `docs/agent-instructions/errors.md` with the hook workflow and CI behavior.
* **Hook Test Cases**: Added an 11-case suite covering Git-level edge cases such as staged vs. unstaged changes, partial staging, untracked working-tree changes, unrelated files, and baseline/index reconstruction.

### Relationship to #1105

This PR does not introduce another validation implementation. It consumes the allocation-aware `errorutil check` behavior from #1105 and uses that same validator for both MeshKit pre-commit and PR CI enforcement.

### Scope

This PR does not introduce:

* a new error-code allocation mechanism
* automatic allocation during validation
* automatic repair of existing integer collisions
* Merge Queue or global allocation locking
* cleanup of historical duplicate-code debt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional local pre-commit validation for staged error-code changes, installable with `make setup-hooks`.
  * Added pull request checks against the appropriate baseline to validate error-code updates.
  * Enhanced detection of duplicate, invalid, or incorrectly allocated error codes, including counter and allocation-window issues.
  * Improved validation for staged, renamed, deleted, and locally allocated error-code changes.

* **Documentation**
  * Documented hook installation, validation behavior, bypass options, and pull request checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->