### PR TITLE
Fix goroutine-lifecycle race that can panic on a closed channel

### DIFF
--- a/registry/model.go
+++ b/registry/model.go
@@ -914,7 +914,19 @@ func InvokeGenerationFromSheetWithOptions(wg *sync.WaitGroup, path string, model
 			// Channel to receive generation result
 			done := make(chan error, 1)
 
+			// Tracked on wg independently of the outer goroutine: if this
+			// model times out, the outer goroutine returns via the
+			// modelCtx.Done() case below and its own wg.Done() fires, but
+			// this inner goroutine is not cancelled and keeps running
+			// (GetPackage takes no context). Without its own wg entry,
+			// wg.Wait() below can return - and close(spreadsheeetChan) can
+			// run - while this goroutine is still alive, so its later send
+			// on spreadsheeetChan panics on the closed channel. Adding it
+			// here keeps the channel open until every producer, including
+			// orphaned ones from timed-out models, is done with it.
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				var genErr error
 
 				if utils.ReplaceSpacesAndConvertToLowercase(model.Registrant) == "meshery" {


### PR DESCRIPTION
Fixes #1102

`InvokeGenerationFromSheetWithOptions` (`registry/model.go`) starts an inner goroutine per model to do the actual generation work, tracked only through the outer per-model goroutine's own `wg` entry. When a model's generation exceeds `opts.ModelTimeout`, the outer goroutine returns via the `modelCtx.Done()` case and its `wg.Done()` fires — but the inner goroutine is not cancelled (`generator.GetPackage()` takes no context) and keeps running, untracked.

If every other model has since finished or timed out, `wg.Wait()` returns and `close(spreadsheeetChan)` runs while that orphaned inner goroutine is still alive. When it later reaches its send on `spreadsheeetChan`, it panics on a closed channel and crashes the whole process — typically after the run has already logged its completion summary, which makes the crash hard to trace back.

This implements the second option from the issue's own suggested direction: add the inner goroutine to the same `WaitGroup` so `spreadsheeetChan` is only closed once every producer, including orphaned ones from timed-out models, has actually finished with it.

## Test plan
- [x] `go build ./registry/...` and `go vet ./registry/...` clean
- [x] Existing tests in `registry/model_generation_test.go` (timeout behavior, progress tracker, model timeout with/without context) pass
- [x] Traced all early-return paths in the inner goroutine — the added `defer wg.Done()` covers every one of them, including the error-exit paths that existed before this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timed-out model generation requests.
  * Prevented potential processing errors and application crashes when results arrive after a request has finished.
  * Added safer handling for late spreadsheet-generation results, ensuring they are ignored gracefully when processing has already closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->